### PR TITLE
Fixes #1985 - Replace ping with nmap

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,6 @@ spec = Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README"]
   s.add_dependency 'json'
   s.add_dependency 'sinatra'
-  s.add_dependency 'net/ping'
   s.rubyforge_project = 'rake'
   s.description = <<EOF
 Foreman Proxy is used via The Foreman Project, it allows Foreman to manage


### PR DESCRIPTION
Replaces ping with nmap. Checks if the binary is on the system and raises a sensible error if not.

As for removing tcp_pingable, from the nmap man page:

The default host discovery done with -sn consists of an ICMP echo request, TCP SYN to port 443, TCP ACK to port 80, and an ICMP timestamp request by default. When executed by an unprivileged user, only SYN packets are sent (using a connect call) to ports 80 and 443 on the target.
