### PR TITLE
Bug Fix: Incorrect IP returned as next available on subnet

### DIFF
--- a/lib/proxy/dhcp/subnet.rb
+++ b/lib/proxy/dhcp/subnet.rb
@@ -139,7 +139,7 @@ module Proxy::DHCP
     def unused_ip args = {}
       # first check if we already have a record for this host
       # if we do, we can simply reuse the same ip address.
-      if args[:mac] and r=has_mac?(args[:mac])
+      if args[:mac] and r=has_mac?(args[:mac]) and valid_range(args).include?(r.ip)
         logger.debug "Found an existing dhcp record #{r}, reusing..."
         return r.ip
       end

--- a/test/subnet_test.rb
+++ b/test/subnet_test.rb
@@ -115,4 +115,26 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
     assert_equal @subnet.size, counter-1
   end
 
+  def test_should_reuse_ip_if_from_same_subnet
+    @subnet.stubs(:has_mac?).returns(stub(:ip => '192.168.0.10'))
+    @subnet.stubs(:icmp_pingable?)
+    @subnet.stubs(:tcp_pingable?)
+    assert_equal '192.168.0.10', @subnet.unused_ip({:mac => '0'})
+  end
+
+  def test_should_not_reuse_ip_if_from_other_subnet
+    @subnet.stubs(:has_mac?).returns(stub(:ip => '10.0.0.10'))
+    @subnet.stubs(:icmp_pingable?)
+    @subnet.stubs(:tcp_pingable?)
+    assert_equal false, @subnet.unused_ip({:mac => '0'}).include?("10.0.0")
+  end
+
+  def test_should_not_reuse_ip_if_from_outside_range
+    @subnet.stubs(:has_mac?).returns(stub(:ip => '192.168.0.250'))
+    @subnet.stubs(:icmp_pingable?)
+    @subnet.stubs(:tcp_pingable?)
+    params = {:mac => '0', :from => '192.168.0.1', :to => '192.168.0.30'}
+    assert_not_equal '192.168.0.250', @subnet.unused_ip(params)  
+  end
+
 end


### PR DESCRIPTION
If there is an existing DHCP record for a host, the address is re-used even if it's from a different subnet.

This fix introduces a check to ensure that the address which is selected only comes from the existing record if the address also belongs to the given subnet.
