### PR TITLE
fixes #1685 - GSS-TSIG support for DNS updates

### DIFF
--- a/bundler.d/krb5.rb
+++ b/bundler.d/krb5.rb
@@ -1,0 +1,3 @@
+group :krb5 do
+  gem 'rkerberos', '>= 0.1.1'
+end

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -26,12 +26,19 @@
 # Defines the TFTP Servername to use, overrides the name in the subnet declaration
 #:tftp_servername: tftp.domain.com
 
-
 # Enable DNS management
 :dns: false
+# valid providers:
+#   nsupdate
+#   nsupdate_gss (for GSS-TSIG support)
+:dns_provider: nsupdate
 #:dns_key: /etc/rndc.key
 # use this setting if you are managing a dns server which is not localhost though this proxy
 #:dns_server: dns.domain.com
+# use dns_tsig_* for GSS-TSIG updates using Kerberos.  Required for Windows MS DNS with
+# Secure Dynamic Updates, or BIND as used in FreeIPA.  Set dns_provider to nsupdate_gss.
+#:dns_tsig_keytab: /usr/share/foreman-proxy/dns.keytab
+#:dns_tsig_principal: DNS/host.example.com@EXAMPLE.COM
 
 # Enable DHCP management
 :dhcp: false

--- a/lib/proxy/dns/nsupdate_gss.rb
+++ b/lib/proxy/dns/nsupdate_gss.rb
@@ -1,0 +1,42 @@
+require 'rkerberos'
+
+module Proxy::DNS
+  class NsupdateGSS < Nsupdate
+    attr_reader :tsig_keytab, :tsig_principal
+
+    def initialize options = {}
+      @tsig_keytab = options[:tsig_keytab]
+      @tsig_principal = options[:tsig_principal]
+      raise "Keytab not configured via dns_tsig_keytab for DNS GSS-TSIG support" unless tsig_keytab
+      raise "Unable to read dns_tsig_keytab file at #{tsig_keytab}" unless File.exist?(tsig_keytab)
+      raise "Kerberos principal required - check dns_tsig_principal setting" unless tsig_principal
+      super(options)
+    end
+
+    protected
+
+    def nsupdate_args
+      "#{super} -g "
+    end
+
+    def nsupdate cmd
+      init_krb5_ccache if cmd == "connect"
+      super
+    end
+
+    private
+
+    def init_krb5_ccache
+      krb5 = Kerberos::Krb5.new
+      ccache = Kerberos::Krb5::CredentialsCache.new
+      logger.info "Requesting credentials for Kerberos principal #{tsig_principal} using keytab #{tsig_keytab}"
+      begin
+        krb5.get_init_creds_keytab tsig_principal, tsig_keytab, nil, ccache
+      rescue => e
+        logger.error "Failed to initialise credential cache from keytab: #{e}"
+        raise Proxy::DNS::Error.new("Unable to initialise Kerberos: #{e}")
+      end
+      logger.debug "Kerberos credential cache initialised with principal: #{ccache.primary_principal}"
+    end
+  end
+end


### PR DESCRIPTION
Replaces GH-75 and GH-28.

Changes since GH-75:
- replaced djberg96-krb5-auth with [rkerberos](https://github.com/djberg96/rkerberos) - a relaunch of the same lib, though I'm waiting on a new release with a patch
- moved GSS-TSIG support into a separate class, added dns_provider setting
