### PR TITLE
fixes #4686 - don't rely on Puppet[:config] to store config file location

### DIFF
--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -23,7 +23,7 @@ module Proxy::Puppet
 
       def puppet_environments
         Initializer.load
-        conf = ConfigReader.new(Puppet[:config]).get
+        conf = ConfigReader.new(Initializer.config).get
 
         env = { }
         # query for the environments variable
@@ -124,7 +124,7 @@ module Proxy::Puppet
 
     def classes
       Initializer.load
-      conf = ConfigReader.new(Puppet[:config]).get
+      conf = ConfigReader.new(Initializer.config).get
       eparser = conf[:master] && conf[:master][:parser] == 'future'
 
       paths.map {|path| PuppetClass.scan_directory path, eparser}.flatten

--- a/test/puppet_environment_test.rb
+++ b/test/puppet_environment_test.rb
@@ -29,6 +29,15 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
     assert_kind_of Proxy::Puppet::PuppetClass, env.classes.first
   end
 
+  def test_uses_puppet_config
+    config_reader = mock('config')
+    config_reader.expects(:get).returns({:main => {}, :master => {}})
+    Proxy::Puppet::Initializer.expects(:config).returns('/foo/puppet.conf').at_least_once
+    Proxy::Puppet::ConfigReader.expects(:new).with('/foo/puppet.conf').returns(config_reader)
+    File.expects(:exist?).with('/foo/puppet.conf').returns(true).at_least_once
+    Proxy::Puppet::Environment.send(:puppet_environments)
+  end
+
   def test_single_static_env
     config = {
         :main => {},

--- a/test/puppet_initializer_test.rb
+++ b/test/puppet_initializer_test.rb
@@ -1,0 +1,22 @@
+require 'test_helper'
+
+class PuppetInitializerTest < Test::Unit::TestCase
+
+  def test_config_returns_puppet_conf
+    SETTINGS.expects(:puppet_conf).returns('/foo/puppet.conf')
+    assert_equal '/foo/puppet.conf', Proxy::Puppet::Initializer.config
+  end
+
+  def test_config_returns_puppetdir
+    SETTINGS.stubs(:puppet_conf).returns(nil)
+    SETTINGS.expects(:puppetdir).returns('/foo')
+    assert_equal '/foo/puppet.conf', Proxy::Puppet::Initializer.config
+  end
+
+  def test_config_returns_default
+    SETTINGS.stubs(:puppet_conf).returns(nil)
+    SETTINGS.expects(:puppetdir).returns(nil)
+    assert_equal '/etc/puppet/puppet.conf', Proxy::Puppet::Initializer.config
+  end
+
+end


### PR DESCRIPTION
Tested on 2.7.25 and 3.5.0-rc1.
