### PR TITLE
Fixes #800 - Adds support for defining next_server

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -22,6 +22,7 @@
 
 # Enable TFTP management
 :tftp: true
+:tftp_server: tftp.domain.com
 :tftproot: /tmp/tftpboot
 
 

--- a/lib/tftp_api.rb
+++ b/lib/tftp_api.rb
@@ -26,6 +26,16 @@ class SmartProxy
     end
   end
 
+  # Get the value for next_server
+  get "/tftp/serverName" do
+     begin
+        log_halt 400, "Smart Proxy does not have a TFTP next_server configured" unless SETTINGS.tftp_server
+        {:serverName => SETTINGS.tftp_server}.to_json
+     rescue Exception => e
+        log_halt 400, 2.to_s
+     end
+  end
+
   # delete a record from a network
   delete "/tftp/:mac" do
     begin


### PR DESCRIPTION
This is a fix for the issue we discussed on IRC, where foreman cannot pull the right next_server value through the smart-proxy.  It adds a setting in the config file for tftp_server to define this.
