### PR TITLE
Environment listing fixes

### DIFF
--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -50,7 +50,7 @@ module Proxy::Puppet
             end
             # Dynamic environments - get every directory under the modulepath
             modulepath.gsub(/\$environment.*/,"/").split(":").each do |base_dir|
-              Dir.glob("#{base_dir}/*") do |dir|
+              Dir.glob("#{base_dir}/*").grep(/\/[A-Za-z0-9_]+$/) do |dir|
                 e = dir.split("/").last
                 env[e] = modulepath.gsub("$environment", e)
               end

--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -41,6 +41,7 @@ module Proxy::Puppet
           env[:production] = conf[:main][:modulepath] || conf[:master][:modulepath]
         end
 
+	new_env = env.clone
         # are we using dynamic puppet environments?
         env.each do|environment, modulepath|
           if modulepath and modulepath.include?("$environment")
@@ -52,15 +53,15 @@ module Proxy::Puppet
             modulepath.gsub(/\$environment.*/,"/").split(":").each do |base_dir|
               Dir.glob("#{base_dir}/*").grep(/\/[A-Za-z0-9_]+$/) do |dir|
                 e = dir.split("/").last
-                env[e] = modulepath.gsub("$environment", e)
+                new_env[e] = modulepath.gsub("$environment", e)
               end
             end
             # get rid of the main environment
-            env.delete(environment)
+            new_env.delete(environment)
           end
         end
 
-        env.reject { |k, v| k.nil? or v.nil? }
+        new_env.reject { |k, v| k.nil? or v.nil? }
       end
     end
 


### PR DESCRIPTION
This fixes bug #1654 by making a copy of the hash we're iterating one.

It also optimizes a little environment discovery by filtering invalid folder names.
In my setup, we uses git replication to map branches to an environment and for each branch we have a folder called "foobar.somegithash" and a symlink just called "foobar" at the same level.
Having both folders makes it very slow as foreman tries to get the classes from these two and in the end fails to add these environments because they have some invalid name.
