### PR TITLE
Initial ABRT proxy support

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -12,7 +12,13 @@
 #:trusted_hosts:
 #- foreman.prod.domain
 #- foreman.dev.domain
+# Following is needed for communication with foreman initiated by the proxy.
 #:foreman_url: http://127.0.0.1:3000
+# SSL settings for client authentication against foreman. In most cases, these
+# will be the same as the ssl_* settings above.
+#:foreman_ssl_ca: ssl/certs/ca.pem
+#:foreman_ssl_cert: ssl/certs/fqdn.pem
+#:foreman_ssl_key: ssl/private_keys/fqdn.pem
 
 # enable the daemon to run in the background
 :daemon: true
@@ -112,6 +118,16 @@
 # in order to retrive all nodes public keys
 # :chef_smartproxy_clientname: 'host.example.net'
 # :chef_smartproxy_privatekey: '/etc/chef/client.pem'
+
+# enable ABRT uReport forwarding
+:abrtproxy: false
+# FAF server instance the reports will be forwarded to (optional)
+#:abrt_server_url: https://retrace.fedoraproject.org/faf
+# Set to true if FAF server uses self-signed certificate
+#:abrt_server_ssl_noverify: true
+# Following two options enable client authentication to FAF server
+#:abrt_server_ssl_cert: /etc/foreman-proxy/faf_client_cert.pem
+#:abrt_server_ssl_key: /etc/foreman-proxy/faf_cleint_key.pem
 
 # enable BMC management  (Bare metal power and bios controls)
 # Available providers:

--- a/lib/abrtproxy_api.rb
+++ b/lib/abrtproxy_api.rb
@@ -1,0 +1,64 @@
+require 'openssl'
+require 'json'
+
+require 'proxy/request'
+require 'proxy/abrtproxy'
+
+STATUS_ACCEPTED = 202
+
+class SmartProxy
+  post "/abrt/reports/new/" do
+    begin
+      cn = Proxy::AbrtProxy::common_name request
+    rescue Proxy::Error::Unauthorized => e
+      log_halt 403, "Client authentication failed: #{e.message}"
+    end
+
+    ureport_json = request['file'][:tempfile].read
+    ureport = JSON.parse(ureport_json)
+
+    #forward to FAF
+    response = nil
+    if SETTINGS.abrt_server_url
+      begin
+        result = Proxy::AbrtProxy::faf_request "/reports/new/", ureport_json
+        response = result.body if result.code.to_s == STATUS_ACCEPTED.to_s
+      rescue RuntimeError => e
+        logger.error "Unable to forward to ABRT server: #{e}"
+      end
+    end
+    if not response
+      # forwarding is not configured or failed
+      # FAF source that generates replies is in src/webfaf/reports/views.py
+      response = { "result" => false,
+                   "message" => "Report forwarded to Foreman server" }.to_json
+    end
+
+    #send report to Foreman
+    begin
+      foreman_report = Proxy::AbrtProxy::create_report cn, ureport
+      Proxy::Request::Reports.new.post_report(foreman_report.to_json)
+    rescue RuntimeError => e
+      log_halt 503, "Unable to forward to Foreman server: #{e}"
+    end
+
+    status STATUS_ACCEPTED
+    response
+  end
+
+  post "/abrt/reports/:action/" do
+    # pass through to real FAF if configured
+    if SETTINGS.abrt_server_url
+      body = request['file'][:tempfile].read
+      result = Proxy::AbrtProxy::faf_request "/reports/#{params[:action]}/", body
+      if result
+        status result.code
+        result.body
+      else
+        log_halt 503, "ABRT server unavailable"
+      end
+    else
+      log_halt 501, "foreman-proxy does not implement /reports/#{params[:action]}/"
+    end
+  end
+end

--- a/lib/chefproxy_api.rb
+++ b/lib/chefproxy_api.rb
@@ -1,4 +1,4 @@
-require 'proxy/chefproxy'
+require 'proxy/request'
 require 'proxy/authentication'
 
 class SmartProxy
@@ -12,13 +12,13 @@ class SmartProxy
 
   post "/api/hosts/facts" do
     Proxy::Authentication::Chef.new.authenticated(request) do |content|
-      Proxy::ChefProxy::Facts.new.post_facts(content)
+      Proxy::Request::Facts.new.post_facts(content)
     end
   end
 
   post "/api/reports" do
     Proxy::Authentication::Chef.new.authenticated(request) do |content|
-      Proxy::ChefProxy::Reports.new.post_report(content)
+      Proxy::Request::Reports.new.post_report(content)
     end
   end
 end

--- a/lib/proxy.rb
+++ b/lib/proxy.rb
@@ -1,5 +1,5 @@
 module Proxy
-  MODULES = %w{dns dhcp tftp puppetca puppet bmc chefproxy}
+  MODULES = %w{dns dhcp tftp puppetca puppet bmc chefproxy abrtproxy}
   VERSION = "1.5-develop"
 
   require "checks"
@@ -18,7 +18,7 @@ module Proxy
   require "proxy/dns"        if SETTINGS.dns
   require "proxy/dhcp"       if SETTINGS.dhcp
   require "proxy/bmc"        if SETTINGS.bmc
-  require "proxy/chefproxy"  if SETTINGS.chefproxy
+  require "proxy/abrtproxy"  if SETTINGS.abrtproxy
 
   def self.features
     MODULES.collect{|mod| mod if SETTINGS.send mod}.compact

--- a/lib/proxy/abrtproxy.rb
+++ b/lib/proxy/abrtproxy.rb
@@ -1,0 +1,111 @@
+require 'net/http'
+require 'net/https'
+require 'uri'
+
+module Proxy::AbrtProxy
+  extend Proxy::Log
+
+  # Generate multipart boundary separator
+  def self.suggest_separator
+      separator = "-"*28
+      base = ('a'..'z').to_a
+      16.times { separator << base[rand(base.size)] }
+      separator
+  end
+
+  # It seems that Net::HTTP does not support multipart/form-data - this function
+  # is adapted from http://stackoverflow.com/a/213276 and lib/proxy/request.rb
+  def self.form_data_file(content, file_content_type)
+    # Assemble the request body using the special multipart format
+    thepart =  "Content-Disposition: form-data; name=\"file\"; filename=\"*buffer*\"\r\n" +
+               "Content-Type: #{ file_content_type }\r\n\r\n#{ content }\r\n"
+
+    boundary = self.suggest_separator
+    while thepart.include? boundary
+      boundary = self.suggest_separator
+    end
+
+    body = "--" + boundary + "\r\n" + thepart + "--" + boundary + "--\r\n"
+    headers = {
+      "User-Agent"     => "foreman-proxy/#{Proxy::VERSION}",
+      "Content-Type"   => "multipart/form-data; boundary=#{ boundary }",
+      "Content-Length" => body.length.to_s
+    }
+
+    return headers, body
+  end
+
+  def self.faf_request(path, content, content_type="application/json")
+    uri              = URI.parse(SETTINGS.abrt_server_url.to_s)
+    http             = Net::HTTP.new(uri.host, uri.port)
+    http.use_ssl     = uri.scheme == 'https'
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+
+    if SETTINGS.abrt_server_ssl_noverify
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
+
+    if SETTINGS.abrt_server_ssl_cert && !SETTINGS.abrt_server_ssl_cert.to_s.empty? \
+        && SETTINGS.abrt_server_ssl_key && !SETTINGS.abrt_server_ssl_key.to_s.empty?
+      http.cert = OpenSSL::X509::Certificate.new(File.read(SETTINGS.abrt_server_ssl_cert))
+      http.key  = OpenSSL::PKey::RSA.new(File.read(SETTINGS.abrt_server_ssl_key), nil)
+    end
+
+    headers, body = self.form_data_file content, content_type
+
+    path = [uri.path, path].join unless uri.path.empty?
+    begin
+      response = http.start { |con| con.post(path, body, headers) }
+    rescue SystemCallError => e
+      # FAF unreachable
+      logger.error e
+      return nil
+    end
+
+    response
+  end
+
+  def self.common_name(request)
+    client_cert = request.env['SSL_CLIENT_CERT']
+    raise Proxy::Error::Unauthorized, "Client certificate required" if client_cert.to_s.empty?
+
+    begin
+      client_cert = OpenSSL::X509::Certificate.new(client_cert)
+    rescue OpenSSL::OpenSSLError => e
+      raise Proxy::Error::Unauthorized, e.message
+    end
+
+    cn = client_cert.subject.to_a.detect { |name, value| name == 'CN' }
+    cn = cn[1] unless cn.nil?
+    raise Proxy::Error::Unauthorized, "Common Name not found in the certificate" unless cn
+
+    return cn
+  end
+
+  # http://projects.theforeman.org/projects/foreman/wiki/Json-report-format
+  def self.create_report(host, ureport)
+    message = ureport["reason"]
+    { "report" => {
+          "host"        => host,
+          "reported_at" => Time.now.utc.to_s,
+          "status"      => { "applied"         => 0,
+                             "restarted"       => 0,
+                             "failed"          => 1,
+                             "failed_restarts" => 0,
+                             "skipped"         => 0,
+                             "pending"         => 0
+                           },
+          "metrics"     => { "resources" => { "total" => 0 },
+                             "time"      => { "total" => 0 }
+                           },
+          "logs"        => [
+                             { "log" => { "sources"  => { "source" => "ABRT" },
+                                          "messages" => { "message" => message },
+                                          "level"    => "err"
+                                        }
+                             }
+                           ]
+          }
+    }
+  end
+end

--- a/lib/proxy/request.rb
+++ b/lib/proxy/request.rb
@@ -3,7 +3,7 @@ require 'net/https'
 require 'uri'
 
 
-module Proxy::ChefProxy
+module Proxy::Request
 
   class ForemanRequest
     def send_request(path, body)

--- a/lib/smart_proxy.rb
+++ b/lib/smart_proxy.rb
@@ -35,6 +35,7 @@ class SmartProxy < Sinatra::Base
   require "dhcp_api"      if SETTINGS.dhcp
   require "bmc_api"       if SETTINGS.bmc
   require "chefproxy_api" if SETTINGS.chefproxy
+  require "abrtproxy_api" if SETTINGS.abrtproxy
 
   begin
     require "facter"

--- a/test/abrt_api_test.rb
+++ b/test/abrt_api_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+require 'helpers'
+require 'json'
+require 'abrtproxy_api'
+require 'ostruct'
+require 'webrick'
+
+ENV['RACK_ENV'] = 'test'
+
+class AbrtApiTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    SmartProxy.new
+  end
+
+  def setup
+    ureport_file = "test/fixtures/abrt/ureport1.json"
+    @post_data = {
+      "file" => Rack::Test::UploadedFile.new(ureport_file, "application/json")
+    }
+    Proxy::AbrtProxy.stubs(:common_name).returns('localhost')
+  end
+
+  def test_forwarding_to_foreman
+    Proxy::Request::Reports.any_instance.expects(:post_report)
+
+    post "/abrt/reports/new/", @post_data
+
+    assert last_response.successful?
+    assert_equal last_response.status, 202
+    data = JSON.parse(last_response.body)
+    assert_equal data['result'], false
+    assert data['message'].is_a?(String), "Response message is not string"
+  end
+
+  def test_forwarding_to_foreman_and_faf
+    response_body = {
+      "result"  => true,
+      "message" => "Hi!"
+    }.to_json
+    response_status = 202
+    faf_response = OpenStruct.new(:code => response_status, :body => response_body)
+
+    Proxy::AbrtProxy.expects(:faf_request).returns(faf_response)
+    Proxy::Request::Reports.any_instance.expects(:post_report).returns(nil)
+    SETTINGS.stubs(:abrt_server_url).returns('https://doesnt.matter/')
+
+    post "/abrt/reports/new/", @post_data
+
+    assert last_response.successful?
+    assert_equal last_response.status, response_status
+    assert_equal last_response.body, response_body
+  end
+
+  def test_forwarding_other_endpoints
+    post "/abrt/reports/attach/", @post_data
+
+    assert_equal last_response.status, 501
+
+    faf_response = OpenStruct.new(:code => 201, :body => "Whatever!")
+    Proxy::AbrtProxy.expects(:faf_request).returns(faf_response)
+    SETTINGS.stubs(:abrt_server_url).returns('https://doesnt.matter/')
+
+    post "/abrt/reports/attach/", @post_data
+
+    assert_equal last_response.status, faf_response.code
+    assert_equal last_response.body, faf_response.body
+  end
+
+  def test_multipart_form_data_file
+    file_contents = '{"foo":"bar"}'
+    headers, body = Proxy::AbrtProxy.form_data_file(file_contents, 'application/json')
+    request_text = "POST /abrt/whatever/ HTTP/1.1\r\n"
+    headers.each do |key,value|
+      request_text << key + ": " + value + "\r\n"
+    end
+    request_text << "\r\n"
+    request_text << body
+
+    req = WEBrick::HTTPRequest.new(WEBrick::Config::HTTP)
+    req.parse(StringIO.new(request_text))
+
+    assert_equal req.request_method, "POST"
+    assert_equal req.query["file"], file_contents
+  end
+end

--- a/test/chefproxy_test.rb
+++ b/test/chefproxy_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'proxy/chefproxy'
+require 'proxy/request'
 require 'webmock/test_unit'
 
 class ChefProxyTest < Test::Unit::TestCase
@@ -12,7 +12,7 @@ class ChefProxyTest < Test::Unit::TestCase
   def test_post_facts
     facts = {'fact' => "sample"}
     stub_request(:post,@foreman_url+'/api/hosts/facts')
-    result = Proxy::ChefProxy::Facts.new.post_facts(facts)
+    result = Proxy::Request::Facts.new.post_facts(facts)
 
     assert(result.is_a? Net::HTTPOK)
   end
@@ -20,7 +20,7 @@ class ChefProxyTest < Test::Unit::TestCase
   def test_post_reports
     report = {'report' => "sample"}
     stub_request(:post,@foreman_url+'/api/reports')
-    result = Proxy::ChefProxy::Reports.new.post_report(report)
+    result = Proxy::Request::Reports.new.post_report(report)
 
     assert(result.is_a? Net::HTTPOK)
   end

--- a/test/fixtures/abrt/ureport1.json
+++ b/test/fixtures/abrt/ureport1.json
@@ -1,0 +1,45 @@
+{   "ureport_version": 2
+,   "reason": "Program /usr/bin/will_segfault was terminated by signal 11"
+,   "reporter": {   "name": "satyr"
+                ,   "version": "0.13"
+                }
+,   "os": {   "name": "fedora"
+          ,   "version": "19"
+          ,   "architecture": "x86_64"
+          ,   "cpe": "cpe:/o:fedoraproject:fedora:19"
+          }
+,   "problem": {   "type": "core"
+               ,   "component": "will-crash"
+               ,   "user": {   "root": false
+                           ,   "local": true
+                           }
+               ,   "signal": 11
+               ,   "executable": "/usr/bin/will_segfault"
+               ,   "stacktrace":
+                     [ {   "crash_thread": true
+                       ,   "frames":
+                             [ {   "address": 4195406
+                               ,   "build_id": "e8c1fa14411a04623afbfac93a5cbab39767cfb2"
+                               ,   "build_id_offset": 1102
+                               ,   "function_name": "main"
+                               ,   "file_name": "/usr/bin/will_segfault"
+                               ,   "fingerprint": "27fec48d69579748149aa1a5456ea2d906ff5744"
+                               } ]
+                       } ]
+               }
+,   "packages": [ {   "name": "glibc"
+                  ,   "epoch": 0
+                  ,   "version": "2.17"
+                  ,   "release": "20.fc19"
+                  ,   "architecture": "x86_64"
+                  ,   "install_time": 1389354420
+                  }
+                , {   "name": "will-crash"
+                  ,   "epoch": 0
+                  ,   "version": "0.4"
+                  ,   "release": "1.fc19"
+                  ,   "architecture": "x86_64"
+                  ,   "install_time": 1391527642
+                  ,   "package_role": "affected"
+                  } ]
+}


### PR DESCRIPTION
This change makes it possible for the proxy to pretend it is ABRT
(Automatic Bug Reporting Tool[1]) server. When it receives a problem
report, it forwards notification of the error to Foreman, and optionally
also forwards the original report to an actual ABRT server.

Non strictly ABRT-related changes:
- Move module Proxy::ChefProxy to Proxy::Request
- Add :foreman_ssl_ options to settings example

[1] https://github.com/abrt/abrt/wiki/ABRT-Project

For some notes regarding usage, see https://groups.google.com/forum/#!topic/foreman-dev/Yk2GrW9ne20

I am quite new to Ruby so please let me know if anything should be done in a different way:)
