### PR TITLE
Fixes #2790 - Optionally set DNS TTL value from settings.yml config file

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -35,6 +35,8 @@
 #:dns_key: /etc/rndc.key
 # use this setting if you are managing a dns server which is not localhost though this proxy
 #:dns_server: dns.domain.com
+# use this setting if you want to override default TTL setting (86400)
+#:dns_ttl: 60
 # use dns_tsig_* for GSS-TSIG updates using Kerberos.  Required for Windows MS DNS with
 # Secure Dynamic Updates, or BIND as used in FreeIPA.  Set dns_provider to nsupdate_gss.
 #:dns_tsig_keytab: /usr/share/foreman-proxy/dns.keytab

--- a/lib/dns_api.rb
+++ b/lib/dns_api.rb
@@ -4,11 +4,15 @@ class SmartProxy
     case SETTINGS.dns_provider
     when "nsupdate"
       require 'proxy/dns/nsupdate'
-      @server = Proxy::DNS::Nsupdate.new(opts.merge(:server => SETTINGS.dns_server))
+      @server = Proxy::DNS::Nsupdate.new(opts.merge(
+        :server => SETTINGS.dns_server,
+        :ttl => SETTINGS.dns_ttl
+      ))
     when "nsupdate_gss"
       require 'proxy/dns/nsupdate_gss'
       @server = Proxy::DNS::NsupdateGSS.new(opts.merge(
         :server => SETTINGS.dns_server,
+        :ttl => SETTINGS.dns_ttl,
         :tsig_keytab => SETTINGS.dns_tsig_keytab,
         :tsig_principal => SETTINGS.dns_tsig_principal
       ))


### PR DESCRIPTION
This allows overriding default DNS TTL value (86400) per smart-proxy instance. It is possible via setting newly introduced dns_ttl variable in settings.yml configuration file.
