### PR TITLE
Fixes some autosign.conf issues (comments, EOL on last line)

### DIFF
--- a/lib/proxy/puppetca.rb
+++ b/lib/proxy/puppetca.rb
@@ -35,6 +35,7 @@ module Proxy::PuppetCA
       if found
         autosign = open(autosign_file, File::TRUNC|File::RDWR)
         autosign.write entries.join("\n")
+        autosign.write "\n"
         autosign.close
         logger.info "Removed #{certname} from autosign"
       else
@@ -59,7 +60,12 @@ module Proxy::PuppetCA
 
     # list of hosts which are now allowed to be installed via autosign
     def autosign_list
-      File.exist?(autosign_file) ? File.read(autosign_file).split : []
+      return [] unless File.exist?(autosign_file)
+      File.read(autosign_file).split("\n").reject { |v|
+        v =~ /^\s*#.*|^$/ ## Remove comments and empty lines
+      }.map { |v|
+        v.chomp ## Strip trailing spaces
+      }
     end
 
     # list of all certificates and their state/fingerprint

--- a/test/fixtures/autosign.conf
+++ b/test/fixtures/autosign.conf
@@ -1,0 +1,6 @@
+# Comment
+
+foo.example.com
+*.bar.example.com
+
+# Comment

--- a/test/puppetca_test.rb
+++ b/test/puppetca_test.rb
@@ -1,6 +1,56 @@
 require 'test_helper'
+require 'tempfile'
+require 'fileutils'
+
 
 class ProxyTest < Test::Unit::TestCase
+  ## Helper for autosign files.
+  def create_temp_autosign_file
+    file = Tempfile.new('autosign_test')
+    begin
+      ## Setup
+      FileUtils.cp './test/fixtures/autosign.conf', file.path
+      Proxy::PuppetCA.stubs(:autosign_file).returns(file.path)
+    rescue
+      file.close
+      file.unlink
+      file = nil
+    end
+    file
+  end
+
+  def test_should_list_autosign_entries
+    Proxy::PuppetCA.stubs(:autosign_file).returns('./test/fixtures/autosign.conf')
+    assert_equal Proxy::PuppetCA.autosign_list, ['foo.example.com', '*.bar.example.com']
+  end
+
+  def test_should_add_autosign_entry
+    file = create_temp_autosign_file
+    content = []
+    begin
+      ## Execute
+      Proxy::PuppetCA.autosign 'foobar.example.com'
+      ## Read output
+      content = file.read.split("\n")
+    ensure
+      file.close
+      file.unlink
+    end
+    assert_equal content.include?('foobar.example.com'), true
+  end
+
+  def test_should_remove_autosign_entry
+    file = create_temp_autosign_file
+    content = ['foo.example.com']
+    begin
+      Proxy::PuppetCA.disable 'foo.example.com'
+      content = file.read.split("\n")
+    ensure
+      file.close
+      file.unlink
+    end
+    assert_equal content.include?('foo.example.com'), false
+  end
 
   def test_should_have_a_logger
     assert_respond_to Proxy::PuppetCA, :logger

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,6 +1,8 @@
 require "test/unit"
 $: << File.join(File.dirname(__FILE__), '..', 'lib')
 require "proxy"
+require "proxy/puppetca"
+require "proxy/tftp"
 require "mocha/setup"
 require "rack/test"
 require 'sinatra'


### PR DESCRIPTION
Ignore commented lines when reading all certificates in autosign and make sure the autosign file contains a EOL on the last line
