### PR TITLE
added puppetrun over ssh support

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -71,8 +71,16 @@
 # valid providers:
 #   puppetrun   (for puppetrun/kick, deprecated in Puppet 3)
 #   mcollective (uses mco puppet)
+#   puppetssh   (run puppet over ssh)
 :puppet_provider: puppetrun
 :puppet_conf: /etc/puppet/puppet.conf
+# whether to use sudo before the ssh command
+:puppetssh_sudo: false
+# the command which will be sent to the host
+:puppetssh_command: /usr/bin/puppet agent --onetime --no-usecacheonfailure
+# With which user should the proxy connect
+#:puppetssh_user: root
+#:puppetssh_keyfile: /etc/foreman-proxy/id_rsa
 
 # enable BMC management  (Bare metal power and bios controls)
 # Available providers:

--- a/lib/proxy/puppet.rb
+++ b/lib/proxy/puppet.rb
@@ -21,9 +21,13 @@ module Proxy::Puppet
       nodes.collect { |n| escape_for_shell(n) }
     end
     
-    def shell_command(cmd)
+    def shell_command(cmd, wait = true)
       begin
         c = popen(cmd)
+        unless wait
+          Process.detach(c.pid)
+          return 0
+        end
         Process.wait(c.pid)
       rescue Exception => e
         logger.error("Exception '#{e}' when executing '#{cmd}'")

--- a/lib/proxy/puppet/puppetssh.rb
+++ b/lib/proxy/puppet/puppetssh.rb
@@ -1,0 +1,23 @@
+require 'proxy/puppet'
+
+module Proxy::Puppet
+  class PuppetSsh < Runner
+    def run
+      cmd = []
+      cmd.push(which("sudo", "/usr/bin")) if SETTINGS.puppetssh_sudo
+      cmd.push(which("ssh", "/usr/bin"))
+      cmd.push("-l #{SETTINGS.puppetssh_user}") if SETTINGS.puppetssh_user
+      cmd.push("-i #{SETTINGS.puppetssh_keyfile}") if SETTINGS.puppetssh_keyfile
+
+      if cmd.include?(false)
+        logger.warn "sudo or the ssh binary is missing."
+        return false
+      end
+
+      ssh_command = escape_for_shell(SETTINGS.puppetssh_command || '/usr/bin/puppet agent --onetime --no-usecacheonfailure')
+      nodes.each do |node|
+        shell_command(cmd + [ escape_for_shell(node), ssh_command ], false )
+      end
+    end
+  end
+end

--- a/lib/puppet_api.rb
+++ b/lib/puppet_api.rb
@@ -8,6 +8,9 @@ class SmartProxy
     when "mcollective"
       require 'proxy/puppet/mcollective'
       @server = Proxy::Puppet::MCollective.new(opts)
+    when "puppetssh"
+      require 'proxy/puppet/puppetssh'
+      @server = Proxy::Puppet::PuppetSsh.new(opts)
     else
       log_halt 400, "Unrecognized or missing puppet_provider: #{SETTINGS.puppet_provider || "MISSING"}"
     end

--- a/test/puppetssh_test.rb
+++ b/test/puppetssh_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+require 'proxy/puppet/puppetssh'
+
+class PuppetSshTest < Test::Unit::TestCase
+  def setup
+    @puppetssh = Proxy::Puppet::PuppetSsh.new(:nodes => ["host1", "host2"])
+  end
+
+  def test_command_line_with_default_command
+    @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
+    @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
+    
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host1", "/usr/bin/puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host2", "/usr/bin/puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"], false).returns(true)
+    assert @puppetssh.run
+  end
+  
+  def test_command_line_with_sudo
+    SETTINGS.stubs(:puppetssh_sudo).returns(true)
+    SETTINGS.stubs(:puppetssh_command).returns('/bin/true')
+    @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
+    @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
+    
+    @puppetssh.expects(:shell_command).with(["/usr/bin/sudo", "/usr/bin/ssh", "host1", "/bin/true"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/sudo", "/usr/bin/ssh", "host2", "/bin/true"], false).returns(true)
+    assert @puppetssh.run
+  end
+  
+  def test_command_line_with_ssh_keyfile
+    SETTINGS.stubs(:puppetssh_keyfile).returns('/root/.ssh/id_rsa')
+    SETTINGS.stubs(:puppetssh_command).returns('/bin/true')
+    @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
+    @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
+    
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-i /root/.ssh/id_rsa", "host1", "/bin/true"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-i /root/.ssh/id_rsa", "host2", "/bin/true"], false).returns(true)
+    assert @puppetssh.run
+  end
+  
+  def test_command_line_with_ssh_username
+    SETTINGS.stubs(:puppetssh_user).returns('root')
+    SETTINGS.stubs(:puppetssh_command).returns('/bin/true')
+    @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
+    @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
+    
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-l root", "host1", "/bin/true"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-l root", "host2", "/bin/true"], false).returns(true)
+    assert @puppetssh.run
+  end
+  
+  def test_command_line_without_sudo
+    SETTINGS.stubs(:puppetssh_command).returns('/bin/true')
+    @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
+    @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
+    
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host1", "/bin/true"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host2", "/bin/true"], false).returns(true)
+    assert @puppetssh.run
+  end
+
+  def test_missing_sudo
+    SETTINGS.stubs(:puppetssh_sudo).returns(true)
+    @puppetssh.stubs(:which).with("sudo", anything).returns(false)
+    @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
+    @puppetssh.stubs(:shell_command).returns(true)
+    assert !@puppetssh.run
+  end
+
+  def test_missing_sudo_and_not_needed
+    SETTINGS.stubs(:puppetssh_sudo).returns(false)
+    @puppetssh.stubs(:which).with("sudo", anything).returns(false)
+    @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
+    @puppetssh.stubs(:shell_command).returns(true)
+    assert @puppetssh.run
+  end
+  
+  def test_missing_ssh
+    @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
+    @puppetssh.stubs(:which).with("ssh", anything).returns(false)
+
+    assert !@puppetssh.run
+  end
+end


### PR DESCRIPTION
Hello!

I wrote a puppetrun over ssh extension. 
Unfortuantely `( Process.detach(c.pid); return 0 ) unless wait` doesn't seem to be very ruby-like...
Maybe someone can help me out with that one :-)

Cheers
Hannes
