### PR TITLE
Refs #969 - Proxy-side changes for serving templates from the proxy

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -25,6 +25,17 @@
 :tftproot: /var/lib/tftpboot
 # Defines the TFTP Servername to use, overrides the name in the subnet declaration
 #:tftp_servername: tftp.domain.com
+#
+# Set this to true if the Proxy should handle template requests on behalf of Foreman
+:templates: false
+# Where is Foreman?
+# no need to specify http(s) here as templates are always retrieved on http
+# Examples:
+# https://myforemanserver.mydomain.com
+# http://1.2.3.4:3000
+#:foreman_url: http://127.0.0.1:3000
+# Where should provisioning hosts request their template from?
+#:template_url: http://192.168.122.1:8443
 
 # Enable DNS management
 :dns: false

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -1,5 +1,5 @@
 module Proxy
-  MODULES = %w{dns dhcp tftp puppetca puppet bmc}
+  MODULES = %w{dns dhcp tftp puppetca puppet bmc templates}
   VERSION = "1.2-develop"
 
   require "checks"
@@ -13,6 +13,7 @@ module Proxy
   require "proxy/log"
   require "proxy/util"
   require "proxy/tftp"     if SETTINGS.tftp
+  require "proxy/template" if SETTINGS.templates
   require "proxy/puppetca" if SETTINGS.puppetca
   require "proxy/puppet"   if SETTINGS.puppet
   require "proxy/dns"      if SETTINGS.dns

--- a/lib/proxy/template.rb
+++ b/lib/proxy/template.rb
@@ -1,0 +1,27 @@
+require "proxy/util"
+require 'uri'
+
+module Proxy::Template
+
+  class Handler
+    extend Proxy::Log
+
+    # Gets a template from Foreman
+    def self.get_template kind, token
+      # Parse the Foreman URI for a connection
+      uri              = URI.parse("#{SETTINGS.foreman_url}/unattended/#{kind}?token=#{token}")
+      req              = Net::HTTP::Get.new(uri.request_uri)
+      http             = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl     = uri.scheme == 'https'
+      # TODO: handle CA properly; for now we'll accept self-signed certs
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE if http.use_ssl?
+      res              = http.start { |http| http.request(req) }
+
+      # You get a 201 from the 'built' URL
+      raise "Error retrieving #{kind} for #{token} from #{uri.host}: #{res.class}" unless ["200", "201"].include?(res.code)
+      logger.info "Template: request for #{kind} using #{token} at #{uri.host}"
+      res.body
+    end
+  end
+
+end

--- a/lib/smart_proxy.rb
+++ b/lib/smart_proxy.rb
@@ -29,6 +29,7 @@ class SmartProxy < Sinatra::Base
 
   require "features_api"
   require "tftp_api"     if SETTINGS.tftp
+  require "template_api" if SETTINGS.templates
   require "puppet_api"   if SETTINGS.puppet
   require "puppetca_api" if SETTINGS.puppetca
   require "dns_api"      if SETTINGS.dns

--- a/lib/template_api.rb
+++ b/lib/template_api.rb
@@ -1,0 +1,19 @@
+require 'proxy/template'
+
+class SmartProxy
+
+  # Get the value for templates
+  get "/unattended/templateServer" do
+     {"templateServer" => (SETTINGS.template_url || "")}.to_json
+  end
+
+  # Render a template from Foreman
+  get "/unattended/:kind" do |kind|
+    log_halt 403, "Proxy not configured to handle templates" unless SETTINGS.templates
+    log_halt 403, "No URI specified for :foreman_url:" unless SETTINGS.foreman_url
+    log_halt(404, "Failed to retrieve #{kind} template for #{params[:token]}: ") {
+      Proxy::Template::Handler.get_template(kind, params[:token])
+    }
+  end
+
+end

--- a/test/template_api_test.rb
+++ b/test/template_api_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+require 'helpers'
+require 'template_api'
+require 'json'
+
+class TemplateApiTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    SmartProxy.new
+  end
+
+  def setup
+    @args = { :token => "test-token" }
+  end
+
+  def test_api_can_return_templateserver
+    SETTINGS.stubs(:template_url).returns("someproxy:8443")
+    get "/unattended/templateServer"
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal("someproxy:8443", data["templateServer"].to_s)
+  end
+
+  def test_api_can_ask_for_a_template
+    Proxy::Template::Handler.stubs(:get_template).returns("An API template")
+    get "/unattended/provision", @args
+    assert last_response.ok?, "Last response was not ok"
+    assert_match("An API template", last_response.body)
+  end
+
+end

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+require 'uri'
+require 'net/http'
+require 'mocha'
+
+
+class TemplateTest < Test::Unit::TestCase
+  def setup
+    @http_mock = mock('Net::HTTPResponse')
+    @http_mock.stubs(:code => '200', :message => "OK", :body => 'A template')
+  end
+
+  def test_template_requests_return_data
+    Net::HTTP.any_instance.expects(:start).returns(@http_mock)
+    assert_equal 'A template', Proxy::Template::Handler.get_template('provision', 'test-token')
+  end
+
+end
+

--- a/test/testing_proxy_settings.rb
+++ b/test/testing_proxy_settings.rb
@@ -2,12 +2,15 @@ require "proxy/settings"
 
 class Settings < OpenStruct
   module TestingSettings
-    DEFAULTS = { :tftp => true,
-                        :puppet => true,
-                        :puppetca => true,
-                        :bmc => true,
-                        :puppet_conf => File.join(File.dirname(__FILE__), 'fixtures', 'puppet.conf'),
-                        :log_file => File.join('logs', 'test.log') }
+    DEFAULTS = { :tftp        => true,
+                 :bmc         => true,
+                 :puppet      => true,
+                 :puppetca    => true,
+                 :puppet_conf => File.join(File.dirname(__FILE__), 'fixtures', 'puppet.conf'),
+                 :log_file    => File.join('logs', 'test.log'),
+                 :templates   => true,
+                 :foreman_url => 'http://127.0.0.1:3000'
+    }
   end
   DEFAULTS.merge!(TestingSettings::DEFAULTS)
 


### PR DESCRIPTION
Compliment to https://github.com/theforeman/foreman/pull/751

Probably also refs #1969 as `:template_url` is the client-facing proxy name, and so could be used for `puppetserver` too. `:foreman_url` could be used for implementing an auto-update-on-feature-change, if we want to.

There's an open issue about serving http on an https proxy, which will probably require a 2-threaded proxy listening on two ports. For now, this functionality is for http proxies only.

@domcleal, do we have somewhere to start putting documentation for 1.3 features?
