### PR TITLE
1809 add ipa support

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -79,6 +79,12 @@
 :bmc: false
 #:bmc_default_provider: freeipmi
 
+# Enable Realm (Kerberos) Management
+#:realm: true
+#:realm_vendor: ipa
+#:realm_tsig_keytab: /usr/share/foreman-proxy/config/krb5.keytab
+#:realm_tsig_principal: foreman-proxy@EXAMPLE.COM
+
 # Where our proxy log files are stored
 # filename or STDOUT
 :log_file: /var/log/foreman-proxy/proxy.log

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -80,6 +80,10 @@
 #:bmc_default_provider: freeipmi
 
 # Enable Realm (Kerberos) Management
+# N.B. - the foreman-proxy user will need to have write permissions to
+#        ~foreman-proxy/.ipa
+# N.B. - the foreman-proxy user will need to have "Host Administration" &
+#        "Host Enrollment" privileges in IPA as well as a keytab that says so!
 #:realm: true
 #:realm_vendor: ipa
 #:realm_tsig_keytab: /usr/share/foreman-proxy/config/krb5.keytab

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -1,5 +1,5 @@
 module Proxy
-  MODULES = %w{dns dhcp tftp puppetca puppet bmc}
+  MODULES = %w{dns dhcp tftp puppetca puppet bmc realm}
   VERSION = "1.2-develop"
 
   require "checks"
@@ -15,6 +15,7 @@ module Proxy
   require "proxy/dns"      if SETTINGS.dns
   require "proxy/dhcp"     if SETTINGS.dhcp
   require "proxy/bmc"      if SETTINGS.bmc
+  require "proxy/realm"    if SETTINGS.realm
 
   def self.features
     MODULES.collect{|mod| mod if SETTINGS.send mod}.compact

--- a/lib/proxy/dns/nsupdate_gss.rb
+++ b/lib/proxy/dns/nsupdate_gss.rb
@@ -1,8 +1,11 @@
 require 'proxy/dns/nsupdate'
-require 'rkerberos'
+require 'proxy/kerberos'
 
 module Proxy::DNS
   class NsupdateGSS < Nsupdate
+
+    include Proxy::Kerberos
+
     attr_reader :tsig_keytab, :tsig_principal
 
     def initialize options = {}
@@ -25,19 +28,19 @@ module Proxy::DNS
       super
     end
 
-    private
-
-    def init_krb5_ccache
-      krb5 = Kerberos::Krb5.new
-      ccache = Kerberos::Krb5::CredentialsCache.new
-      logger.info "Requesting credentials for Kerberos principal #{tsig_principal} using keytab #{tsig_keytab}"
-      begin
-        krb5.get_init_creds_keytab tsig_principal, tsig_keytab, nil, ccache
-      rescue => e
-        logger.error "Failed to initialise credential cache from keytab: #{e}"
-        raise Proxy::DNS::Error.new("Unable to initialise Kerberos: #{e}")
-      end
-      logger.debug "Kerberos credential cache initialised with principal: #{ccache.primary_principal}"
-    end
+#    private
+#
+#    def init_krb5_ccache
+#      krb5 = Kerberos::Krb5.new
+#      ccache = Kerberos::Krb5::CredentialsCache.new
+#      logger.info "Requesting credentials for Kerberos principal #{tsig_principal} using keytab #{tsig_keytab}"
+#      begin
+#        krb5.get_init_creds_keytab tsig_principal, tsig_keytab, nil, ccache
+#      rescue => e
+#        logger.error "Failed to initialise credential cache from keytab: #{e}"
+#        raise Proxy::DNS::Error.new("Unable to initialise Kerberos: #{e}")
+#      end
+#      logger.debug "Kerberos credential cache initialised with principal: #{ccache.primary_principal}"
+#    end
   end
 end

--- a/lib/proxy/kerberos.rb
+++ b/lib/proxy/kerberos.rb
@@ -1,0 +1,26 @@
+#require 'rubygems'
+require 'rkerberos'
+require 'krb5_auth'
+
+module Proxy::Kerberos
+
+  def init_krb5_ccache
+    begin
+      krb5 = Kerberos::Krb5.new
+      ccache = Kerberos::Krb5::CredentialsCache.new
+    rescue => e
+      logger.error "Failed to create kerberos objects: #{e}"
+      raise Proxy::Error.new("Failed to create kerberos objects: #{e}")
+    end
+
+    logger.info "Requesting credentials for Kerberos principal #{@tsig_principal} using keytab #{@tsig_keytab}"
+    begin
+      krb5.get_init_creds_keytab @tsig_principal, @tsig_keytab, nil, ccache
+    rescue => e
+      logger.error "Failed to initialise credential cache from keytab: #{e}"
+      raise Proxy::DNS::Error.new("Unable to initialise Kerberos: #{e}")
+    end
+    logger.debug "Kerberos credential cache initialised with principal: #{ccache.primary_principal}"
+  end
+
+end

--- a/lib/proxy/realm.rb
+++ b/lib/proxy/realm.rb
@@ -1,5 +1,4 @@
-require 'rkerberos'
-require 'krb5_auth'
+require 'proxy/kerberos'
 
 module Proxy::Realm
   class Error < RuntimeError; end

--- a/lib/proxy/realm.rb
+++ b/lib/proxy/realm.rb
@@ -1,0 +1,20 @@
+require 'rkerberos'
+require 'krb5_auth'
+
+module Proxy::Realm
+  class Error < RuntimeError; end
+  class KerberosError < RuntimeError; end
+
+  class Client
+    include Proxy::Log
+
+    def initialize options = {}
+      @fqdn   = options[:fqdn]
+
+      raise("Must define FQDN") if @fqdn.nil?
+    end
+
+  end
+end
+
+# vim: ai ts=2 sts=2 et sw=2 ft=ruby

--- a/lib/proxy/realm/ipa.rb
+++ b/lib/proxy/realm/ipa.rb
@@ -1,0 +1,105 @@
+module Proxy::Realm
+    class IPA < Client
+
+      include Proxy::Util
+      attr_accessor :tsig_keytab, :tsig_principal, :fqdn
+      attr_reader :pwd, :output
+  
+      def initialize( options = {})
+        @fqdn = options[:fqdn]
+        @tsig_keytab = options[:tsig_keytab]
+        @tsig_principal = options[:tsig_principal]
+        raise "Keytab not configured via ipa_tsig_keytab for IPA GSS-TSIG support" unless tsig_keytab
+        raise "Unable to read ipa_tsig_keytab file at #{tsig_keytab}" unless File.exist?(tsig_keytab)
+        raise "Kerberos principal required - check ipa_tsig_principal setting" unless tsig_principal
+        logger.debug "ipa: created client obj for #{@fqdn}"
+      end
+
+      def host_find
+        logger.debug "ipa: trying to find #{@fqdn}"
+        ipa "host-find"
+      end
+
+      def host_add
+        pwd = mk_pwd
+        ipa "host-add", "--password=#{pwd}"
+        pwd
+      end
+
+      def host_del
+        ipa "host-del"
+      end
+  
+      protected
+  
+      def ipa_args
+        args = " "
+        args = "--password=secret "
+        args
+      end
+  
+      def ipa(cmd, args=nil)
+        init_krb5_ccache
+        @output = nil
+        find_ipa if @ipa.nil?
+        ipa_cmd = "#{@ipa} #{cmd} #{@fqdn} #{args}"
+        logger.debug "running #{ipa_cmd}"
+        @output = `#{ipa_cmd} 2>&1`
+        if @output.empty? or @output =~ /Error/i
+          logger.debug "ipa: errors\n" + @output.to_s
+          if @output =~ /Insufficient access/i
+            raise Proxy::Realm::KerberosError.new(@output.to_s)
+          else
+            raise Proxy::Realm::Error.new(@output.to_s)
+          end
+        end
+  
+        logger.debug "ipa: output\n" + @output.to_s
+        #output.to_json
+
+      end
+  
+      private
+  
+      def init_krb5_ccache
+          logger.info "Requesting IPA credentials for Kerberos principal #{tsig_principal} using keytab #{tsig_keytab}"
+        begin
+          ccache = Kerberos::Krb5::CredentialsCache.new
+        rescue => e
+          logger.error "IPA Failed to create new Kerberos::Krb5::CredentialsCache:  #{e}"
+          raise Proxy::Realm::KerberosError.new("Unable to initialise Kerberos: #{e}")
+        end  
+        begin
+          krb5 = Kerberos::Krb5.new
+        rescue => e
+          logger.error "IPA Failed to create new Kerberos::Krb5: #{e}"
+          raise Proxy::Realm::KerberosError.new("Unable to initialise Kerberos: #{e}")
+        end  
+        begin
+          krb5.get_init_creds_keytab tsig_principal, tsig_keytab, nil, ccache
+        rescue => e
+          logger.error "IPA Failed to initialise credential cache from keytab: #{e}"
+          raise Proxy::Realm::KerberosError.new("Unable to initialise Kerberos: #{e}")
+        end
+        logger.debug "Kerberos credential cache initialised with principal: #{ccache.primary_principal}"
+      end
+
+  
+      def find_ipa
+        @ipa = which("ipa", "/usr/bin")
+        unless File.exists?("#{@ipa}")
+          logger.warn "unable to find ipa binary, maybe missing ipa-admintools package?"
+          raise "unable to find ipa binary"
+        end
+      end
+
+      # I would love to have "ipa host-add" generate the password, but can't
+      # think of a way to do that without actually adding the host
+      def mk_pwd
+        (0...8).map{(65+rand(26)).chr}.join
+      end
+  
+  end
+end
+
+# vim: ai ts=2 sts=2 et sw=2 ft=ruby

--- a/lib/proxy/realm/ipa.rb
+++ b/lib/proxy/realm/ipa.rb
@@ -11,10 +11,10 @@ module Proxy::Realm
       @fqdn = options[:fqdn]
       @tsig_keytab = options[:tsig_keytab]
       @tsig_principal = options[:tsig_principal]
-      raise "Keytab not configured via ipa_tsig_keytab for IPA GSS-TSIG support" unless tsig_keytab
-      raise "Unable to read ipa_tsig_keytab file at #{tsig_keytab}" unless File.exist?(tsig_keytab)
-      raise "Kerberos principal required - check ipa_tsig_principal setting" unless tsig_principal
-      init_krb5_ccache @tsig_keytab, @tsig_principal
+      raise "Keytab not configured via ipa_tsig_keytab for IPA GSS-TSIG support" unless @tsig_keytab
+      raise "Unable to read ipa_tsig_keytab file at #{@tsig_keytab}" unless File.exist?(@tsig_keytab)
+      raise "Kerberos principal required - check ipa_tsig_principal setting" unless @tsig_principal
+      init_krb5_ccache
       logger.debug "ipa: created client obj for #{@fqdn}"
     end
 

--- a/lib/proxy/realm/ipa.rb
+++ b/lib/proxy/realm/ipa.rb
@@ -1,103 +1,105 @@
 module Proxy::Realm
-    class IPA < Client
+  class IPA < Client
 
-      include Proxy::Util
-      attr_accessor :tsig_keytab, :tsig_principal, :fqdn
-      attr_reader :pwd, :output
-  
-      def initialize( options = {})
-        @fqdn = options[:fqdn]
-        @tsig_keytab = options[:tsig_keytab]
-        @tsig_principal = options[:tsig_principal]
-        raise "Keytab not configured via ipa_tsig_keytab for IPA GSS-TSIG support" unless tsig_keytab
-        raise "Unable to read ipa_tsig_keytab file at #{tsig_keytab}" unless File.exist?(tsig_keytab)
-        raise "Kerberos principal required - check ipa_tsig_principal setting" unless tsig_principal
-        logger.debug "ipa: created client obj for #{@fqdn}"
-      end
+    include Proxy::Kerberos
+    include Proxy::Util
 
-      def host_find
-        logger.debug "ipa: trying to find #{@fqdn}"
-        ipa "host-find"
-      end
+    attr_accessor :tsig_keytab, :tsig_principal, :fqdn
+    attr_reader :pwd, :output
 
-      def host_add
-        pwd = mk_pwd
-        ipa "host-add", "--password=#{pwd}"
-        pwd
-      end
+    def initialize( options = {})
+      @fqdn = options[:fqdn]
+      @tsig_keytab = options[:tsig_keytab]
+      @tsig_principal = options[:tsig_principal]
+      raise "Keytab not configured via ipa_tsig_keytab for IPA GSS-TSIG support" unless tsig_keytab
+      raise "Unable to read ipa_tsig_keytab file at #{tsig_keytab}" unless File.exist?(tsig_keytab)
+      raise "Kerberos principal required - check ipa_tsig_principal setting" unless tsig_principal
+      init_krb5_ccache @tsig_keytab, @tsig_principal
+      logger.debug "ipa: created client obj for #{@fqdn}"
+    end
 
-      def host_del
-        ipa "host-del"
-      end
-  
-      protected
-  
-      def ipa_args
-        args = " "
-        args = "--password=secret "
-        args
-      end
-  
-      def ipa(cmd, args=nil)
-        init_krb5_ccache
-        @output = nil
-        find_ipa if @ipa.nil?
-        ipa_cmd = "#{@ipa} #{cmd} #{@fqdn} #{args}"
-        logger.debug "running #{ipa_cmd}"
-        @output = `#{ipa_cmd} 2>&1`
-        if @output.empty? or @output =~ /Error/i
-          logger.debug "ipa: errors\n" + @output.to_s
-          if @output =~ /Insufficient access/i
-            raise Proxy::Realm::KerberosError.new(@output.to_s)
-          else
-            raise Proxy::Realm::Error.new(@output.to_s)
-          end
-        end
-  
-        logger.debug "ipa: output\n" + @output.to_s
-        #output.to_json
+    def host_find
+      logger.debug "ipa: trying to find #{@fqdn}"
+      ipa "host-find"
+    end
 
-      end
-  
-      private
-  
-      def init_krb5_ccache
-          logger.info "Requesting IPA credentials for Kerberos principal #{tsig_principal} using keytab #{tsig_keytab}"
-        begin
-          ccache = Kerberos::Krb5::CredentialsCache.new
-        rescue => e
-          logger.error "IPA Failed to create new Kerberos::Krb5::CredentialsCache:  #{e}"
-          raise Proxy::Realm::KerberosError.new("Unable to initialise Kerberos: #{e}")
-        end  
-        begin
-          krb5 = Kerberos::Krb5.new
-        rescue => e
-          logger.error "IPA Failed to create new Kerberos::Krb5: #{e}"
-          raise Proxy::Realm::KerberosError.new("Unable to initialise Kerberos: #{e}")
-        end  
-        begin
-          krb5.get_init_creds_keytab tsig_principal, tsig_keytab, nil, ccache
-        rescue => e
-          logger.error "IPA Failed to initialise credential cache from keytab: #{e}"
-          raise Proxy::Realm::KerberosError.new("Unable to initialise Kerberos: #{e}")
-        end
-        logger.debug "Kerberos credential cache initialised with principal: #{ccache.primary_principal}"
-      end
+    def host_add
+      pwd = mk_pwd
+      ipa "host-add", "--password=#{pwd}"
+      pwd
+    end
 
-  
-      def find_ipa
-        @ipa = which("ipa", "/usr/bin")
-        unless File.exists?("#{@ipa}")
-          logger.warn "unable to find ipa binary, maybe missing ipa-admintools package?"
-          raise "unable to find ipa binary"
+    def host_del
+      ipa "host-del"
+    end
+
+    protected
+
+    def ipa_args
+      args = " "
+      args = "--password=secret "
+      args
+    end
+
+    def ipa(cmd, args=nil)
+      @output = nil
+      find_ipa if @ipa.nil?
+      ipa_cmd = "#{@ipa} #{cmd} #{@fqdn} #{args}"
+      logger.debug "running #{ipa_cmd}"
+      @output = `#{ipa_cmd} 2>&1`
+      if @output.empty? or @output =~ /Error/i
+        logger.debug "ipa: errors\n" + @output.to_s
+        if @output =~ /Insufficient access/i
+          raise Proxy::Realm::KerberosError.new(@output.to_s)
+        else
+          raise Proxy::Realm::Error.new(@output.to_s)
         end
       end
 
-      # I would love to have "ipa host-add" generate the password, but can't
-      # think of a way to do that without actually adding the host
-      def mk_pwd
-        (0...8).map{(65+rand(26)).chr}.join
+      logger.debug "ipa: output\n" + @output.to_s
+      #output.to_json
+
+    end
+
+    private
+
+#    def init_krb5_ccache
+#        logger.info "Requesting IPA credentials for Kerberos principal #{tsig_principal} using keytab #{tsig_keytab}"
+#      begin
+#        ccache = Kerberos::Krb5::CredentialsCache.new
+#      rescue => e
+#        logger.error "IPA Failed to create new Kerberos::Krb5::CredentialsCache:  #{e}"
+#        raise Proxy::Realm::KerberosError.new("Unable to initialise Kerberos: #{e}")
+#      end  
+#      begin
+#        krb5 = Kerberos::Krb5.new
+#      rescue => e
+#        logger.error "IPA Failed to create new Kerberos::Krb5: #{e}"
+#        raise Proxy::Realm::KerberosError.new("Unable to initialise Kerberos: #{e}")
+#      end  
+#      begin
+#        krb5.get_init_creds_keytab tsig_principal, tsig_keytab, nil, ccache
+#      rescue => e
+#        logger.error "IPA Failed to initialise credential cache from keytab: #{e}"
+#        raise Proxy::Realm::KerberosError.new("Unable to initialise Kerberos: #{e}")
+#      end
+#      logger.debug "Kerberos credential cache initialised with principal: #{ccache.primary_principal}"
+#    end
+
+
+    def find_ipa
+      @ipa = which("ipa", "/usr/bin")
+      unless File.exists?("#{@ipa}")
+        logger.warn "unable to find ipa binary, maybe missing ipa-admintools package?"
+        raise "unable to find ipa binary"
       end
+    end
+
+    # I would love to have "ipa host-add" generate the password, but can't
+    # think of a way to do that without actually adding the host
+    def mk_pwd
+      (0...8).map{(65+rand(26)).chr}.join
+    end
   
   end
 end

--- a/lib/realm_api.rb
+++ b/lib/realm_api.rb
@@ -8,7 +8,6 @@ class SmartProxy < Sinatra::Base
 
     case SETTINGS.realm_vendor.downcase
       when "ipa"
-
         require 'proxy/realm/ipa'
         unless SETTINGS.realm_tsig_keytab and SETTINGS.realm_tsig_principal \
           and File.exist?(SETTINGS.realm_tsig_keytab)

--- a/lib/realm_api.rb
+++ b/lib/realm_api.rb
@@ -6,7 +6,7 @@ class SmartProxy < Sinatra::Base
     raise "Smart Proxy is not configured to support Realm" unless SETTINGS.realm
     #raise "No client host specified" unless fqdn
 
-    case SETTINGS.realm_provider.downcase
+    case SETTINGS.realm_vendor.downcase
       when "ipa"
 
         require 'proxy/realm/ipa'

--- a/lib/realm_api.rb
+++ b/lib/realm_api.rb
@@ -1,0 +1,91 @@
+require 'pry-remote'
+class SmartProxy < Sinatra::Base
+
+  use Rack::MethodOverride
+  def client_setup fqdn
+    raise "Smart Proxy is not configured to support Realm" unless SETTINGS.realm
+    #raise "No client host specified" unless fqdn
+
+    case SETTINGS.realm_provider.downcase
+      when "ipa"
+
+        require 'proxy/realm/ipa'
+        unless SETTINGS.realm_tsig_keytab and SETTINGS.realm_tsig_principal \
+          and File.exist?(SETTINGS.realm_tsig_keytab)
+          log_halt 400, "Unable to find the Realm keytab file (or realm_tsig_principal is not set)"
+        end
+        Proxy::Realm::IPA.new(
+          :fqdn => fqdn,
+          #:fqdn => "utest.collmedia.net",
+          :tsig_keytab => SETTINGS.realm_tsig_keytab,
+          :tsig_principal => SETTINGS.realm_tsig_principal
+        )
+      else
+        log_halt 400, "Unrecognized or missing Realm vendor type: #{SETTINGS.realm_vendor.nil? ? "MISSING" : SETTINGS.realm_vendor}"
+    end
+  rescue => e
+    log_halt 400, e
+  end
+
+  helpers do
+  end
+
+  before do
+    #client_setup params[:fqdn] if request.path_info =~ /realm/
+  end
+
+  get "/realm/:fqdn" do
+    #fqdn = params[:fqdn]
+    #binding.remote_pry
+
+    client = client_setup params[:fqdn]
+    
+#    binding.remote_pry
+
+    begin
+    client.host_find
+      if request.accept? 'application/json'
+        content_type :json
+        {
+          :fqdn => client.fqdn,
+          :output => client.output,
+          #:tsig_keytab => @client.tsig_keytab,
+          #:tsig_principal => @client.tsig_principal
+        }.to_json
+      else
+        erb :"realm/show"
+      end
+    rescue => e
+      log_halt 400, e
+    end
+  end
+
+  # create a new host in a realm
+  post "/realm/" do
+    fqdn = params[:fqdn]
+#    binding.remote_pry
+    begin
+      client = client_setup fqdn
+      client.host_add
+      client.pwd.to_json
+    rescue Proxy::Realm::Error => e
+      log_halt 409, e
+    rescue Exception => e
+      log_halt 400, e
+    end
+  end
+
+  # delete a host from a realm
+  delete "/realm/:value" do
+    fqdn = params[:value]
+    begin
+      client = client_setup({:fqdn => fqdn})
+      client.host_del
+    rescue => e
+      log_halt 400, e
+    end
+  end
+
+end
+
+# vim: ai ts=2 sts=2 et sw=2 ft=ruby

--- a/lib/smart_proxy.rb
+++ b/lib/smart_proxy.rb
@@ -33,6 +33,7 @@ class SmartProxy < Sinatra::Base
   require "dns_api"      if SETTINGS.dns
   require "dhcp_api"     if SETTINGS.dhcp
   require "bmc_api"      if SETTINGS.bmc
+  require "realm_api"    if SETTINGS.realm
   require "features_api"
 
   begin


### PR DESCRIPTION
I've added support for IPA, which I think also leads the way for MS-AD support as Dominic outlined in http://projects.theforeman.org/projects/foreman/wiki/RealmJoinIntegration

I refactored a bit of code, taking the kerberos call out of proxy/dns/nsupdate_gss and putting  it into a kerberos Module to be mixed in to proxies that require it.  I hope I didn't screw it up!

Foreman server-side support of this proxy is pending . . .
