### PR TITLE
fixes #2085 - load Puppet 3 app defaults for master mode too

### DIFF
--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -1,5 +1,6 @@
 module Proxy::Puppet
 
+  require 'proxy/puppet/initializer'
   require 'proxy/puppet/puppet_class'
   require 'puppet'
 
@@ -20,30 +21,7 @@ module Proxy::Puppet
       private
 
       def puppet_environments
-        Puppet.clear
-        if Puppet::PUPPETVERSION.to_i >= 3
-          # Used on Puppet 3.0, private method that clears the "initialized or
-          # not" state too, so a full config reload takes place and we pick up
-          # new environments
-          Puppet.settings.send(:clear_everything_for_tests)
-        end
-
-        if SETTINGS.puppet_conf
-          Puppet[:config] = SETTINGS.puppet_conf
-          raise("Cannot read #{Puppet[:config]}") unless File.exist?(Puppet[:config])
-        elsif Puppet::PUPPETVERSION.to_i >= 3
-          Puppet[:config] = "/etc/puppet/puppet.conf"
-        end
-        logger.info "Reading environments from Puppet config file: #{Puppet[:config]}"
-
-        if Puppet::PUPPETVERSION.to_i >= 3
-          # Initializing Puppet directly and not via the Faces API, so indicate
-          # the run mode to parse [master].  Don't use --run_mode=master or
-          # bug #17492 is hit and Puppet can't parse it.
-          Puppet.settings.initialize_global_settings(['--config', Puppet[:config], '--run_mode' 'master'])
-        else
-          Puppet.parse_config
-        end
+        Initializer.load
         conf = Puppet.settings.instance_variable_get(:@values)
 
         env = { }

--- a/lib/proxy/puppet/initializer.rb
+++ b/lib/proxy/puppet/initializer.rb
@@ -1,0 +1,39 @@
+module Proxy::Puppet
+
+  require 'puppet'
+
+  class Initializer
+    extend Proxy::Log
+
+    class << self
+      def load
+        Puppet.clear
+        if Puppet::PUPPETVERSION.to_i >= 3
+          # Used on Puppet 3.0, private method that clears the "initialized or
+          # not" state too, so a full config reload takes place and we pick up
+          # new environments
+          Puppet.settings.send(:clear_everything_for_tests)
+        end
+
+        if SETTINGS.puppet_conf
+          Puppet[:config] = SETTINGS.puppet_conf
+          raise("Cannot read #{Puppet[:config]}") unless File.exist?(Puppet[:config])
+        elsif Puppet::PUPPETVERSION.to_i >= 3
+          Puppet[:config] = "/etc/puppet/puppet.conf"
+        end
+        logger.info "Initializing from Puppet config file: #{Puppet[:config]}"
+
+        if Puppet::PUPPETVERSION.to_i >= 3
+          # Initializing Puppet directly and not via the Faces API, so indicate
+          # the run mode to parse [master].  Don't use --run_mode=master or
+          # bug #17492 is hit and Puppet can't parse it.
+          Puppet.settings.initialize_global_settings(['--config', Puppet[:config], '--run_mode', 'master'])
+          Puppet.settings.initialize_app_defaults(Puppet::Settings.app_defaults_for_run_mode(Puppet::Util::RunMode['master']))
+        else
+          Puppet.parse_config
+        end
+      end
+    end
+
+  end
+end

--- a/lib/proxy/puppet/puppet_class.rb
+++ b/lib/proxy/puppet/puppet_class.rb
@@ -1,4 +1,4 @@
-require 'puppet'
+require 'proxy/puppet/initializer'
 
 module Proxy::Puppet
 
@@ -9,6 +9,7 @@ module Proxy::Puppet
       # returns an array of PuppetClass objects.
       def scan_directory directory
         # Get a Puppet Parser to parse the manifest source
+        Initializer.load
         parser = Puppet::Parser::Parser.new Puppet::Node::Environment.new
         Dir.glob("#{directory}/*/manifests/**/*.pp").map do |filename|
           scan_manifest File.read(filename), filename, parser
@@ -18,7 +19,10 @@ module Proxy::Puppet
       def scan_manifest manifest, filename = '', parser = nil
         klasses = []
         # Get a Puppet Parser to parse the manifest source
-        parser ||= Puppet::Parser::Parser.new(Puppet::Node::Environment.new)
+        unless parser
+          Initializer.load
+          parser = Puppet::Parser::Parser.new(Puppet::Node::Environment.new)
+        end
         already_seen = Set.new parser.known_resource_types.hostclasses.keys
         already_seen << '' # Prevent the toplevel "main" class from matching
         ast = parser.parse manifest


### PR DESCRIPTION
Allows $confdir and other run mode specific settings to be initialised from
the defaults present in Puppet::Util::RunMode.  When requesting detail on
classes, the Puppet parser indirectly requests app level settings so both
global and app settings are needed.  Refactored into shared code for both
parser and environments to use.

No new tests, since the old ones were already failing!
