### PR TITLE
Always empty PXEClient on native_ms.rb server

### DIFF
--- a/lib/proxy/dhcp.rb
+++ b/lib/proxy/dhcp.rb
@@ -5,6 +5,7 @@ module Proxy::DHCP
   require "proxy/dhcp/server"
   Standard = {
               :hostname              => {:code => 12, :kind => "String"    }, # The host's name
+              :PXEClient             => {:code => 60, :kind => "String"    }, # Needs to be empty for foreman to function
               :nextServer            => {:code => 66, :kind => "String"    }, # From where we download the pxeboot image via TFTP
               :filename              => {:code => 67, :kind => "String"    }  # The pxeboot image
              }

--- a/lib/proxy/dhcp/server/native_ms.rb
+++ b/lib/proxy/dhcp/server/native_ms.rb
@@ -35,7 +35,6 @@ module Proxy::DHCP
       ignored_attributes = [:ip, :mac, :name, :subnet]
       options.delete_if{|k,v| ignored_attributes.include?(k.to_sym) }
       return if options.empty?  # This reservation is just for an IP and MAC
-      options["PXEClient"] = '""'
 
       # TODO: Refactor these execs into a popen
       alternate_vendor_name = nil

--- a/lib/proxy/dhcp/server/native_ms.rb
+++ b/lib/proxy/dhcp/server/native_ms.rb
@@ -35,6 +35,7 @@ module Proxy::DHCP
       ignored_attributes = [:ip, :mac, :name, :subnet]
       options.delete_if{|k,v| ignored_attributes.include?(k.to_sym) }
       return if options.empty?  # This reservation is just for an IP and MAC
+      options["PXEClient"] = '""'
 
       # TODO: Refactor these execs into a popen
       alternate_vendor_name = nil

--- a/lib/proxy/dhcp/server/native_ms.rb
+++ b/lib/proxy/dhcp/server/native_ms.rb
@@ -31,11 +31,10 @@ module Proxy::DHCP
       cmd = "scope #{record.subnet.network} add reservedip #{record.ip} #{record.mac.gsub(/:/,"")} #{record.name}"
       execute(cmd, "Added DHCP reservation for #{record}")
 
-      options = record.options
+      options = {"PXEClient" => ""}.merge(record.options)
       ignored_attributes = [:ip, :mac, :name, :subnet]
       options.delete_if{|k,v| ignored_attributes.include?(k.to_sym) }
       return if options.empty?  # This reservation is just for an IP and MAC
-      options["PXEClient"] = '""'
 
       # TODO: Refactor these execs into a popen
       alternate_vendor_name = nil
@@ -44,7 +43,7 @@ module Proxy::DHCP
           vendor, attr = match[1,2].map(&:to_sym)
           msg = "set value for #{key}"
           begin
-            execute "scope #{record.subnet.network} set reservedoptionvalue #{record.ip} #{SUNW[attr][:code]} #{SUNW[attr][:kind]} vendor=#{alternate_vendor_name || vendor} #{value}", msg, true
+            execute "scope #{record.subnet.network} set reservedoptionvalue #{record.ip} #{SUNW[attr][:code]} #{SUNW[attr][:kind]} vendor=#{alternate_vendor_name || vendor} \"#{value}\"", msg, true
           rescue Proxy::DHCP::Error => e
             alternate_vendor_name = find_or_create_vendor_name vendor.to_s, e
             retry
@@ -52,7 +51,7 @@ module Proxy::DHCP
         else
           logger.debug "key: " + key.inspect
           k = Standard[key] || Standard[key.to_sym]
-          execute "scope #{record.subnet.network} set reservedoptionvalue #{record.ip} #{k[:code]} #{k[:kind]} #{value}", msg, true
+          execute "scope #{record.subnet.network} set reservedoptionvalue #{record.ip} #{k[:code]} #{k[:kind]} \"#{value}\"", msg, true
         end
       end
 


### PR DESCRIPTION
Often DHCP scopes have PXEClient set by default. This interferes with
the way Foreman does pxe/tftp. With this patch the default is to set
PXEClient to empty string when using native_ms.
