### PR TITLE
Ipmi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 tags
+.idea/
 config/settings.yml
 .idea
 logs

--- a/bin/smart-proxy
+++ b/bin/smart-proxy
@@ -35,6 +35,7 @@ class SmartProxy < Sinatra::Base
   require "puppetca_api" if SETTINGS.puppetca
   require "dns_api"      if SETTINGS.dns
   require "dhcp_api"     if SETTINGS.dhcp
+  require "bmc_api"      if SETTINGS.bmc
   require "features_api"
 
   begin

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -59,6 +59,13 @@
 :puppet: false
 :puppet_conf: /etc/puppet/puppet.conf
 
+# enable BMC management  (Bare metal power and bios controls)
+# Ensure that you have freeipmi or ipmitool command line tools installed
+# You will also need the rubyipmi gem
+:bmc: false
+# Available bmc providers: freeipmi, ipmitool (Optional)
+#:bmc_default_provider: freeipmi
+
 # Where our proxy log files are stored
 # filename or STDOUT
 :log_file: /var/log/foreman-proxy/proxy.log

--- a/lib/bmc_api.rb
+++ b/lib/bmc_api.rb
@@ -1,0 +1,255 @@
+require 'proxy/bmc/ipmi'
+require 'proxy/bmc'
+
+class SmartProxy < Sinatra::Base
+
+  # All GET requests will only read ipmi data, no changes
+  # All PUT requests will update information on the bmc device
+
+  get "/bmc" do
+    # return list of available options
+  end
+
+  # Returns a list of bmc providers
+  get "/bmc/providers" do
+    {:providers => Proxy::BMC.providers}.to_json
+  end
+
+  # Returns a list of installed providers
+  get "/bmc/providers/installed" do
+    {:installed_providers => Proxy::BMC.installed_providers?}.to_json
+  end
+
+  # returns host operations
+  get "/bmc/:host" do
+    {:actions => %w[chassis lan]}.to_json
+  end
+
+  # returns chassis operations
+  get "/bmc/:host/chassis" do
+    {:actions => %w[power identify config]}.to_json
+  end
+
+  # Gets the power status, does not change power
+  get "/bmc/:host/chassis/power/?:action?" do
+
+    # return hint on valid options
+    if params[:action].nil?
+      return {:actions => ["on", "off", "status"]}.to_json
+    end
+    bmc_setup
+    begin
+      case params[:action]
+      when "status"
+        {:action => params[:action], :result => @bmc.powerstatus}.to_json
+      when "off"
+        {:action => params[:action], :result => @bmc.poweroff?}.to_json
+      when "on"
+        {:action => params[:action], :result => @bmc.poweron?}.to_json
+      else
+        {:error => "The action: #{params[:action]} is not a valid action"}.to_json
+      end
+
+    rescue => e
+      log_halt 400, e
+    end
+
+  end
+
+  get "/bmc/:host/lan/?:action?" do
+    if params[:action].nil?
+      return {:actions => ["ip", "netmask", "mac", "gateway"]}.to_json
+    end
+    bmc_setup
+    begin
+      case params[:action]
+      when "ip"
+        {:action => params[:action], :result =>@bmc.ip}.to_json
+      when "netmask"
+        {:action => params[:action], :result =>@bmc.netmask}.to_json
+      when "mac"
+        {:action => params[:action], :result =>@bmc.mac}.to_json
+      when "gateway"
+        {:action => params[:action], :result =>@bmc.gateway}.to_json
+      else
+        {:error => "The action: #{params[:action]} is not a valid action"}.to_json
+      end
+    rescue => e
+      log_halt 400, e
+    end
+  end
+
+  get "/bmc/:host/chassis/identify/?:action?" do
+
+    # return hint on valid options
+    if params[:action].nil?
+      return {:actions => ["status"]}.to_json
+    end
+    bmc_setup
+    # determine which function should be executed
+    begin
+      case params[:action]
+      when "status"
+        {:action => params[:action], :result =>@bmc.identifystatus}.to_json
+      else
+        {:error => "The action: #{params[:action]} is not a valid action"}.to_json
+      end
+    rescue => e
+      log_halt 400, e
+    end
+  end
+
+  get "/bmc/:host/chassis/config/?:function?" do
+
+    # return hint on valid options
+    # removing bootdevice until its supported in rubyipmi
+    if params[:function].nil?
+      #return {:actions => ["bootdevice", "bootdevices"]}.to_json
+      return {:functions => ["bootdevices"]}.to_json
+
+    end
+    bmc_setup
+    begin
+      case params[:function]
+        #when "bootdevice"
+        #  @bmc.chassis.config.bootdevice.to_json
+      when "bootdevices"
+        {:devices => @bmc.bootdevices}.to_json
+      else
+        {:error => "The action: #{params[:function]} is not a valid function"}.to_json
+      end
+    rescue => e
+      log_halt 400, e
+    end
+  end
+
+  put "/bmc/:host/chassis/power/?:action?" do
+
+    # return hint on valid options
+    if params[:action].nil?
+      return {:actions => ["on", "off", "cycle", "soft"]}.to_json
+    end
+    bmc_setup
+    begin
+      case params[:action]
+      when "on"
+        {:action => params[:action], :result => @bmc.poweron}.to_json
+      when "off"
+        {:action => params[:action], :result =>@bmc.poweroff}.to_json
+      when "cycle"
+        {:action => params[:action], :result =>@bmc.powercycle}.to_json
+      when "soft"
+        {:action => params[:action], :result =>@bmc.poweroff(true)}.to_json
+      else
+        {:error => "The action: #{params[:action]} is not a valid action"}.to_json
+      end
+
+    rescue => e
+      log_halt 400, e
+    end
+  end
+
+  put "/bmc/:host/chassis/config/?:function?/?:action?" do
+
+    if params[:function].nil?
+      return {:functions => ["bootdevice"]}.to_json
+    end
+    bmc_setup
+    begin
+      case params[:function]
+
+      when "bootdevice"
+        if params[:action].nil?
+          return {:actions => @bmc.bootdevices, :options => ["reboot", "persistent"]}.to_json
+        end
+        case params[:action]
+        when /pxe/
+          {:action => params[:action], :result => @bmc.bootpxe(params[:reboot],params[:persistent])}.to_json
+        when /cdrom/
+          {:action => params[:action], :result =>@bmc.bootcdrom(params[:reboot],params[:persistent])}.to_json
+        when /bios/
+          {:action => params[:action], :result =>@bmc.bootbios(params[:reboot],params[:persistent])}.to_json
+        when /disk/
+          {:action => params[:action], :result =>@bmc.bootdisk(params[:reboot],params[:persistent])}.to_json
+        else
+          if @bmc.bootdevices.include?(params[:action])
+            {:action => params[:action], :result =>@bmc.bootdevice({:device => params[:action],
+                                                                    :reboot => params[:reboot],
+                                                                    :persistent => params[:persistent]})}.to_json
+          else
+            {:error => "#{params[:action]} is not a valid boot device"}.to_json
+          end
+        end
+
+      else
+        {:error => "The action: #{params[:function]} is not a valid function"}.to_json
+      end
+    rescue => e
+      log_halt 400, e
+    end
+
+  end
+
+  put "/bmc/:host/chassis/identify/?:action?" do
+
+    if params[:action].nil?
+      return {:actions => ["on", "off"]}.to_json
+    end
+    bmc_setup
+    begin
+      case params[:action]
+      when "on"
+        {:action => params[:action], :result =>@bmc.identifyon}.to_json
+      when "off"
+        {:action => params[:action], :result =>@bmc.identifyoff}.to_json
+      else
+        {:error => "The action: #{params[:function]} is not a valid function"}.to_json
+
+      end
+
+    rescue => e
+      log_halt 400, e
+    end
+
+  end
+
+  private
+
+  def bmc_setup
+
+    raise "Smart Proxy is not configured to support BMC control" unless SETTINGS.bmc
+
+    # Either use the default provider or allow user to specify provider in request
+    provider_type ||= params[:bmc_provider] || SETTINGS.bmc_default_provider
+
+    provider_type.downcase! if provider_type
+
+    raise "unauthorized" unless auth.provided?
+
+    raise "bad_authentication_request" unless auth.basic?
+
+    username, password = auth.credentials
+
+    # check to see if provider is given and no default provider is set, search for installed providers
+    unless Proxy::BMC.installed?(provider_type)
+      # check if provider_type is a valid type
+      if Proxy::BMC.providers.include?(provider_type)
+        log_halt 400, "#{provider_type} is not installed, please install a ipmi provider"
+      else
+        log_halt 400, "Unrecognized or missing bmc provider type: #{provider_type}"
+      end
+    end
+
+    # all the use of the http auth basic header to pass credentials
+    args = {:host => params[:host], :username => username,
+            :password => password, :bmc_provider => provider_type}
+    @bmc = Proxy::BMC::IPMI.new(args)
+  rescue => e
+    log_halt 400, e
+  end
+
+  def auth
+    @auth ||= Rack::Auth::Basic::Request.new(request.env)
+  end
+
+end

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -1,5 +1,5 @@
 module Proxy
-  MODULES = %w{dns dhcp tftp puppetca puppet}
+  MODULES = %w{dns dhcp tftp puppetca puppet bmc}
   VERSION = "1.0"
 
   require "checks"
@@ -14,6 +14,7 @@ module Proxy
   require "proxy/puppet"   if SETTINGS.puppet
   require "proxy/dns"      if SETTINGS.dns
   require "proxy/dhcp"     if SETTINGS.dhcp
+  require "proxy/bmc"      if SETTINGS.bmc
 
   def self.features
     MODULES.collect{|mod| mod if SETTINGS.send mod}.compact

--- a/lib/proxy/bmc.rb
+++ b/lib/proxy/bmc.rb
@@ -1,0 +1,19 @@
+require 'proxy/bmc/ipmi'
+
+module Proxy
+  module BMC
+
+    # This is a top level function to list all providers accepted
+    def self.installed_providers?
+      IPMI.providers_installed?
+    end
+
+    def self.providers
+      IPMI.providers
+    end
+
+    def self.installed?(provider)
+      IPMI.installed?(provider)
+    end
+ end
+end

--- a/lib/proxy/bmc/base.rb
+++ b/lib/proxy/bmc/base.rb
@@ -1,0 +1,110 @@
+module Proxy
+  module BMC
+    class Base
+
+      # This is the base class for bmc control.  Treat this class as an interface
+      def initialize(args)
+        @host = connect(args)
+      end
+
+      def poweroff(soft=false)
+        raise NotImplementedError.new
+      end
+
+      def poweron
+        raise NotImplementedError.new
+      end
+
+      def poweron?
+        raise NotImplementedError.new
+      end
+
+      def poweroff?
+        raise NotImplementedError.new
+      end
+
+      def self.installed?
+        raise NotImplementedError.new
+      end
+
+      def self.providers
+        raise NotImplementedError.new
+      end
+
+      def self.providers_installed?
+        raise NotImplementedError.new
+      end
+
+      def powerstatus
+        raise NotImplementedError.new
+      end
+
+      def identifystatus
+        raise NotImplementedError.new
+      end
+
+      def powercycle
+        raise NotImplementedError.new
+      end
+
+      def bootdevice
+        raise NotImplementedError.new
+      end
+
+      def bootdevices
+        raise NotImplementedError.new
+      end
+
+      def bootdevice=(args={:device => nil, :reboot => false, :persistent => false})
+        raise NotImplementedError.new
+      end
+
+      def identifyon
+        raise NotImplementedError.new
+      end
+
+      def identifyoff
+        raise NotImplementedError.new
+      end
+
+      def bootpxe(reboot=false, persistent=false)
+        raise NotImplementedError.new
+      end
+
+      def bootdisk(reboot=false, persistent=false)
+        raise NotImplementedError.new
+      end
+
+      def bootbios(reboot=false, persistent=false)
+        raise NotImplementedError.new
+      end
+
+      def bootcdrom(reboot=false, persistent=false)
+        raise NotImplementedError.new
+      end
+
+      # return the ip of the bmc device
+      def ip
+        raise NotImplementedError.new
+      end
+
+      # return the mac of the bmc device
+      def mac
+        raise NotImplementedError.new
+      end
+
+      # return the gateway of the bmc device
+      def gateway
+        raise NotImplementedError.new
+      end
+
+      # return the netmask of the bmc device
+      def netmask
+        raise NotImplementedError.new
+      end
+
+      protected
+      attr_reader :host
+    end
+  end
+end

--- a/lib/proxy/bmc/ipmi.rb
+++ b/lib/proxy/bmc/ipmi.rb
@@ -1,0 +1,134 @@
+require 'rubyipmi'
+require 'proxy/bmc/base'
+
+module Proxy
+  module BMC
+    class IPMI < Base
+      include Proxy::Log
+
+      def self.installed?(provider)
+        # check with the lib to see if at least one provider is installed
+        if provider
+          Rubyipmi.is_provider_installed?(provider)
+        else
+          Rubyipmi.provider_installed?
+        end
+      end
+
+      def self.providers_installed?
+        return Rubyipmi.providers_installed?
+      end
+
+      def self.providers
+        return Rubyipmi.providers
+      end
+
+      # Turn the ipmi device off, if its already off then nothing will happen
+      # If soft=true then the ipmi will perform a graceful shutdown
+      def poweroff(soft=false)
+        if soft
+          host.chassis.power.softShutdown
+        else
+          host.chassis.power.off
+        end
+      end
+
+      # Turn the ipmi device on, if its already on then nothing will happen
+      def poweron
+        host.chassis.power.on
+      end
+
+      # Power cycle the ipmi device
+      def powercycle
+        host.chassis.power.cycle
+      end
+
+      def bootdevices
+        ["pxe", "disk", "bios", "cdrom"]
+      end
+
+      def bootdevice
+        host.chassis.config.bootdevice
+      end
+
+      def bootdevice=(args={:device => nil, :reboot => false, :persistent => false})
+        host.chassis.bootdevice(args[:device], args[:reboot], args[:persistent])
+      end
+
+      def connect(args = { })
+        Rubyipmi.connect(args[:username], args[:password], args[:host], args[:bmc_provider])
+      end
+
+      # Turn the led light on
+      def identifyon
+        host.chassis.identify(true)
+      end
+
+      # Turn the led light off
+      def identifyoff
+        host.chassis.identify(false)
+      end
+
+      # Return true or false if power is on
+      def poweron?
+        host.chassis.power.on?
+      end
+
+      # Return true or false if power is off
+      def poweroff?
+        host.chassis.power.off?
+      end
+
+      # This function will get the power state and return on or off
+      def powerstatus
+        host.chassis.power.status
+      end
+
+      # Get the status of the led (on or off)
+      def identifystatus
+        host.chassis.identifystatus
+      end
+
+      # Boot to pxe
+      def bootpxe(reboot=false, persistent=false)
+        host.chassis.bootpxe(reboot, persistent)
+      end
+
+      # boot to disk
+      def bootdisk(reboot=false, persistent=false)
+        host.chassis.bootdisk(reboot, persistent)
+      end
+
+      # boot to bios
+      def bootbios(reboot=false, persistent=false)
+        host.chassis.bootbios(reboot, persistent)
+      end
+
+      # boot to cdrom
+      def bootcdrom(reboot=false, persistent=false)
+        host.chassis.bootcdrom(reboot, persistent)
+      end
+
+      # return the ip of the bmc device
+      def ip
+        host.bmc.lan.ip
+      end
+
+      # return the mac of the bmc device
+      def mac
+        host.bmc.lan.mac
+      end
+
+      # return the gateway of the bmc device
+      def gateway
+        host.bmc.lan.gateway
+      end
+
+      # return the netmask of the bmc device
+      def netmask
+        host.bmc.lan.netmask
+      end
+
+    end
+  end
+end

--- a/test/bmc_api_test.rb
+++ b/test/bmc_api_test.rb
@@ -1,0 +1,231 @@
+require 'test_helper'
+require 'helpers'
+require 'bmc_api'
+require 'json'
+
+ENV['RACK_ENV'] = 'test'
+
+class BmcApiTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    SmartProxy.new
+  end
+
+  def setup
+    # Testing instructions
+    #rake test TEST=test/bmc_api_test.rb
+
+    user     ||= ENV["ipmiuser"] || "user"
+    pass     ||= ENV["ipmipass"] || "pass"
+    @host    ||= ENV["ipmihost"] || "host"
+    provider ||= ENV["ipmiprovider"] || nil
+    @args    = { :bmc_provider => provider }
+    authorize user, pass
+  end
+
+  def test_api_can_put_power_action
+    Proxy::BMC::IPMI.any_instance.stubs(:poweroff).returns(true)
+    put "/bmc/#{host}/chassis/power/off", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/true|false/, data["result"].to_s)
+  end
+
+  def test_api_can_get_power_on_status
+    Proxy::BMC::IPMI.any_instance.stubs(:poweron?).returns(true)
+    get "/bmc/#{host}/chassis/power/on", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/true|false/, data["result"].to_s)
+  end
+
+  def test_api_can_get_power_off
+    Proxy::BMC::IPMI.any_instance.stubs(:poweroff?).returns(true)
+    get "/bmc/#{host}/chassis/power/off", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/true|false/, data["result"].to_s)
+  end
+
+  def test_api_can_get_ip
+    Proxy::BMC::IPMI.any_instance.stubs(:ip).returns("192.168.1.1")
+    get "/bmc/#{host}/lan/ip", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal("192.168.1.1", data["result"].to_s)
+  end
+
+  def test_api_can_get_netmask
+    Proxy::BMC::IPMI.any_instance.stubs(:netmask).returns("255.255.255.0")
+    get "/bmc/#{host}/lan/netmask", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal("255.255.255.0", data["result"].to_s)
+  end
+
+  def test_api_can_get_gateway
+    Proxy::BMC::IPMI.any_instance.stubs(:gateway).returns("192.168.1.1")
+    get "/bmc/#{host}/lan/gateway", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal("192.168.1.1", data["result"].to_s)
+  end
+
+  def test_api_can_get_mac
+    Proxy::BMC::IPMI.any_instance.stubs(:mac).returns("e0:f8:47:04:bc:26")
+    get "/bmc/#{host}/lan/mac", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal("e0:f8:47:04:bc:26", data["result"].to_s)
+  end
+
+  def test_api_can_identify
+    Proxy::BMC::IPMI.any_instance.stubs(:identifyon).returns(true)
+    put "/bmc/#{host}/chassis/identify/on", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/true|false/, data["result"].to_s)
+  end
+
+  def test_api_can_set_pxe_boot_device
+    Proxy::BMC::IPMI.any_instance.stubs(:bootpxe).returns(true)
+    put "/bmc/#{host}/chassis/config/bootdevice/pxe", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/true|false/, data["result"].to_s)
+  end
+
+  def test_api_can_set_disk_boot_device
+    Proxy::BMC::IPMI.any_instance.stubs(:bootdisk).returns(true)
+    put "/bmc/#{@host}/chassis/config/bootdevice/disk", @args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/true|false/, data["result"].to_s)
+  end
+
+  def test_api_can_set_cdrom_boot_device
+    Proxy::BMC::IPMI.any_instance.stubs(:bootcdrom).returns(true)
+    put "/bmc/#{@host}/chassis/config/bootdevice/cdrom", @args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/true|false/, data["result"].to_s)
+  end
+
+  def test_api_can_set_bios_boot_device
+    Proxy::BMC::IPMI.any_instance.stubs(:bootbios).returns(true)
+    put "/bmc/#{@host}/chassis/config/bootdevice/bios", @args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/true|false/, data["result"].to_s)
+  end
+
+  def test_api_returns_actions_for_power_get
+    get "/bmc/#{host}/chassis/power", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_operator(data["actions"].length, :>, 0)
+  end
+
+  def test_api_returns_functions_for_config_get
+    get "/bmc/#{host}/chassis/config", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_operator(data["functions"].length, :>, 0)
+  end
+
+  def test_api_returns_functions_for_chassis_config_get
+    get "/bmc/#{host}/chassis/config/", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_operator(data["functions"].length, :>, 0)
+  end
+
+  def test_api_returns_bootdevices_for_chassis_config_bootdevices_get
+    get "/bmc/#{host}/chassis/config/bootdevices", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_operator(data["devices"].length, :>, 0)
+  end
+
+  def test_api_returns_actions_for_power_put
+    put "/bmc/#{host}/chassis/power", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_operator(data["actions"].length, :>, 0)
+  end
+
+  def test_api_returns_actions_for_identify_put
+    put "/bmc/#{host}/chassis/identify", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_operator(data["actions"].length, :>, 0)
+  end
+
+  def test_api_returns_actions_for_boot_devices_put
+    put "/bmc/#{host}/chassis/config/bootdevice", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_operator(data["actions"].length, :>, 0)
+  end
+
+  def test_api_returns_actions_for_lan
+    get "/bmc/#{host}/lan", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_operator(data["actions"].length, :>, 0)
+  end
+
+  def test_api_returns_error_for_boot_devices_get
+    get "/bmc/#{host}/chassis/config/bogus", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/not a valid/, data["error"])
+  end
+
+  def test_api_returns_error_for_boot_devices_put
+    put "/bmc/#{host}/chassis/config/bootdevice/bogus", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/not a valid/, data["error"])
+  end
+
+  def test_api_returns_error_for_power_get
+    get "/bmc/#{host}/chassis/power/bogus", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/not a valid/, data["error"])
+  end
+
+  def test_api_returns_error_for_power_put
+    put "/bmc/#{host}/chassis/power/bogus", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/not a valid/, data["error"])
+  end
+
+  def test_api_returns_error_for_identify_put
+    put "/bmc/#{host}/chassis/identify/bogus", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/not a valid/, data["error"])
+  end
+
+  def test_api_returns_error_for_config_put
+    put "/bmc/#{host}/chassis/config/bogus", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/not a valid/, data["error"])
+  end
+
+  def test_api_bmc_returns_error_correctly
+    get "/bmc/#{host}/lan/bogus", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/not a valid/, data["error"])
+  end
+
+  private
+  attr_reader :host, :args
+
+end

--- a/test/bmc_test.rb
+++ b/test/bmc_test.rb
@@ -1,0 +1,66 @@
+require 'test_helper'
+require 'proxy/bmc/ipmi'
+
+class BmcTest < Test::Unit::TestCase
+
+  # Testing instructions
+  #rake test TEST=test/bmc_test.rb
+
+  def setup
+    @args    = { :username => "user", :password => "pass", :bmc_provider => "ipmitool", :host => "host" }
+    @bmc     = Proxy::BMC::IPMI.new(@args)
+  end
+
+  def test_creates_rubyipmi_object
+    assert_not_nil bmc
+  end
+
+  def test_should_turnoff_led
+      Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:identify).returns(true)
+      assert_equal(true, bmc.identifyoff)
+  end
+
+  def test_should_turnon_led
+    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:identify).returns(true)
+    assert_equal(true, bmc.identifyon)
+  end
+
+  def test_should_power_off
+    Rubyipmi::Ipmitool::Power.any_instance.stubs(:off).returns(true)
+    assert_equal(true, bmc.poweroff)
+  end
+
+  def test_should_power_on
+    Rubyipmi::Ipmitool::Power.any_instance.stubs(:on).returns(true)
+    assert_equal(true, bmc.poweron)
+  end
+
+  def test_should_power_cycle
+    Rubyipmi::Ipmitool::Power.any_instance.stubs(:cycle).returns(true)
+    assert_equal(true, bmc.powercycle)
+  end
+
+  def test_should_bootpxe
+    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:bootpxe).returns(true)
+    bmc.bootpxe
+  end
+
+  def test_should_bootdisk
+    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:bootdisk).returns(true)
+    bmc.bootdisk
+  end
+
+  def test_should_bootbios
+    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:bootbios).returns(true)
+    bmc.bootbios
+  end
+
+  def test_should_bootcdrom
+    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:bootcdrom).returns(true)
+    bmc.bootcdrom
+  end
+
+  private
+  attr_reader :bmc
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,5 @@ require "test/unit"
 $: << File.join(File.dirname(__FILE__), '..', 'lib')
 require "proxy"
 require "mocha"
+require "rack/test"
+require 'sinatra'


### PR DESCRIPTION
This will add support to smartproxy that allows bmc management via http(s).  

authentication is handled via http basic auth.
