### PR TITLE
fixes #1929 - set umask sensibly to prevent world writable files

### DIFF
--- a/lib/daemon.rb
+++ b/lib/daemon.rb
@@ -9,7 +9,7 @@ if RUBY_VERSION < "1.9"
         Dir.chdir "/"                  # Release old working directory.
       end
 
-      File.umask 0000                  # Ensure sensible umask. Adjust as needed.
+      File.umask 0022                  # Ensure sensible umask. Adjust as needed.
 
       logdir = File.join(APP_ROOT, "logs")
       FileUtils.mkdir_p logdir


### PR DESCRIPTION
Previous umask wasn't very sensible at all, this locks it down.

It does restrict group writes, but I can't think of an instance where this would be needed for files created by the proxy.
