### PR TITLE
fixes #2261 - fixes for CI testing under Ruby 1.9

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -4,4 +4,6 @@ group :test do
   gem 'rack-test'
   gem 'single_test'
   gem 'ci_reporter', '>= 1.6.3'
+  gem 'rdoc'
+  gem 'minitest', :platforms => :ruby_19
 end

--- a/lib/proxy/settings.rb
+++ b/lib/proxy/settings.rb
@@ -1,3 +1,4 @@
+require "checks"
 require "yaml"
 require "ostruct"
 require "pathname"

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -1,13 +1,15 @@
 begin
-  require 'ci/reporter/rake/test_unit'
+  testtool = RUBY_VERSION =~ /^1\.8/ ? 'test_unit' : 'minitest'
+  require "ci/reporter/rake/#{testtool}"
   namespace :jenkins do
-    task :unit => ["jenkins:setup:test_unit", 'rake:test']
+    task :unit => ["jenkins:setup:#{testtool}", 'rake:test']
 
     namespace :setup do
       task :pre_ci do
         ENV["CI_REPORTS"] = 'jenkins/reports/unit/'
         gem 'ci_reporter'
       end
+      task :minitest  => [:pre_ci, "ci:setup:minitest"]
       task :test_unit => [:pre_ci, "ci:setup:testunit"]
     end
   end

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -3,11 +3,11 @@ require 'test_helper'
 class ProxyUtilTest < Test::Unit::TestCase
 
   def test_util_should_support_path
-    assert Proxy::Util.instance_methods.include? RUBY_VERSION >= '1.9.3' ? :which : "which"
+    assert Proxy::Util.instance_methods.include? RUBY_VERSION =~ /^1\.8/ ? "which" : :which
   end
 
   def test_util_shell_escape
-    assert Proxy::Util.methods.include? RUBY_VERSION >= '1.9.3' ? :escape_for_shell : "escape_for_shell"
+    assert Proxy::Util.methods.include? RUBY_VERSION =~ /^1\.8/ ? "escape_for_shell" : :escape_for_shell
     assert_equal Proxy::Util.escape_for_shell("; rm -rf"), '\;\ rm\ -rf'
     assert_equal Proxy::Util.escape_for_shell("vm.test.com,physical.test.com"), "vm.test.com,physical.test.com"
     assert_equal Proxy::Util.escape_for_shell("vm.test.com physical.test.com"), 'vm.test.com\ physical.test.com'


### PR DESCRIPTION
Support minitest in Jenkins rake tasks, add rdoc and minitest deps due to
old 1.9.2 versions.  Fix PLATFORM under 1.9, fix 1.9.3 specific test.
