### PR TITLE
Allow proxy to work on both ruby 1.9 and 1.8

### DIFF
--- a/bin/smart-proxy
+++ b/bin/smart-proxy
@@ -3,7 +3,8 @@
 $LOAD_PATH.unshift *Dir["#{File.dirname(__FILE__)}/../lib"]
 APP_ROOT = "#{File.dirname(__FILE__)}/.."
 
-require "rubygems"
+require "checks"
+require "rubygems" if USE_GEMS
 require "proxy"
 require "sinatra-patch"
 require "json"
@@ -18,10 +19,16 @@ class SmartProxy < Sinatra::Base
 
   set :root, APP_ROOT
   set :views, APP_ROOT + '/views'
-  set :public, APP_ROOT + '/public'
   set :logging, true
   set :env,     :production
   set :run,     true
+
+  # This changed in later Sinatra versions
+  if ( Sinatra::VERSION.split('.').map{|s|s.to_i} <=> [1,3,0] ) > 0
+    set :public_folder, APP_ROOT + '/public'
+  else
+    set :public, APP_ROOT + '/public'
+  end
 
   require "tftp_api"     if SETTINGS.tftp
   require "puppet_api"   if SETTINGS.puppet

--- a/extra/debian/init.d
+++ b/extra/debian/init.d
@@ -55,6 +55,7 @@ do_start()
 	#   2 if daemon could not be started
 	start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --test > /dev/null \
 		|| return 1
+	 export USE_GEMS=false   # No need for rubygems here
 	start-stop-daemon --start --quiet --chuid $DAEMON_USER --pidfile $PIDFILE --exec $DAEMON -- \
 		$DAEMON_ARGS \
 		|| return 2

--- a/lib/checks.rb
+++ b/lib/checks.rb
@@ -1,0 +1,12 @@
+# included in various places, to check the ruby environment
+
+# Test for 1.9
+if (RUBY_VERSION.split('.').map{|s|s.to_i} <=> [1,9,0]) > 0 then
+  PLATFORM = RUBY_PLATFORM
+  RUBY_1_9 = true
+else
+  RUBY_1_9 = false
+end
+
+# Don't load rubygems in production, it's for developers
+USE_GEMS = ENV['USE_GEMS'] == "false" ? false : true

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -2,10 +2,11 @@ module Proxy
   MODULES = %w{dns dhcp tftp puppetca puppet}
   VERSION = "0.3.1"
 
+  require "checks"
   require "proxy/settings"
   require "fileutils"
   require "pathname"
-  require "rubygems"       # required for testing
+  require "rubygems" if USE_GEMS # required for testing
   require "proxy/log"
   require "proxy/util"
   require "proxy/tftp"     if SETTINGS.tftp

--- a/lib/proxy/dhcp/server/isc.rb
+++ b/lib/proxy/dhcp/server/isc.rb
@@ -162,7 +162,7 @@ module Proxy::DHCP
     end
 
     def report msg, response=""
-      if response.nil? or !response.grep(/can't|no more|not connected|Syntax error/).empty?
+      if response.nil? or (!response.empty? and !response.grep(/can't|no more|not connected|Syntax error/).empty?)
         logger.error "Omshell failed:\n" + (response.nil? ? "No response from DHCP server" : response.join(", "))
         msg.sub! /Removed/,    "remove"
         msg.sub! /Added/,      "add"

--- a/lib/proxy/dhcp/server/native_ms.rb
+++ b/lib/proxy/dhcp/server/native_ms.rb
@@ -1,4 +1,5 @@
-require 'rubygems'
+require 'checks'
+require 'rubygems' if USE_GEMS
 require 'win32/open3'
 
 module Proxy::DHCP

--- a/lib/proxy/dhcp/subnet.rb
+++ b/lib/proxy/dhcp/subnet.rb
@@ -1,8 +1,9 @@
+require 'checks'
 require 'ipaddr'
 require 'proxy/dhcp/monkey_patches' unless IPAddr.new.respond_to?('to_range')
-require 'ping'
+require 'ping' unless RUBY_1_9
 require 'proxy/validations'
-require "net/ping"
+require 'net/ping'
 
 module Proxy::DHCP
   # Represents a DHCP Subnet


### PR DESCRIPTION
Fixes Bug #1680

I;d like some more thorough testing on Ruby 1.8 and 1.9 - it seemed to work for my two proxies in those environments. I tested creating a host to ensure the discover-ip-by-ping stuff still works, and I imported a subnet to ensure the changes there work in both rubies. Still, more formal tests would be good ;)
