### PR TITLE
Update for Smart-Proxy 0.3.1 Debian package

### DIFF
--- a/extra/debian/changelog
+++ b/extra/debian/changelog
@@ -1,3 +1,9 @@
+foreman-proxy (0.3.1-1) unstable; urgency=low
+
+  * New upstream release
+
+ -- Jochen Schalanda <jochen@schalanda.name>  Wed, 28 Dec 2011 13:41:00 +0100
+
 foreman-proxy (0.3-1) unstable; urgency=low
 
   * New upstream release


### PR DESCRIPTION
As usual a bit late for release. ;)

Change consists of simple new changelog entry to build the smart-proxy 0.3.1 Debian package.
