### PR TITLE
Change default log_level for debians log_level to INFO

### DIFF
--- a/extra/debian/settings.yml
+++ b/extra/debian/settings.yml
@@ -59,5 +59,5 @@
 # filename or STDOUT
 :log_file: /var/log/foreman-proxy/foreman-proxy.log
 # valid options are
-# Logger::WARN, Logger::DEBUG, Logger::Error, Logger::Fatal, Logger:INFO, LOGGER::UNKNOWN
-:log_level: Logger::INFO
+# WARN, DEBUG, Error, FATAL, INFO, UNKNOWN
+:log_level: INFO


### PR DESCRIPTION
Starting with commit 5821a2694b1d62ad6c250fdced123bfe8d17cf4e the
log level is looked up using the get_const method which requires
unqualified strings. This patch fixes the default log level for the
debian package and updates the comments.
