### PR TITLE
Remove dependency on net-ping

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -47,7 +47,6 @@ spec = Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README"]
   s.add_dependency 'json'
   s.add_dependency 'sinatra'
-  s.add_dependency 'net/ping'
   s.rubyforge_project = 'rake'
   s.description = <<EOF
 Foreman Proxy is used via The Foreman Project, it allows Foreman to manage


### PR DESCRIPTION
Tested on ruby 1.8 and ruby 1.9.
