### PR TITLE
Store and re-use the last IP we pinged

### DIFF
--- a/lib/proxy/dhcp/monkey_patch_subnet.rb
+++ b/lib/proxy/dhcp/monkey_patch_subnet.rb
@@ -1,0 +1,9 @@
+class Array
+  # Ruby1.8 doesn't have a rotate function, so we add our own...
+  def rotate n = 1
+    return self if empty?
+    n %= length
+    self[n..-1]+self[0...n]
+  end
+end
+


### PR DESCRIPTION
Store the last successful IP returned to the Foreman UI in a file in /tmp. Use a file lock to make sure concurrent process don't try and offer the same IP to two users.
