### PR TITLE
Allow a Squid proxy to be managed by the Smart Proxy

### DIFF
--- a/bin/smart-proxy
+++ b/bin/smart-proxy
@@ -35,6 +35,7 @@ class SmartProxy < Sinatra::Base
   require "puppetca_api" if SETTINGS.puppetca
   require "dns_api"      if SETTINGS.dns
   require "dhcp_api"     if SETTINGS.dhcp
+  require "squid_api"    if SETTINGS.squid
   require "features_api"
 
   begin

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -1,5 +1,5 @@
 module Proxy
-  MODULES = %w{dns dhcp tftp puppetca puppet}
+  MODULES = %w{dhcp dns puppetca puppet squid tftp}
   VERSION = "1.0"
 
   require "checks"
@@ -9,11 +9,12 @@ module Proxy
   require "rubygems" if USE_GEMS # required for testing
   require "proxy/log"
   require "proxy/util"
-  require "proxy/tftp"     if SETTINGS.tftp
+  require "proxy/dhcp"     if SETTINGS.dhcp
+  require "proxy/dns"      if SETTINGS.dns
   require "proxy/puppetca" if SETTINGS.puppetca
   require "proxy/puppet"   if SETTINGS.puppet
-  require "proxy/dns"      if SETTINGS.dns
-  require "proxy/dhcp"     if SETTINGS.dhcp
+  require "proxy/squid"    if SETTINGS.squid
+  require "proxy/tftp"     if SETTINGS.tftp
 
   def self.features
     MODULES.collect{|mod| mod if SETTINGS.send mod}.compact

--- a/lib/proxy/squid.rb
+++ b/lib/proxy/squid.rb
@@ -5,7 +5,27 @@ module Proxy::Squid
   require "proxy/settings"
 
   class << self
-    def reconfigure *host
+    def add *hosts
+      hosts.each do |ip_addr|
+        filename = File.join(SETTINGS.squid_conf_dir, 'foreman.d', "#{ip_addr}.conf")
+        File.open( filename, 'w' ) do |f|
+          f.puts "acl foreman_clients src #{ip_addr}"
+        end
+      end
+      reconfigure
+    end
+
+    def rm *hosts
+      hosts.each do |ip_addr|
+        filename = File.join(SETTINGS.squid_conf_dir, 'foreman.d', "#{ip_addr}.conf")
+        File.unlink( filename )
+      end
+      reconfigure
+    end
+  end
+
+  private
+  def reconfigure *host
       path  = ['/usr/sbin', '/usr/bin', '/opt/squid3/bin', '/opt/squid/bin']
       squid = which('squid3', path) || which('squid', path)
       sudo  = which('sudo', '/usr/bin')
@@ -29,23 +49,4 @@ module Proxy::Squid
 
       return true
     end
-
-    def add *hosts
-      hosts.each do |ip_addr|
-        filename = File.join(SETTINGS.squid_conf_dir, 'foreman.d', "#{ip_addr}.conf")
-        File.open( filename, 'w' ) do |f|
-          f.puts "acl foreman_clients src #{ip_addr}"
-        end
-      end
-      reconfigure
-    end
-
-    def rm *hosts
-      hosts.each do |ip_addr|
-        filename = File.join(SETTINGS.squid_conf_dir, 'foreman.d', "#{ip_addr}.conf")
-        File.unlink( filename )
-      end
-      reconfigure
-    end
-  end
 end

--- a/lib/proxy/squid.rb
+++ b/lib/proxy/squid.rb
@@ -1,0 +1,51 @@
+module Proxy::Squid
+  extend Proxy::Log
+  extend Proxy::Util
+
+  require "proxy/settings"
+
+  class << self
+    def reconfigure *host
+      path  = ['/usr/sbin', '/usr/bin', '/opt/squid3/bin', '/opt/squid/bin']
+      squid = which('squid3', path) || which('squid', path)
+      sudo  = which('sudo', '/usr/bin')
+
+      unless squid and sudo
+        logger.warn 'sudo or squid binary was not found - aborting'
+        return false
+      end
+
+      parse_output = %x[#{sudo} #{squid} -k parse]
+      if $? != 0
+        logger.warn parse_output
+        return false
+      end
+
+      restart_output = %x[#{sudo} #{squid} -k reconfigure]
+      if $? != 0
+        logger.warn restart_output
+        return false
+      end
+
+      return true
+    end
+
+    def add *hosts
+      hosts.each do |ip_addr|
+        filename = File.join(SETTINGS.squid_conf_dir, 'foreman.d', "#{ip_addr}.conf")
+        File.open( filename, 'w' ) do |f|
+          f.puts "acl foreman_clients src #{ip_addr}"
+        end
+      end
+      reconfigure
+    end
+
+    def rm *hosts
+      hosts.each do |ip_addr|
+        filename = File.join(SETTINGS.squid_conf_dir, 'foreman.d', "#{ip_addr}.conf")
+        File.unlink( filename )
+      end
+      reconfigure
+    end
+  end
+end

--- a/lib/squid_api.rb
+++ b/lib/squid_api.rb
@@ -1,18 +1,24 @@
 # Should only be accessible by Foreman
 class SmartProxy
-  # Having two handlers isn't DRY
-  post %r{/squid/(add|rm)$} do
-    require 'pp'
-    pp params
-
-    action = params[:captures].first
+  post '/squid/add' do
     host   = params[:host]
 
     begin
-      log_halt 400, "Couldn't #{action} squid ACL: no host specified" unless host
-      log_halt 500, "Failed to #{action} squid ACL" unless Proxy::Squid.send action.to_sym, host
+      log_halt 400, "Couldn't add squid ACL: no host specified" unless host
+      log_halt 500, "Failed to add squid ACL" unless Proxy::Squid.add host
     rescue => e
-      log_halt 500, "Failed to #{action} squid configuration: #{e}"
+      log_halt 500, "Failed to add squid configuration: #{e}"
+    end
+  end
+
+  delete '/squid/rm' do
+    host   = params[:host]
+
+    begin
+      log_halt 400, "Couldn't remove squid ACL: no host specified" unless host
+      log_halt 500, "Failed to remove squid ACL" unless Proxy::Squid.rm host
+    rescue => e
+      log_halt 500, "Failed to remove squid configuration: #{e}"
     end
   end
 

--- a/lib/squid_api.rb
+++ b/lib/squid_api.rb
@@ -1,0 +1,19 @@
+# Should only be accessible by Foreman
+class SmartProxy
+  # Having two handlers isn't DRY
+  post %r{/squid/(add|rm)$} do
+    require 'pp'
+    pp params
+
+    action = params[:captures].first
+    host   = params[:host]
+
+    begin
+      log_halt 400, "Couldn't #{action} squid ACL: no host specified" unless host
+      log_halt 500, "Failed to #{action} squid ACL" unless Proxy::Squid.send action.to_sym, host
+    rescue => e
+      log_halt 500, "Failed to #{action} squid configuration: #{e}"
+    end
+  end
+
+end


### PR DESCRIPTION
When you are provisioning hosts that cannot reach the
Foreman server due to the network's design, you may
want to have a Squid proxy running on the subnet to
provide access. This permits such a proxy to be
managed with the Smart Proxy.

Currently, "managed" means adding and removing files
which control access to the proxy for a single host:

```
acl foreman_clients src host_that_cant_reach_foreman
```

This permits the host to use the Squid proxy to reach
Foreman, for example when notifying the server that the
build has completed.

Set "squid: true" and "squid_conf_dir" to the configuration
directory for your proxy (typically, /etc/squid or
/etc/squid3) to enable Squid management. Inside this
directory, you must create a directory called "foreman.d"
which will store the files that the Smart Proxy manages.
Include the directory with "include /etc/squid/foreman.d/*.conf"
and provide a url_regex ACL called "foreman_url" - this is the
resource that the Squid proxy will permit access to for the
ACL entries that the Smart Proxy manages.

An example configuration follows:

```
#           hostname                type    proxy port  icp port    options
cache_peer  foreman.localdomain     parent  80          0           no-query

http_port   80

acl Safe_ports port 80 21 443 563 70 210 1025-65535
http_access deny !Safe_ports

acl SSL_ports port 443
acl CONNECT method CONNECT
http_access deny CONNECT !SSL_ports

acl foreman_url url_regex ^http://foreman.localdomain/unattended/
include /etc/squid3/foreman.d/*.conf

# Permit access only to known safe ports
http_access deny !safe_ports
http_access allow foreman_clients foreman_url

# Must be the last rule
http_access deny all
```

The user the Smart Proxy runs as must be able to use sudo
to run the squid binary as root without a password.

Caveats:
- There is no test suite for this feature yet

Resolves http://theforeman.org/issues/969
