### PR TITLE
DHCP global search by record + pxegrub option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ bundler.d/Gemfile.local.rb
 .rvmrc*
 .ruby-version
 .bundle
+tmp

--- a/lib/dhcp_api.rb
+++ b/lib/dhcp_api.rb
@@ -50,6 +50,17 @@ class SmartProxy < Sinatra::Base
     end
   end
 
+  get "/dhcp/find/:record" do
+    begin
+      content_type :json
+      records = @server.find_record(params[:record])
+      log_halt 404, "Record #{params[:record]} not found" unless records
+      records.to_json
+    rescue => e
+      log_halt 400, e
+    end
+  end
+
   get "/dhcp/:network" do
     begin
       load_subnet

--- a/lib/proxy/dhcp/server.rb
+++ b/lib/proxy/dhcp/server.rb
@@ -76,7 +76,7 @@ module Proxy::DHCP
     def find_record record
       subnets.each do |s|
         s.records.each do |v|
-          return v if record.is_a?(String) and (v.ip == record or v.mac == record)
+          return v.options if record.is_a?(String) and (v.ip == record or v.mac == record or v.options[:hostname] == record)
           return v if record.is_a?(Proxy::DHCP::Record) and v == record
           return v if record.is_a?(IPAddr) and v.ip == record.to_s
         end

--- a/lib/proxy/dhcp/server/isc.rb
+++ b/lib/proxy/dhcp/server/isc.rb
@@ -37,6 +37,7 @@ module Proxy::DHCP
       statements << "filename = \\\"#{options[:filename]}\\\";"  if options[:filename]
       statements << bootServer(options[:nextServer])             if options[:nextServer]
       statements << "option host-name = \\\"#{record.name}\\\";" if record.name
+      statements << "option grubmenu = \\\"#{options[:grubmenu]}\\\";" if options[:grubmenu]
 
       omcmd "set statements = \"#{statements.join(" ")}\""      unless statements.empty?
       omcmd "create"
@@ -112,6 +113,8 @@ module Proxy::DHCP
         options[:nextServer] = $1
       when /^filename\s+(\S+)/
         options[:filename] = $1
+      when /^grubmenu\s+(\S+)/
+        options[:grubmenu] = $1
         # Lease options
       when /^binding\s+state\s+(\S+)/
         options[:state] = $1


### PR DESCRIPTION
DHCP global search by record (MAC, IP or hostname). Example:
- <proxy-host>:8443/dhcp/find/<MAC|IP|hostname>

DHCP option "pxegrub" added to allow to specify a path to pxegrub file
to override default menu.lst-<MAC>. Requires dhcpd.conf to have the
following 2 lines in it:

option grubmenu code 150 = text;
option dhcp-parameter-request-list = concat(option
dhcp-parameter-request-list,bootmenu);

Example:
curl -X POST http://dhcp:8443/dhcp/<network> -d 'hostname=blah' -d
'ip=<ip>' -d 'mac=<mac>' -d
'grubmenu=pxelinux.cfg/01-<mac-with-dashes>' -d 'filename=pxegrub.0'
