### PR TITLE
Add to_json method to lease and reservation module

### DIFF
--- a/lib/proxy/dhcp/record/lease.rb
+++ b/lib/proxy/dhcp/record/lease.rb
@@ -14,5 +14,9 @@ module Proxy::DHCP
       false
     end
 
+    def to_json(*options)
+      Hash[[:ip, :mac, :starts, :ends, :state].map{|s| [s, send(s)]}].to_json(options)
+    end
+
   end
 end

--- a/lib/proxy/dhcp/record/reservation.rb
+++ b/lib/proxy/dhcp/record/reservation.rb
@@ -16,5 +16,9 @@ module Proxy::DHCP
       options[arg]
     end
 
+    def to_json(*options)
+      Hash[[:hostname, :ip, :mac].map{|s| [s, send(s)]}].to_json(options)
+    end
+
   end
 end


### PR DESCRIPTION
The /dhcp/:network returned strings instead of dicts for
reservation and leases. This patch adds to_json methods
for reservation and lease to return dicts instead of strings.
