### PR TITLE
fixes #4660 - stub omshell during DHCP tests

### DIFF
--- a/test/server_isc_test.rb
+++ b/test/server_isc_test.rb
@@ -15,8 +15,8 @@ class ServerIscTest < Test::Unit::TestCase
     SmartProxy.new
   end
 
-  def test_sparc_host
-    data = {
+  def sparc_attrs
+    {
       "hostname"=>"itgsyddev910.macbank",
       "mac"=>"00:21:28:6d:62:e8",
       "ip"=>"192.168.122.11",
@@ -32,11 +32,32 @@ class ServerIscTest < Test::Unit::TestCase
       "<SPARC-Enterprise-T5120>root_server_ip"=>"192.168.122.24",
       "<SPARC-Enterprise-T5120>install_path"=>"/Solaris/install/Solaris_5.10_sparc_hw0811"
     }
+  end
+
+  def test_sparc_host_creation
     s=Proxy::DHCP::Server.new('192.168.122.1')
     sub=Proxy::DHCP::Subnet.new(s,'192.168.122.0','255.255.255.0')
     Proxy::DHCP::Server::ISC.any_instance.stubs(:find_subnet).returns(sub)
-    post '/dhcp/192.168.122.10', data
+    Proxy::DHCP::Server::ISC.any_instance.stubs(:omcmd)
+    post '/dhcp/192.168.122.10', sparc_attrs
     assert last_response.ok?, 'Last response was not ok'
+  end
+
+  def test_sparc_host_quirks
+    dhcp = Proxy::DHCP::Server::ISC.new(:name => '192.168.122.1', :config => './test/dhcp.conf', :leases => './test/dhcp.leases')
+    assert_equal [], dhcp.send(:solaris_options_statements, {})
+
+    assert_equal [
+      %q{option SUNW.JumpStart-server \"192.168.122.24:/Solaris/jumpstart\";},
+      %q{option SUNW.install-path \"/Solaris/install/Solaris_5.10_sparc_hw0811\";},
+      %q{option SUNW.install-server-hostname \"itgsyddev807.macbank\";},
+      %q{option SUNW.install-server-ip-address 192.168.122.24;},
+      %q{option SUNW.root-path-name \"/Solaris/install/Solaris_5.10_sparc_hw0811/Solaris_10/Tools/Boot\";},
+      %q{option SUNW.root-server-hostname \"itgsyddev807.macbank\";},
+      %q{option SUNW.root-server-ip-address 192.168.122.24;},
+      %q{option SUNW.sysid-config-file-server \"192.168.122.24:/Solaris/jumpstart/sysidcfg/sysidcfg_primary\";},
+      %q{vendor-option-space SUNW;}
+    ], dhcp.send(:solaris_options_statements, sparc_attrs).sort
   end
 
   def test_ztp_quirks


### PR DESCRIPTION
It looks like omcmd/shell wasn't actually stubbed out, so we were probably making real calls to a DNS server at 192.168.122.1.  Extended tests for the SPARC attributes while I was here, so we're checking more than the response code.

Three green runs:
http://ci.theforeman.org/job/test_proxy_develop_pull_request/236/
http://ci.theforeman.org/job/test_proxy_develop_pull_request/237/
http://ci.theforeman.org/job/test_proxy_develop_pull_request/238/
