### PR TITLE
fixes #1915 - load environments from Puppet 3

### DIFF
--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -21,10 +21,25 @@ module Proxy::Puppet
 
       def puppet_environments
         Puppet.clear
+        if Puppet::PUPPETVERSION.to_i >= 3
+          # Used on Puppet 3.0, private method that clears the "initialized or
+          # not" state too, so a full config reload takes place and we pick up
+          # new environments
+          Puppet.settings.send(:clear_everything_for_tests)
+        end
+
         Puppet[:config] = SETTINGS.puppet_conf if SETTINGS.puppet_conf
         raise("Cannot read #{Puppet[:config]}") unless File.exist?(Puppet[:config])
         logger.info "Reading environments from Puppet config file: #{Puppet[:config]}"
-        Puppet.parse_config
+
+        if Puppet::PUPPETVERSION.to_i >= 3
+          # Initializing Puppet directly and not via the Faces API, so indicate
+          # the run mode to parse [master].  Don't use --run_mode=master or
+          # bug #17492 is hit and Puppet can't parse it.
+          Puppet.settings.initialize_global_settings(['--config', Puppet[:config], '--run_mode' 'master'])
+        else
+          Puppet.parse_config
+        end
         conf = Puppet.settings.instance_variable_get(:@values)
 
         env = { }


### PR DESCRIPTION
Two changes to support loading environment settings from Puppet 3:
- explicitly specify the run_mode as being 'master' to ensure the config is
  parsed in a puppetmaster context
- call private method to fully clear the state in Puppet::Settings allowing for
  a full reparsing of the config to pick up changes in environments (Puppet bug
  #17783)

This supersedes GH-40 as it explicitly loads the master run_mode and will allow for environments to be reloaded without restarting the proxy.  I've filed #17783 with Puppet to give us  back a better public interface for doing this, it should included in the Puppet 3.1 refactor of the settings stuff.
