### PR TITLE
identifies omshell key conflict output

### DIFF
--- a/lib/proxy/dhcp/server/isc.rb
+++ b/lib/proxy/dhcp/server/isc.rb
@@ -170,6 +170,7 @@ module Proxy::DHCP
         msg  = "Failed to #{msg}"
         msg += ": Entry already exists" if response and response.grep(/object: already exists/).size > 0
         msg += ": No response from DHCP server" if response.nil? or response.grep(/not connected/).size > 0
+        raise Proxy::DHCP::Collision, "Hardware address conflict." if response and response.grep(/object: key conflict/).size > 0
         raise Proxy::DHCP::Error.new(msg)
       else
         logger.info msg


### PR DESCRIPTION
one-line patch

You'll get a key conflict from omshell when trying to add a hardware
address that already exists in a host { } statement in dhcpd.conf.
This can be quite difficult to figure out, this should atleast alert you on it.

> create
> can't open object: key conflict
