### PR TITLE
fixes #1983 - use /etc/puppet/puppet.conf by default

### DIFF
--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -28,8 +28,12 @@ module Proxy::Puppet
           Puppet.settings.send(:clear_everything_for_tests)
         end
 
-        Puppet[:config] = SETTINGS.puppet_conf if SETTINGS.puppet_conf
-        raise("Cannot read #{Puppet[:config]}") unless File.exist?(Puppet[:config])
+        if SETTINGS.puppet_conf
+          Puppet[:config] = SETTINGS.puppet_conf
+          raise("Cannot read #{Puppet[:config]}") unless File.exist?(Puppet[:config])
+        elsif Puppet::PUPPETVERSION.to_i >= 3
+          Puppet[:config] = "/etc/puppet/puppet.conf"
+        end
         logger.info "Reading environments from Puppet config file: #{Puppet[:config]}"
 
         if Puppet::PUPPETVERSION.to_i >= 3


### PR DESCRIPTION
When initialising Puppet 3 settings directly, a config dir or file is required,
so default to /etc/puppet/puppet.conf (as the puppetca code also does).

(As mentioned in the commit message, the puppetca code already has a fallback for /etc/puppet, so the environments code should do the same.)
