### PR TITLE
Fix proxy for 1.9

### DIFF
--- a/bin/smart-proxy
+++ b/bin/smart-proxy
@@ -18,7 +18,7 @@ class SmartProxy < Sinatra::Base
 
   set :root, APP_ROOT
   set :views, APP_ROOT + '/views'
-  set :public, APP_ROOT + '/public'
+  set :public_folder, APP_ROOT + '/public'
   set :logging, true
   set :env,     :production
   set :run,     true

--- a/extra/debianbuild/build.sh
+++ b/extra/debianbuild/build.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -e
+
+if [ $# -lt 1 ]; then
+  CONF="/home/build/.nightly-foreman"
+else
+  CONF="/home/build/.nightly-${1}"
+fi
+
+if [ -f "${CONF}" ]; then
+  source "${CONF}"
+else
+  echo "Couldn't find ${CONF}. Quitting."
+  exit 1
+fi
+
+DATE=$(date -R)
+UNIXTIME=$(date +%s)
+RELEASE="${VERSION}-~nightlybuild${UNIXTIME}"
+
+GIT='/usr/bin/git'
+
+mkdir -p "${BUILD_DIR}"
+rm -rf "${BUILD_DIR}"/*
+cd "${BUILD_DIR}"
+
+$GIT clone "${REPO}" "${TARGET}"
+cd "${TARGET}"
+$GIT checkout "${BRANCH}"
+$GIT submodule init
+$GIT submodule update
+
+LAST_COMMIT=$($GIT rev-list HEAD|/usr/bin/head -n 1)
+
+prepare_build
+
+rm -rf $(/usr/bin/find "${TARGET}" -name '.git*')
+
+mv debian/changelog debian/changelog.tmp
+
+echo "$PACKAGE_NAME ($RELEASE) UNRELEASED; urgency=low
+
+  * Automatically built package based on the state of
+    $REPO at commit $LAST_COMMIT
+
+ -- $MAINTAINER  $DATE
+" > debian/changelog
+
+cat debian/changelog.tmp >> debian/changelog
+rm -f debian/changelog.tmp
+
+echo -n '3.0 (native)' > debian/source/format
+/usr/bin/dpkg-buildpackage -F -tc -uc -us
+
+/usr/bin/reprepro -b "${REPO_DIR}" includedsc "${DEB_REPO}" "${BUILD_DIR}"/*.dsc
+/usr/bin/reprepro -b "${REPO_DIR}" includedeb "${DEB_REPO}" "${BUILD_DIR}"/*.deb

--- a/extra/debianbuild/build.sh
+++ b/extra/debianbuild/build.sh
@@ -3,9 +3,9 @@
 set -e
 
 if [ $# -lt 1 ]; then
-  CONF="/home/build/.nightly-foreman"
+  CONF="/home/greg/build-area/.nightly-foreman"
 else
-  CONF="/home/build/.nightly-${1}"
+  CONF="/home/greg/build-area/.nightly-${1}"
 fi
 
 if [ -f "${CONF}" ]; then
@@ -51,7 +51,8 @@ cat debian/changelog.tmp >> debian/changelog
 rm -f debian/changelog.tmp
 
 echo -n '3.0 (native)' > debian/source/format
-/usr/bin/dpkg-buildpackage -F -tc -uc -us
+# We use -d here since on a Centos box we can't check the installed debs
+/usr/bin/dpkg-buildpackage -d -tc -uc -us
 
-/usr/bin/reprepro -b "${REPO_DIR}" includedsc "${DEB_REPO}" "${BUILD_DIR}"/*.dsc
-/usr/bin/reprepro -b "${REPO_DIR}" includedeb "${DEB_REPO}" "${BUILD_DIR}"/*.deb
+#/home/greg/bin/reprepro -b "${REPO_DIR}" includedeb "${DEB_REPO}" "${BUILD_DIR}"/*.deb
+/home/greg/bin/reprepro --ignore=wrongdistribution -b "${REPO_DIR}" include "${DEB_REPO}" "${BUILD_DIR}"/*.changes

--- a/extra/debianbuild/dot-nightly-smart-proxy
+++ b/extra/debianbuild/dot-nightly-smart-proxy
@@ -1,0 +1,15 @@
+PACKAGE_NAME='foreman-proxy'
+VERSION='0.5'
+MAINTAINER='Greg Sutcliffe <gsutcliffe@gmail.com>'
+
+BUILD_DIR="/home/build/nightly-${PACKAGE_NAME}"
+TARGET="${BUILD_DIR}/${PACKAGE_NAME}"
+REPO='git://github.com/theforeman/smart-proxy.git'
+BRANCH='develop'
+
+REPO_DIR='/home/build/foreman-repo'
+DEB_REPO='nightly'
+
+function prepare_build() {
+  mv ./extra/debian .
+}

--- a/extra/debianbuild/dot-nightly-smart-proxy
+++ b/extra/debianbuild/dot-nightly-smart-proxy
@@ -1,15 +1,19 @@
+export PATH=~/bin:~/usr/bin:$PATH
+export PERL5OPT="-I${HOME}/perl/lib/perl5 -I${HOME}/perl/lib/perl5/site_perl"
+
 PACKAGE_NAME='foreman-proxy'
 VERSION='0.5'
 MAINTAINER='Greg Sutcliffe <gsutcliffe@gmail.com>'
 
-BUILD_DIR="/home/build/nightly-${PACKAGE_NAME}"
+BUILD_DIR="/home/greg/build-area/nightly-${PACKAGE_NAME}"
 TARGET="${BUILD_DIR}/${PACKAGE_NAME}"
 REPO='git://github.com/theforeman/smart-proxy.git'
 BRANCH='develop'
 
-REPO_DIR='/home/build/foreman-repo'
+REPO_DIR='/home/greg/build-area/foreman-repo'
 DEB_REPO='nightly'
 
 function prepare_build() {
-  mv ./extra/debian .
+  cd /home/greg/github/smart-proxy && git pull && cd -
+  cp -r /home/greg/github/smart-proxy/extra/debian .
 }

--- a/lib/proxy/dhcp/server/isc.rb
+++ b/lib/proxy/dhcp/server/isc.rb
@@ -162,6 +162,7 @@ module Proxy::DHCP
     end
 
     def report msg, response=""
+      response = [*response].compact
       if response.nil? or !response.grep(/can't|no more|not connected|Syntax error/).empty?
         logger.error "Omshell failed:\n" + (response.nil? ? "No response from DHCP server" : response.join(", "))
         msg.sub! /Removed/,    "remove"

--- a/lib/proxy/dhcp/subnet.rb
+++ b/lib/proxy/dhcp/subnet.rb
@@ -1,6 +1,5 @@
 require 'ipaddr'
 require 'proxy/dhcp/monkey_patches' unless IPAddr.new.respond_to?('to_range')
-require 'ping'
 require 'proxy/validations'
 require "net/ping"
 
@@ -193,7 +192,7 @@ module Proxy::DHCP
     end
 
     def privileged_user
-      (PLATFORM =~ /linux/i and Process.uid == 0) or PLATFORM =~ /mingw/
+      (RUBY_PLATFORM =~ /linux/i and Process.uid == 0) or RUBY_PLATFORM =~ /mingw/
     end
   end
 end

--- a/lib/proxy/settings.rb
+++ b/lib/proxy/settings.rb
@@ -10,7 +10,7 @@ class Settings < OpenStruct
 end
 
 settings = YAML.load(raw_config)
-if PLATFORM =~ /mingw/
+if RUBY_PLATFORM =~ /mingw/
   settings.delete :puppetca if settings.has_key? :puppetca
   settings.delete :puppet   if settings.has_key? :puppet
   settings[:x86_64] = File.exist?('c:\windows\sysnative\cmd.exe')

--- a/lib/sinatra-patch.rb
+++ b/lib/sinatra-patch.rb
@@ -1,7 +1,7 @@
 require "sinatra/base"
 require "openssl"
 require "webrick/https"
-require "daemon" unless PLATFORM =~/mingw/
+require "daemon" unless RUBY_PLATFORM =~/mingw/
 module Sinatra
   class Base
     # Run the Sinatra app as a self-hosted server using
@@ -18,7 +18,7 @@ module Sinatra
 
       FileUtils.mkdir_p(File.join(APP_ROOT, 'tmp/pids'))
 
-      if SETTINGS.daemon and PLATFORM !~ /mingw/
+      if SETTINGS.daemon and RUBY_PLATFORM !~ /mingw/
         Process.daemon(true)
         if SETTINGS.daemon_pid.nil?
           pid = "#{APP_ROOT}/tmp/pids/server.pid"


### PR DESCRIPTION
Two parts to this pull req...

1) The files needed to rebuild the Debian package. I felt we should store these in Git, so I've added them.

2) Changes for ruby 1.9. I run my proxy on an Archlinux box, and this is what I needed to change to make the proxy run there (Arch defaults to ruby1.9). I think this commit would actually break 1.8 compatibility, so we probably need to do more work, but it needed writing down somewhere :)
