### PR TITLE
Allow the DNS smart-proxy to manage CNAME's

### DIFF
--- a/lib/proxy/dns/nsupdate.rb
+++ b/lib/proxy/dns/nsupdate.rb
@@ -33,6 +33,8 @@ module Proxy::DNS
           else
             nsupdate "update add #{@value}.  #{@ttl} IN #{@type} #{@fqdn}"
           end
+        when "CNAME"
+          nsupdate "update add #{@fqdn}.  #{@ttl} #{@type} #{@value}"
       end
       nsupdate "disconnect"
     ensure
@@ -43,7 +45,7 @@ module Proxy::DNS
     def remove
       nsupdate "connect"
       case @type
-      when "A"
+      when "A", "CNAME"
         nsupdate "update delete #{@fqdn} #{@type}"
       when "PTR"
         nsupdate "update delete #{@value} #{@type}"


### PR DESCRIPTION
This is a very simple change to the DNS smart proxy so it can support DNS CNAME's.

I would love to take a crack at implementing the version 2.0 DNS API for the proxy but this should get things to work for the time being.
