### PR TITLE
fixes #3874 - extend paths for FreeBSD support

### DIFF
--- a/extra/query.rb
+++ b/extra/query.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/ruby
+#!/usr/bin/env ruby
 # == Synopsis
 #
 # Queries a remote smart proxy via https

--- a/lib/proxy/bmc/shell.rb
+++ b/lib/proxy/bmc/shell.rb
@@ -31,7 +31,7 @@ module Proxy
 
       def powercycle
         # search for sudo
-        sudo = which("sudo", "/usr/bin")
+        sudo = which("sudo")
 
         unless sudo
           logger.warn "sudo binary was not found - aborting"

--- a/lib/proxy/dhcp/server/isc.rb
+++ b/lib/proxy/dhcp/server/isc.rb
@@ -1,6 +1,7 @@
 require 'time'
 module Proxy::DHCP
   class ISC < Server
+    include Proxy::Util
 
     def initialize options
       super(options[:name])
@@ -144,7 +145,8 @@ module Proxy::DHCP
 
     def omcmd cmd, msg=nil
       if cmd == "connect"
-        @om = IO.popen("/bin/sh -c '/usr/bin/omshell 2>&1'", "r+")
+        om_binary = which("omshell")
+        @om = IO.popen("/bin/sh -c '#{om_binary} 2>&1'", "r+")
         @om.puts "key #{SETTINGS.dhcp_key_name} \"#{SETTINGS.dhcp_key_secret}\"" if SETTINGS.dhcp_key_name and SETTINGS.dhcp_key_secret
         @om.puts "server #{name}"
         @om.puts "connect"

--- a/lib/proxy/dns/nsupdate.rb
+++ b/lib/proxy/dns/nsupdate.rb
@@ -89,7 +89,7 @@ module Proxy::DNS
     private
 
     def find_nsupdate
-      @nsupdate = which("nsupdate", "/usr/bin")
+      @nsupdate = which("nsupdate")
       unless File.exists?("#{@nsupdate}")
         logger.warn "unable to find nsupdate binary, maybe missing bind-utils package?"
         raise "unable to find nsupdate binary"

--- a/lib/proxy/puppet/mcollective.rb
+++ b/lib/proxy/puppet/mcollective.rb
@@ -4,13 +4,13 @@ module Proxy::Puppet
   class MCollective < Runner
     def run
       cmd = []
-      cmd.push(which("sudo", "/usr/bin"))
+      cmd.push(which("sudo"))
 
       if SETTINGS.puppet_user
         cmd.push("-u", SETTINGS.puppet_user)
       end
 
-      cmd.push(which("mco", ["/usr/bin", "/opt/puppet/bin"]))
+      cmd.push(which("mco", "/opt/puppet/bin"))
 
       if cmd.include?(false)
         logger.warn "sudo or the mco binary is missing."

--- a/lib/proxy/puppet/puppet_ssh.rb
+++ b/lib/proxy/puppet/puppet_ssh.rb
@@ -4,8 +4,8 @@ module Proxy::Puppet
   class PuppetSSH < Runner
     def run
       cmd = []
-      cmd.push(which('sudo', '/usr/bin')) if SETTINGS.puppetssh_sudo
-      cmd.push(which('ssh', '/usr/bin'))
+      cmd.push(which('sudo')) if SETTINGS.puppetssh_sudo
+      cmd.push(which('ssh'))
       cmd.push("-l #{SETTINGS.puppetssh_user}") if SETTINGS.puppetssh_user
       if (file = SETTINGS.puppetssh_keyfile)
         if File.exists?(file)
@@ -20,7 +20,7 @@ module Proxy::Puppet
         return false
       end
 
-      ssh_command = escape_for_shell(SETTINGS.puppetssh_command || '/usr/bin/puppet agent --onetime --no-usecacheonfailure')
+      ssh_command = escape_for_shell(SETTINGS.puppetssh_command || 'puppet agent --onetime --no-usecacheonfailure')
       nodes.each do |node|
         shell_command(cmd + [escape_for_shell(node), ssh_command], false)
       end

--- a/lib/proxy/puppet/puppetrun.rb
+++ b/lib/proxy/puppet/puppetrun.rb
@@ -4,10 +4,10 @@ module Proxy::Puppet
   class PuppetRun < Runner
     def run
       # Search in /opt/ for puppet enterprise users
-      default_path = ["/usr/sbin", "/usr/bin", "/opt/puppet/bin"]
+      default_path = "/opt/puppet/bin"
       # search for puppet for users using puppet 2.6+
       cmd = []
-      cmd.push(which("sudo", "/usr/bin"))
+      cmd.push(which("sudo"))
 
       if SETTINGS.puppet_user
         cmd.push("-u", SETTINGS.puppet_user)

--- a/lib/proxy/puppet/salt.rb
+++ b/lib/proxy/puppet/salt.rb
@@ -4,8 +4,8 @@ module Proxy::Puppet
   class Salt < Runner
     def run
       cmd = []
-      cmd.push(which('sudo', '/usr/bin'))
-      cmd.push(which('salt', '/usr/bin'))
+      cmd.push(which('sudo'))
+      cmd.push(which('salt'))
 
       if cmd.include?(false)
         logger.warn 'sudo or the salt binary is missing.'

--- a/lib/proxy/puppetca.rb
+++ b/lib/proxy/puppetca.rb
@@ -105,9 +105,9 @@ module Proxy::PuppetCA
         raise "SSL/CA unavailable on this machine"
       end
 
-      # puppetca is the old method of using puppet cert which is new in puppet 2.6
-      default_path = ["/usr/sbin","/opt/puppet/bin", "/opt/puppet/sbin", "/usr/bin"]
+      default_path = ["/opt/puppet/bin", "/opt/puppet/sbin"]
 
+      # puppetca is the old method of using puppet cert which is new in puppet 2.6
       if Puppet::PUPPETVERSION.to_i < 3
         @puppetca = which("puppetca", default_path) || which("puppet", default_path)
       else
@@ -125,7 +125,7 @@ module Proxy::PuppetCA
       # Tell puppetca to use the ssl dir that Foreman has been told to use
       @puppetca << " --ssldir #{ssl_dir}"
 
-      @sudo = which("sudo", "/usr/bin")
+      @sudo = which("sudo")
       unless File.exists?("#{@sudo}")
         logger.warn "unable to find sudo binary"
         raise "Unable to find sudo"

--- a/lib/proxy/util.rb
+++ b/lib/proxy/util.rb
@@ -49,6 +49,7 @@ module Proxy::Util
   # accepts a binary name and an array of paths to search first
   # if path is omitted will search only in user PATH
   def which(bin, *path)
+    path = path + ['/usr/bin', '/usr/sbin', '/usr/local/bin', '/usr/local/sbin']
     path += ENV['PATH'].split(File::PATH_SEPARATOR)
     path.flatten.uniq.each do |dir|
       dest = File.join(dir, bin)

--- a/test/puppetca_test.rb
+++ b/test/puppetca_test.rb
@@ -58,7 +58,7 @@ class ProxyTest < Test::Unit::TestCase
 
   def test_which_should_return_a_binary_path
     ENV.stubs(:[]).with('PATH').returns(['/foo', '/bin', '/usr/bin'].join(File::PATH_SEPARATOR))
-    { '/foo' => false, '/bin' => true, '/usr/bin' => false }.each do |p,r|
+    { '/foo' => false, '/bin' => true, '/usr/bin' => false, '/usr/sbin' => false, '/usr/local/bin' => false, '/usr/local/sbin' => false }.each do |p,r|
       FileTest.stubs(:file?).with("#{p}/ls").returns(r)
       FileTest.stubs(:executable?).with("#{p}/ls").returns(r)
     end

--- a/test/puppetssh_test.rb
+++ b/test/puppetssh_test.rb
@@ -10,8 +10,8 @@ class PuppetSshTest < Test::Unit::TestCase
     @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
     @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
 
-    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host1", "/usr/bin/puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"], false).returns(true)
-    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host2", "/usr/bin/puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host1", "puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host2", "puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"], false).returns(true)
     assert @puppetssh.run
   end
 


### PR DESCRIPTION
FreeBSD is putting packaged software into /usr/local, so paths have to be extended for it to work.
