### PR TITLE
REVIEW ONLY: fixes #1685 - GSS-TSIG support for DNS updates

### DIFF
--- a/bundler.d/krb5.rb
+++ b/bundler.d/krb5.rb
@@ -1,0 +1,3 @@
+group :krb5 do
+  gem 'djberg96-krb5-auth', :require => 'krb5_auth', :git => 'git://github.com/djberg96/krb5-auth.git', :branch => 'custom'
+end

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -32,6 +32,10 @@
 #:dns_key: /etc/rndc.key
 # use this setting if you are managing a dns server which is not localhost though this proxy
 #:dns_server: dns.domain.com
+# use dns_tsig_* for GSS-TSIG updates using Kerberos.  Required for Windows MS DNS with
+# Secure Dynamic Updates, or BIND as used in FreeIPA.
+#:dns_tsig_keytab: /usr/share/foreman-proxy/dns.keytab
+#:dns_tsig_principal: DNS/host.example.com@EXAMPLE.COM
 
 # Enable DHCP management
 :dhcp: false

--- a/lib/dns_api.rb
+++ b/lib/dns_api.rb
@@ -1,8 +1,8 @@
-require "proxy/dns/bind"
+require "proxy/dns/nsupdate"
 
 class SmartProxy
   def setup(opts)
-    @server = Proxy::DNS::Bind.new(opts.merge(:server => SETTINGS.dns_server))
+    @server = Proxy::DNS::Nsupdate.new(opts.merge(:server => SETTINGS.dns_server))
   end
 
   post "/dns/" do


### PR DESCRIPTION
Based on patch by theforemanuser123 oliver_weinmann@gmx.de.

---

Posting for review as an alternative to GH-28.  I found the kinit/klist method rather fragile when testing against FreeIPA (which also uses GSS-TSIG), so this is an alternative using the krb5_auth library.  It uses the djberg96-krb5-auth fork (the more actively maintained one) to request Kerberos credentials using the keytab and load them into the credential cache.

I've got a spec for EL6 for the rubygem here: https://github.com/domcleal/foreman-rpms/commit/76f424a8 (@skottler), though we'll use a proper release instead of patching 0.9.0 or using :git in the Gemfile.
