### PR TITLE
Don't call sudo if the calling user is the same as :puppet_user

### DIFF
--- a/lib/proxy/puppet/mcollective.rb
+++ b/lib/proxy/puppet/mcollective.rb
@@ -4,10 +4,12 @@ module Proxy::Puppet
   class MCollective < Runner
     def run
       cmd = []
-      cmd.push(which("sudo"))
+      unless ENV['USER'] == SETTINGS.puppet_user
+        cmd.push(which("sudo"))
 
-      if SETTINGS.puppet_user
-        cmd.push("-u", SETTINGS.puppet_user)
+        if SETTINGS.puppet_user
+          cmd.push("-u", SETTINGS.puppet_user)
+        end
       end
 
       cmd.push(which("mco", "/opt/puppet/bin"))


### PR DESCRIPTION
Hi,

the idea behind this change is that we don't really need to invoke sudo if the calling user (ENV['USER']) is the same as the one defined in :puppet_user.

Cheers,
Matteo
