### PR TITLE
Making proxy to be compliant with Sinatra 1.4.2 release

### DIFF
--- a/lib/dhcp_api.rb
+++ b/lib/dhcp_api.rb
@@ -37,7 +37,7 @@ class SmartProxy < Sinatra::Base
 
   get "/dhcp" do
     begin
-      if request.accept.include?("application/json")
+      if request.accept? 'application/json'
         content_type :json
 
         log_halt 404, "No subnets found on server @{name}" unless @subnets
@@ -53,7 +53,7 @@ class SmartProxy < Sinatra::Base
   get "/dhcp/:network" do
     begin
       load_subnet
-      if request.accept.include?("application/json")
+      if request.accept? 'application/json'
         content_type :json
         {:reservations => @subnet.reservations, :leases => @subnet.leases}.to_json
       else
@@ -104,7 +104,7 @@ class SmartProxy < Sinatra::Base
       record = load_subnet[params[:record]]
       log_halt 404, "Record #{params[:network]}/#{params[:record]} not found" unless record
       @server.delRecord @subnet, record
-      if request.accept.include?("application/json")
+      if request.accept? 'application/json'
         content_type :json
         {}
       else

--- a/lib/features_api.rb
+++ b/lib/features_api.rb
@@ -2,7 +2,7 @@ class SmartProxy < Sinatra::Base
   get "/features" do
     begin
       @features = Proxy.features.sort
-      if request.accept.include?("application/json")
+      if request.accept? 'application/json'
         content_type :json
         @features.to_json
       else

--- a/lib/helpers.rb
+++ b/lib/helpers.rb
@@ -14,7 +14,7 @@ class SmartProxy < Sinatra::Base
         message += e.message
         code     = code || 400
       end
-      content_type :json if request.accept.include?("application/json")
+      content_type :json if request.accept?("application/json")
       logger.error message
       logger.debug exception.backtrace.join("\n") if exception.is_a?(Exception)
       halt code, message

--- a/lib/sinatra-patch.rb
+++ b/lib/sinatra-patch.rb
@@ -49,4 +49,13 @@ module Sinatra
       puts "== Someone is already performing on port #{port}!"
     end
   end
+
+  module MonkeyRequest
+    # We need request.accept? method also in pre-1.3.0 versions. This is simplified
+    # version of the method that only accept one parameter (mime type string).
+    def accept? type
+      accept.include? type
+    end
+  end
+  Request.send :include, MonkeyRequest if not Request.method_defined? :accept?
 end


### PR DESCRIPTION
This change in Sinatra 1.4.2

https://github.com/sinatra/sinatra/pull/626/files

introduces new class AcceptEntry which is used for comparison of the accept
flag. Since we use request.accept.include? it does not work anymore on my
system:

```
(rdb:3) pp request.accept
[application/json]

(rdb:3) pp request.accept.include?("application/json")
false

(rdb:3) pp request.accept[0].class
Sinatra::Request::AcceptEntry
```

This patch changes all places where we use this comparison and changes it to
the standard way. This should be compatible across old Sinatra versions, but
please confirm this explicitly.
