### PR TITLE
Saltstack puppet provider

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -73,6 +73,7 @@
 #   puppetrun   (for puppetrun/kick, deprecated in Puppet 3)
 #   mcollective (uses mco puppet)
 #   puppetssh   (run puppet over ssh)
+#   salt        (uses salt puppet.run)
 :puppet_provider: puppetrun
 :puppet_conf: /etc/puppet/puppet.conf
 # whether to use sudo before the ssh command

--- a/lib/proxy/puppet/salt.rb
+++ b/lib/proxy/puppet/salt.rb
@@ -1,0 +1,22 @@
+require 'proxy/puppet'
+
+module Proxy::Puppet
+  class Salt < Runner
+    def run
+      cmd = []
+      cmd.push(which('sudo', '/usr/bin'))
+      cmd.push(which('salt', '/usr/bin'))
+
+      if cmd.include?(false)
+        logger.warn 'sudo or the salt binary is missing.'
+        return false
+      end
+
+      cmd.push('-L')
+      cmd.push(shell_escaped_nodes.join(','))
+      cmd.push('puppet.run')
+
+      shell_command(cmd)
+    end
+  end
+end

--- a/lib/puppet_api.rb
+++ b/lib/puppet_api.rb
@@ -11,6 +11,9 @@ class SmartProxy
     when "puppetssh"
       require 'proxy/puppet/puppet_ssh'
       @server = Proxy::Puppet::PuppetSSH.new(opts)
+    when "salt"
+      require 'proxy/puppet/salt'
+      @server = Proxy::Puppet::Salt.new(opts)
     else
       log_halt 400, "Unrecognized or missing puppet_provider: #{SETTINGS.puppet_provider || "MISSING"}"
     end

--- a/test/puppetsalt_test.rb
+++ b/test/puppetsalt_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+require 'proxy/puppet/salt'
+
+class PuppetSaltTest < Test::Unit::TestCase
+  def setup
+    @salt = Proxy::Puppet::Salt.new(:nodes => ['host1', 'host2'])
+  end
+
+  def test_command_line_with_default_command
+    @salt.stubs(:which).with('sudo', anything).returns('/usr/bin/sudo')
+    @salt.stubs(:which).with('salt', anything).returns('/usr/bin/salt')
+
+    @salt.expects(:shell_command).with(['/usr/bin/sudo', '/usr/bin/salt', '-L', 'host1,host2', 'puppet.run']).returns(true)
+    assert @salt.run
+  end
+
+  def test_missing_sudo
+    @salt.stubs(:which).with('sudo', anything).returns(false)
+    @salt.stubs(:which).with('salt', anything).returns('/usr/bin/salt')
+    assert !@salt.run
+  end
+
+  def test_missing_salt
+    @salt.stubs(:which).with('sudo', anything).returns('/usr/bin/sudo')
+    @salt.stubs(:which).with('salt', anything).returns(false)
+    assert !@salt.run
+  end
+end


### PR DESCRIPTION
This provider allows puppet runs to be triggered by 'salt host puppet.run'.
It depends on a working Saltstack installation.
