### PR TITLE
Add warning if no environments found 

### DIFF
--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -61,6 +61,7 @@ module Proxy::Puppet
         if env.values.compact.size == 0
           # fall back to defaults - we probably don't use environments
           env[:production] = conf[:main][:modulepath] || conf[:master][:modulepath] || '/etc/puppet/modules'
+          logger.warn "No environments found - falling back to defaults (production - #{env[:production]})"
         end
 
         new_env = env.clone


### PR DESCRIPTION
... and smart-proxy falls back to defaults
