### PR TITLE
Change handling of dynamic and static modulepaths

### DIFF
--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -95,7 +95,7 @@ module Proxy::Puppet
           end
 
           # group array of hashes, join values (modulepaths) and create dynamic environment => modulepath
-          dynamic_environment = temp_environment.group_by(&:keys).map{|k, v| {k.first => v.flat_map(&:values).join(':')}}
+          dynamic_environment = temp_environment.group_by(&:keys).map{|k, v| {k.first => v.flatten.map(&:values).join(':')}}
 
           dynamic_environment.each do |h|
             h.each do |k,v|

--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -62,21 +62,44 @@ module Proxy::Puppet
             end
           end
 
+          # parting modulepath into static and dynamic paths
+          staticpath = modulepath.split(":")
+          dynamicpath = modulepath.split(":")
+
           modulepath.split(":").each do |base_dir|
             if base_dir.include?("$environment")
-              # remove this entry from the current env so that static paths are unaltered
-              temp_path = modulepath.split(':')
-              temp_path.delete base_dir
-              if temp_path.empty?
-                new_env.delete environment
-              else
-                new_env[environment] = temp_path.join(':')
-              end
-              # Dynamic environments - get every directory under the modulepath
-              Dir.glob("#{base_dir.gsub(/\$environment(.*)/,"/")}/*").grep(/\/[A-Za-z0-9_]+$/) do |dir|
-                e = dir.split("/").last
-                new_env[e.to_sym] = base_dir.gsub("$environment", e)
-              end
+              # remove this entry from the static paths
+              staticpath.delete base_dir
+            else
+              # remove this entry from the dynamic paths
+              dynamicpath.delete base_dir
+            end
+          end
+
+          # remove or add static environment
+          if staticpath.empty?
+            new_env.delete environment
+          else
+            new_env[environment] = staticpath.join(':')
+          end
+
+          # create dynamic environments and modulepaths (array of hash)
+          temp_environment = []
+
+          dynamicpath.each do |base_dir|
+            # Dynamic environments - get every directory under the modulepath
+            Dir.glob("#{base_dir.gsub(/\$environment(.*)/,"/")}/*").grep(/\/[A-Za-z0-9_]+$/) do |dir|
+              e = dir.split("/").last
+              temp_environment.push({e => base_dir.gsub("$environment", e)})
+            end
+          end
+
+          # group array of hashes, join values (modulepaths) and create dynamic environment => modulepath
+          dynamic_environment = temp_environment.group_by(&:keys).map{|k, v| {k.first => v.flat_map(&:values).join(':')}}
+
+          dynamic_environment.each do |h|
+            h.each do |k,v|
+              new_env[k.to_sym] = v
             end
           end
         end

--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -84,22 +84,24 @@ module Proxy::Puppet
           end
 
           # create dynamic environments and modulepaths (array of hash)
-          temp_environment = []
+          unless dynamicpath.empty?
+            temp_environment = []
 
-          dynamicpath.each do |base_dir|
-            # Dynamic environments - get every directory under the modulepath
-            Dir.glob("#{base_dir.gsub(/\$environment(.*)/,"/")}/*").grep(/\/[A-Za-z0-9_]+$/) do |dir|
-              e = dir.split("/").last
-              temp_environment.push({e => base_dir.gsub("$environment", e)})
+            dynamicpath.each do |base_dir|
+              # Dynamic environments - get every directory under the modulepath
+              Dir.glob("#{base_dir.gsub(/\$environment(.*)/,"/")}/*").grep(/\/[A-Za-z0-9_]+$/) do |dir|
+                e = dir.split("/").last
+                temp_environment.push({e => base_dir.gsub("$environment", e)})
+              end
             end
-          end
 
-          # group array of hashes, join values (modulepaths) and create dynamic environment => modulepath
-          dynamic_environment = temp_environment.group_by(&:keys).map{|k, v| {k.first => v.flatten.map(&:values).join(':')}}
+            # group array of hashes, join values (modulepaths) and create dynamic environment => modulepath
+            dynamic_environment = temp_environment.group_by(&:keys).map{|k, v| {k.first => v.flatten.map(&:values).join(':')}}
 
-          dynamic_environment.each do |h|
-            h.each do |k,v|
-              new_env[k.to_sym] = v
+            dynamic_environment.each do |h|
+              h.each do |k,v|
+                new_env[k.to_sym] = v
+              end
             end
           end
         end

--- a/test/fixtures/multi_module/dev/modules1/test3/manifests/init.pp
+++ b/test/fixtures/multi_module/dev/modules1/test3/manifests/init.pp
@@ -1,0 +1,3 @@
+class test3 {
+  notify { "A third class fixture": }
+}

--- a/test/fixtures/multi_module/dev/modules2/test4/manifests/init.pp
+++ b/test/fixtures/multi_module/dev/modules2/test4/manifests/init.pp
@@ -1,0 +1,3 @@
+class test4 {
+  notify { "A fourth class fixture": }
+}

--- a/test/fixtures/multi_module/prod/modules1/test1/manifests/init.pp
+++ b/test/fixtures/multi_module/prod/modules1/test1/manifests/init.pp
@@ -1,0 +1,3 @@
+class test1 {
+  notify { "A first class fixture": }
+}

--- a/test/fixtures/multi_module/prod/modules2/test2/manifests/init.pp
+++ b/test/fixtures/multi_module/prod/modules2/test2/manifests/init.pp
@@ -1,0 +1,3 @@
+class test2 {
+  notify { "A second class fixture": }
+}

--- a/test/puppet_environment_test.rb
+++ b/test/puppet_environment_test.rb
@@ -83,6 +83,30 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
     assert_array_equal env_class_map, [["prod", "test"], ["dev", "test2"]]
   end
 
+  def test_multiple_modulepath_in_single_env_with_multiple_dynamic_path
+    config = {
+        :main => {},
+        :master => { :modulepath=>'./test/fixtures/multi_module/$environment/modules1:./test/fixtures/multi_module/$environment/modules2' }
+    }
+    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    env = Proxy::Puppet::Environment.all
+    assert_array_equal env.map { |e| e.name }, ['dev','prod']
+    env_class_map = env.map { |e| [e.name, e.classes.map { |c| c.name }].flatten }
+    assert_array_equal env_class_map, [["prod", "test1"], ["prod", "test2"], ["dev", "test3"], ["dev", "test4"]]
+  end
+
+  def test_multiple_modulepath_in_single_env_with_multiple_dynamic_path_and_static_path
+    config = {
+        :main => {},
+        :master => { :modulepath=>'./test/fixtures/environments/prod:./test/fixtures/multi_module/$environment/modules1:./test/fixtures/multi_module/$environment/modules2' }
+    }
+    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    env = Proxy::Puppet::Environment.all
+    assert_array_equal env.map { |e| e.name }, ['dev','prod']
+    env_class_map = env.map { |e| [e.name, e.classes.map { |c| c.name }].flatten }
+    assert_array_equal env_class_map, [["prod", "test"], ["prod", "test1"], ["prod", "test2"], ["dev", "test3"], ["dev", "test4"]]
+  end
+
   def test_multiple_modulepath_in_single_env_with_dynamic_path
     config = {
         :main => {},

--- a/test/puppet_environment_test.rb
+++ b/test/puppet_environment_test.rb
@@ -92,7 +92,7 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
     env = Proxy::Puppet::Environment.all
     assert_array_equal env.map { |e| e.name }, ['dev','prod']
     env_class_map = env.map { |e| [e.name, e.classes.map { |c| c.name }].flatten }
-    assert_array_equal env_class_map, [["prod", "test1"], ["prod", "test2"], ["dev", "test3"], ["dev", "test4"]]
+    assert_array_equal env_class_map, [["prod", "test1", "test2"], ["dev", "test3", "test4"]]
   end
 
   def test_multiple_modulepath_in_single_env_with_multiple_dynamic_path_and_static_path
@@ -102,9 +102,9 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
     }
     Puppet.settings.stubs(:instance_variable_get).returns(config)
     env = Proxy::Puppet::Environment.all
-    assert_array_equal env.map { |e| e.name }, ['dev','prod']
+    assert_array_equal env.map { |e| e.name }, ['master','dev','prod']
     env_class_map = env.map { |e| [e.name, e.classes.map { |c| c.name }].flatten }
-    assert_array_equal env_class_map, [["prod", "test"], ["prod", "test1"], ["prod", "test2"], ["dev", "test3"], ["dev", "test4"]]
+    assert_array_equal env_class_map, [["master", "test"], ["prod", "test1", "test2"], ["dev", "test3", "test4"]]
   end
 
   def test_multiple_modulepath_in_single_env_with_dynamic_path


### PR DESCRIPTION
Previously the foreman-proxy could only handle one dynamic modulepath. This restriction was changed.

Example puppet.conf:

```
modulepath = /etc/puppet/environments/$environment/path_1:/etc/puppet/environments/$environment/path_2
```

The previously foreman-proxy will only handle /etc/puppet/environments/$environment/path_1. All modules in /etc/puppet/environments/$environment/path_1 are not observed.

The refactored code will now seperate static and dynamic modulepaths, creates all dynamic environments with all there modulepaths (modulepath_1:modulepath_n).
