### PR TITLE
kill dead 'about' link

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -12,7 +12,6 @@
           <ol> 
             <a href='/dhcp'>     <li>Home</li> </a>
             <a href='/features'> <li>Features</li> </a>
-            <a href='about'>     <li>About</li> </a>
           </ol> 
         </div> 
       </div> 


### PR DESCRIPTION
remove "about" link from layout.erb,  there doesn't seem to be a corresponding page.
