### PR TITLE
Fix log_level comment for settings.yml.example

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -59,5 +59,5 @@
 # filename or STDOUT
 :log_file: /tmp/proxy.log
 # valid options are
-# WARN, DEBUG, Error, Fatal, INFO, UNKNOWN
+# WARN, DEBUG, Error, FATAL, INFO, UNKNOWN
 #:log_level: DEBUG


### PR DESCRIPTION
Logger.constants does not contain Fatal but only FATAL. This change
adjusts the comment for log_level.
