### PR TITLE
adds Proxy::Logger to Proxy::DNS::Nsupdate class

### DIFF
--- a/lib/proxy/dns/nsupdate.rb
+++ b/lib/proxy/dns/nsupdate.rb
@@ -4,6 +4,7 @@ require 'resolv'
 module Proxy::DNS
   class Nsupdate < Record
 
+    include Proxy::Logger
     include Proxy::Util
     attr_reader :resolver
 

--- a/lib/proxy/dns/nsupdate.rb
+++ b/lib/proxy/dns/nsupdate.rb
@@ -4,7 +4,7 @@ require 'resolv'
 module Proxy::DNS
   class Nsupdate < Record
 
-    include Proxy::Logger
+    include Proxy::Log
     include Proxy::Util
     attr_reader :resolver
 


### PR DESCRIPTION
without this, 'logger.debug' and such does nothing at all
