### PR TITLE
fixes #2547 - fix ruby-abi on non-SCL EL6

### DIFF
--- a/foreman-proxy.spec
+++ b/foreman-proxy.spec
@@ -22,16 +22,15 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
 
 BuildArch:      noarch
 
-%if 0%{?fedora} && 0%{?fedora} < 17
-Requires: %{?scl_prefix}ruby(abi) = 1.8
+%if "%{?scl}" == "ruby193" || 0%{?rhel} > 6 || (0%{?fedora} > 16 && 0%{?fedora} < 19)
+Requires: %{?scl_prefix}ruby(abi) = 1.9.1
 %else
 %if 0%{?fedora} && 0%{?fedora} > 18
 Requires: %{?scl_prefix}ruby(release)
 %else
-Requires: %{?scl_prefix}ruby(abi) = 1.9.1
+Requires: %{?scl_prefix}ruby(abi) = 1.8
 %endif
 %endif
-
 
 Requires:       %{?scl_prefix}rubygems
 Requires:       %{?scl_prefix}rubygem(rake) >= 0.8.3


### PR DESCRIPTION
@mbacovsky could you review please?

Scratch build here: https://koji.katello.org/koji/taskinfo?taskID=36520

Tested with the latest non-SCL rkerberos build and it installs on EL6 using sinatra from EPEL.
