### PR TITLE
fixes #1567 - Foreman-proxy ignores dhcpd.conf include directive

### DIFF
--- a/lib/dhcp_api.rb
+++ b/lib/dhcp_api.rb
@@ -10,7 +10,7 @@ class SmartProxy < Sinatra::Base
         log_halt 400, "Unable to find the DHCP configuration or lease files"
       end
       @server = Proxy::DHCP::ISC.new({:name => "127.0.0.1",
-                                      :config => File.read(SETTINGS.dhcp_config),
+                                      :config => SETTINGS.dhcp_config,
                                       :leases => File.read(SETTINGS.dhcp_leases)})
     when "native_ms"
       require 'proxy/dhcp/server/native_ms'


### PR DESCRIPTION
Adding functionality that can detect and parse included files in dhcpd.conf.
Supports same syntax as dhcpd.conf(5) manual page specifies on the include
statement:

```
    include "filename";

           The include statement is used to read in a named file, and
           process the contents of that file as though it were entered in
           place of the include statement.
```

This parsing currently requires (unlike isc-dhcpd) that the include statement
is on it's own line, preceded by optional whitespace.
