### PR TITLE
fixes #2077 - proxy should not return nil for parameters with a function...

### DIFF
--- a/lib/proxy/puppet/puppet_class.rb
+++ b/lib/proxy/puppet/puppet_class.rb
@@ -96,6 +96,8 @@ module Proxy::Puppet
             when Puppet::Parser::AST::ASTHash
               Hash[value.value.each.inject([]) { |arr, (k,v)| (arr << [ast_to_value(k), ast_to_value(v)]) rescue arr }]
             # Let's see if a raw evaluation works with no scope for any other type
+            when Puppet::Parser::AST::Function
+              "${#{value}}"
             else
               if value.respond_to? :evaluate
                 # Can probably work for: (depending on the actual content)
@@ -112,7 +114,6 @@ module Proxy::Puppet
                 # - Puppet::Parser::AST::Variable
                 # - Puppet::Parser::AST::HashOrArrayAccess
                 # - Puppet::Parser::AST::ResourceReference
-                # - Puppet::Parser::AST::Function
                 value.evaluate nil
               else
                 raise TypeError


### PR DESCRIPTION
... call

in cases where puppet has class declaration such as:

  class xyz($param = myfunction('p'))

the proxy would return a that param value is nil.
this patch changes that, so it return it as a string, allowing users to know
that a function call was there, and allow them to override it if they want.
