### PR TITLE
Added the ability to use rvmsudo when calling `puppet cert` commands.

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -84,6 +84,7 @@
 #   salt        (uses salt puppet.run)
 #   customrun   (calls a custom command with args)
 :puppet_provider: puppetrun
+#:use_rvmsudo: false
 
 # customrun command details
 # Set :customrun_cmd to the full path of the script you want to run, instead of /bin/false

--- a/lib/proxy/puppetca.rb
+++ b/lib/proxy/puppetca.rb
@@ -125,7 +125,7 @@ module Proxy::PuppetCA
       # Tell puppetca to use the ssl dir that Foreman has been told to use
       @puppetca << " --ssldir #{ssl_dir}"
 
-      use_rvmsudo == true ? @sudo = which("rvmsudo") : @sudo = which("sudo")
+      use_rvmsudo? == true ? @sudo = which("rvmsudo") : @sudo = which("sudo")
       unless File.exists?("#{@sudo}")
         logger.warn "unable to find sudo binary"
         raise "Unable to find sudo"
@@ -134,7 +134,7 @@ module Proxy::PuppetCA
 
     end
 
-    def use_rvmsudo
+    def use_rvmsudo?
       SETTINGS.use_rvmsudo || false
     end
 

--- a/lib/proxy/puppetca.rb
+++ b/lib/proxy/puppetca.rb
@@ -125,13 +125,17 @@ module Proxy::PuppetCA
       # Tell puppetca to use the ssl dir that Foreman has been told to use
       @puppetca << " --ssldir #{ssl_dir}"
 
-      @sudo = which("sudo")
+      use_rvmsudo == true ? @sudo = which("rvmsudo") : @sudo = which("sudo")
       unless File.exists?("#{@sudo}")
         logger.warn "unable to find sudo binary"
         raise "Unable to find sudo"
       end
       logger.debug "Found sudo at #{@sudo}"
 
+    end
+
+    def use_rvmsudo
+      SETTINGS.use_rvmsudo || false
     end
 
     def ssldir


### PR DESCRIPTION
Setup:

CentOS 6.4
RVM
Ruby 2.0.0-p451 via RVM
Puppet, Facter, Hiera, etc... provided by Gem installs
Foreman (git repo, just an ENC, served out through Passenger)
smart-proxy (git repo)
Puppet Master (served out through Passenger)

With my stack, I noticed that smart-proxy was throwing an error when attempting to use sudo with the puppet cert command:

$ sudo -S /usr/share/foreman/foreman-proxy/vendor/ruby/2.0.0/bin/puppet cert --ssldir /var/lib/puppet/ssl --list --all
/usr/lib/ruby/site_ruby/1.8/rubygems.rb:779:in `report_activate_error': Could not find RubyGem puppet (>= 0) (Gem::LoadError)
    from /usr/lib/ruby/site_ruby/1.8/rubygems.rb:214:in`activate'
    from /usr/lib/ruby/site_ruby/1.8/rubygems.rb:1082:in `gem'
    from /usr/share/foreman/foreman-proxy/vendor/ruby/2.0.0/bin/puppet:22

From the looks of it, it's trying to use the system's Ruby installation. In order to resolve this, I've added another config option that specifies whether or not to use rvmsudo, which passes the appropriate RVM environment variables to sudo. If :use_rvmsudo: is commented out (default), or set to anything other than true (no quotes), smart-proxy will use sudo. So it shouldn't interfere with existing installations.

Here is a snippet from proxy.log with :use_rvmsudo: set to true:

D, [2014-02-25T15:11:39.825499 #4441] DEBUG -- : Found puppetca at /usr/share/foreman/foreman-proxy/vendor/ruby/2.0.0/bin/puppet
D, [2014-02-25T15:11:39.825753 #4441] DEBUG -- : Found sudo at /usr/local/rvm/bin/rvmsudo
D, [2014-02-25T15:11:39.825815 #4441] DEBUG -- : Executing /usr/local/rvm/bin/rvmsudo -S /usr/share/foreman/foreman-proxy/vendor/ruby/2.0.0/bin/puppet cert --ssldir /var/lib/puppet/ssl --list --all

And with :use_rvmsudo: set to false:

D, [2014-02-25T15:14:33.972073 #5612] DEBUG -- : Found puppetca at /usr/share/foreman/foreman-proxy/vendor/ruby/2.0.0/bin/puppet
D, [2014-02-25T15:14:33.972251 #5612] DEBUG -- : Found sudo at /usr/bin/sudo
D, [2014-02-25T15:14:33.972316 #5612] DEBUG -- : Executing /usr/bin/sudo -S /usr/share/foreman/foreman-proxy/vendor/ruby/2.0.0/bin/puppet cert --ssldir /var/lib/puppet/ssl --list --all
W, [2014-02-25T15:14:34.002148 #5612]  WARN -- : Failed to run puppetca: 
E, [2014-02-25T15:14:34.002710 #5612] ERROR -- : Failed to list certificates: Execution of puppetca failed, check log files
