### PR TITLE
fixes #3965 Change API endpoint for chef_proxy to be the same as Foreman's

### DIFF
--- a/lib/chefproxy_api.rb
+++ b/lib/chefproxy_api.rb
@@ -10,13 +10,13 @@ class SmartProxy
     log_halt(401, "Unauthorized : " + env['sinatra.error'].message )
   end
 
-  post "/facts" do
+  post "/api/hosts/facts" do
     Proxy::Authentication::Chef.new.authenticated(request) do |content|
       Proxy::ChefProxy::Facts.new.post_facts(content)
     end
   end
 
-  post "/reports" do
+  post "/api/reports" do
     Proxy::Authentication::Chef.new.authenticated(request) do |content|
       Proxy::ChefProxy::Reports.new.post_report(content)
     end


### PR DESCRIPTION
This is needed to be transparent from client side.

@ares : you're ok ?
