### PR TITLE
Add shell provider to the BMC API

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -62,10 +62,10 @@
 :puppet_conf: /etc/puppet/puppet.conf
 
 # enable BMC management  (Bare metal power and bios controls)
-# Ensure that you have freeipmi or ipmitool command line tools installed
-# You will also need the rubyipmi gem
+# Available providers:
+# - freeipmi / ipmitool - requires the appropriate package installed, and the rubyipmi gem
+# - shell - for local reboot control (requires sudo access to /sbin/shutdown for the proxy user)
 :bmc: false
-# Available bmc providers: freeipmi, ipmitool (Optional)
 #:bmc_default_provider: freeipmi
 
 # Where our proxy log files are stored

--- a/lib/proxy/bmc.rb
+++ b/lib/proxy/bmc.rb
@@ -1,19 +1,14 @@
-require 'proxy/bmc/ipmi'
-
 module Proxy
   module BMC
 
-    # This is a top level function to list all providers accepted
+    # Just a bunch of stubs
     def self.installed_providers?
-      IPMI.providers_installed?
     end
 
     def self.providers
-      IPMI.providers
     end
 
     def self.installed?(provider)
-      IPMI.installed?(provider)
     end
   end
 end

--- a/lib/proxy/bmc/shell.rb
+++ b/lib/proxy/bmc/shell.rb
@@ -1,0 +1,55 @@
+require 'proxy/bmc/base'
+
+module Proxy
+  module BMC
+    class Shell < Base
+      include Proxy::Log
+      include Proxy::Util
+
+      def initialize
+      end
+
+      def self.installed?(args)
+        return true # We can always shell out
+      end
+
+      # Must be on
+      def poweron?
+        true
+      end
+
+      # Must be on
+      def poweroff?
+        false
+      end
+
+      # Must be on
+      def powerstatus
+        "on"
+      end
+
+      def powercycle
+        # search for sudo
+        sudo         = which("sudo", "/usr/bin")
+
+        unless sudo
+          logger.warn "sudo binary was not found - aborting"
+          return false
+        end
+
+        cycle_cmd = [sudo,"shutdown","-r","now","foreman_proxy initiated shutdown via BMC shell api"]
+
+        # Returns a boolean with whether or not the command executed successfully.
+        stdout = `#{cycle_cmd.join(' ')}`
+        if $? == 0
+          logger.info "Shutdown command successful"
+          return true
+        else
+          logger.warn "The attempted shutdown failed: \n#{stdout}"
+          return false
+        end
+      end
+        
+    end
+  end
+end

--- a/test/bmc_api_shell_test.rb
+++ b/test/bmc_api_shell_test.rb
@@ -1,0 +1,35 @@
+require 'test_helper'
+require 'helpers'
+require 'bmc_api'
+require 'json'
+
+ENV['RACK_ENV'] = 'test'
+
+class BmcApiShellTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    SmartProxy.new
+  end
+
+  def setup
+    # Testing instructions
+    #rake test TEST=test/bmc_api_test.rb
+
+    @host    ||= ENV["ipmihost"] || "host"
+    provider ||= ENV["ipmiprovider"] || "shell"
+    @args    = { :bmc_provider => provider }
+    require 'proxy/bmc/shell'
+  end
+
+  def test_api_shell_should_powercycle_with_shutdown
+    Proxy::BMC::Shell.any_instance.stubs(:powercycle).returns(true)
+    args = { :bmc_provider => 'shell' }
+    get "/bmc/#{host}/chassis/power/cycle", args
+    @args = { :username => "user", :password => "pass", :bmc_provider => "ipmitool", :host => "host" }
+  end
+
+  private
+  attr_reader :host, :args
+
+end


### PR DESCRIPTION
- Only Accepts on/off/status/cycle for power commands
- Needs sudo for the proxy to call /sbin/shutdown
- Adds a simple test for calling the shutdown api
