### PR TITLE
Remove the SCL prefix from the name

### DIFF
--- a/foreman-proxy.spec
+++ b/foreman-proxy.spec
@@ -9,7 +9,7 @@
     %global scl_ruby /usr/bin/ruby
 %endif
 
-Name:           %{?scl_prefix}foreman-proxy
+Name:           foreman-proxy
 Version:        1.2.9999
 Release:        1%{dist}
 Summary:        Restful Proxy for DNS, DHCP, TFTP, PuppetCA and Puppet


### PR DESCRIPTION
The package name shouldn't be SCL prefixed because that breaks a number of things, like tito's interfact with dist-git.
