### PR TITLE
fixes #4658 - parse puppet.conf with augeas instead of puppet internals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,5 @@ Gemfile.lock
 bundler.d/Gemfile.local.rb
 .rbenv*
 .rvmrc*
-.ruby-version
+.ruby-*
 .bundle

--- a/bundler.d/puppet.rb
+++ b/bundler.d/puppet.rb
@@ -1,3 +1,4 @@
 group :puppet do
   gem 'puppet'
+  gem 'ruby-augeas', :require => 'augeas'
 end

--- a/lib/proxy/puppet/config_reader.rb
+++ b/lib/proxy/puppet/config_reader.rb
@@ -1,0 +1,35 @@
+require 'augeas'
+
+module Proxy
+  module Puppet
+    class ConfigReader
+      attr_reader :config
+
+      def initialize(config)
+        raise "Puppet config at #{config} was not found" unless File.exist?(config)
+        @config = config
+      end
+
+      def get
+        return @config_hash if @config_hash
+
+        aug = nil
+        begin
+          aug = Augeas::open(nil, nil, Augeas::NO_MODL_AUTOLOAD)
+          aug.set('/augeas/load/Puppet/lens', 'Puppet.lns')
+          aug.set('/augeas/load/Puppet/incl', config)
+          aug.load
+
+          @config_hash = Hash.new { |h,k| h[k] = {} }
+          aug.match("/files#{config}/*/*[label() != '#comment']").each do |path|
+            (section, key) = path.split('/')[-2..-1].map(&:to_sym)
+            @config_hash[section][key] = aug.get(path)
+          end
+        ensure
+          aug.close if aug
+        end
+        @config_hash
+      end
+    end
+  end
+end

--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -1,6 +1,7 @@
 module Proxy::Puppet
 
   require 'proxy/puppet/initializer'
+  require 'proxy/puppet/config_reader'
   require 'proxy/puppet/puppet_class'
   require 'puppet'
 
@@ -22,7 +23,7 @@ module Proxy::Puppet
 
       def puppet_environments
         Initializer.load
-        conf = Puppet.settings.instance_variable_get(:@values)
+        conf = ConfigReader.new(Puppet[:config]).get
 
         env = { }
         # query for the environments variable
@@ -122,7 +123,8 @@ module Proxy::Puppet
     end
 
     def classes
-      conf = Puppet.settings.instance_variable_get(:@values)
+      Initializer.load
+      conf = ConfigReader.new(Puppet[:config]).get
       eparser = conf[:master] && conf[:master][:parser] == 'future'
 
       paths.map {|path| PuppetClass.scan_directory path, eparser}.flatten

--- a/test/puppet_config_reader_test.rb
+++ b/test/puppet_config_reader_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class PuppetConfigReaderTest < Test::Unit::TestCase
+
+  def setup
+    @puppet_conf = File.expand_path(File.join(File.dirname(__FILE__), 'fixtures', 'puppet.conf'))
+  end
+
+  def build
+    Proxy::Puppet::ConfigReader.new(@puppet_conf)
+  end
+
+  def test_should_initialize
+    assert_kind_of Proxy::Puppet::ConfigReader, build
+  end
+
+  def test_get_should_return_section_hash
+    assert_kind_of Hash, build.get
+    assert_equal [:agent, :development, :main, :master, :production], build.get.keys.sort
+  end
+
+  def test_get_section_contents_hash
+    assert_kind_of Hash, build.get[:production]
+    assert_equal [:modulepath], build.get[:production].keys
+    assert_equal '/etc/puppet/modules/production:/etc/puppet/modules/common', build.get[:production][:modulepath]
+  end
+
+end

--- a/test/puppet_environment_test.rb
+++ b/test/puppet_environment_test.rb
@@ -34,7 +34,7 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
         :main => {},
         :production => { :modulepath=>'./test/fixtures/environments/prod' }
     }
-    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns(config)
     env = Proxy::Puppet::Environment.all
     assert_array_equal env.map { |e| e.name }, ['production']
   end
@@ -44,7 +44,7 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
         :main => {},
         :master => { :modulepath=>'./test/fixtures/environments/prod' }
     }
-    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns(config)
     env = Proxy::Puppet::Environment.all
     assert_array_equal env.map { |e| e.name }, ['production']
   end
@@ -55,7 +55,7 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
         :production  => { :modulepath=>'./test/fixtures/environments/prod' },
         :development => { :modulepath=>'./test/fixtures/environments/dev' }
     }
-    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns(config)
     env = Proxy::Puppet::Environment.all
     assert_array_equal env.map { |e| e.name }, ['development', 'production']
   end
@@ -65,7 +65,7 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
         :main => {},
         :production  => { :modulepath=>'./test/fixtures/environments/dev:./test/fixtures/environments/prod' },
     }
-    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns(config)
     env = Proxy::Puppet::Environment.all
     assert_array_equal env.map { |e| e.name }, ['production']
     assert_array_equal env.first.classes.map { |c| c.name}, ['test','test2']
@@ -76,7 +76,7 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
         :main => {},
         :master => { :modulepath=>'./test/fixtures/environments/$environment/' }
     }
-    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns(config)
     env = Proxy::Puppet::Environment.all
     assert_array_equal env.map { |e| e.name }, ['dev','prod']
     env_class_map = env.map { |e| [e.name, e.classes.map { |c| c.name }].flatten }
@@ -88,7 +88,7 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
         :main => {},
         :master => { :modulepath=>'./test/fixtures/multi_module/$environment/modules1:./test/fixtures/multi_module/$environment/modules2' }
     }
-    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns(config)
     env = Proxy::Puppet::Environment.all
     assert_array_equal env.map { |e| e.name }, ['dev','prod']
     env_class_map = env.map { |e| [e.name, e.classes.map { |c| c.name }].flatten }
@@ -100,7 +100,7 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
         :main => {},
         :master => { :modulepath=>'./test/fixtures/environments/prod:./test/fixtures/multi_module/$environment/modules1:./test/fixtures/multi_module/$environment/modules2' }
     }
-    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns(config)
     env = Proxy::Puppet::Environment.all
     assert_array_equal env.map { |e| e.name }, ['master','dev','prod']
     env_class_map = env.map { |e| [e.name, e.classes.map { |c| c.name }].flatten }
@@ -112,7 +112,7 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
         :main => {},
         :master => { :modulepath=>'./test/fixtures/environments/$environment:./test/fixtures/modules_include' }
     }
-    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns(config)
     env = Proxy::Puppet::Environment.all
     assert_array_equal env.map { |e| e.name }, ['dev', 'prod', 'master']
   end
@@ -122,7 +122,7 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
         :main => {},
         :master => { :modulepath=>'./no/such/$environment/modules:./test/fixtures/environments/prod' }
     }
-    Puppet.settings.stubs(:instance_variable_get).returns(config)
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns(config)
     env = Proxy::Puppet::Environment.all
     assert_array_equal env.map { |e| e.name }, ['master']
   end


### PR DESCRIPTION
@ares?

Tested on EL6 with Puppet 3.5 successfully.
