### PR TITLE
fixes #5239 - update for Puppet 3.5 future parser changes

### DIFF
--- a/lib/proxy/puppet/class_scanner_eparser.rb
+++ b/lib/proxy/puppet/class_scanner_eparser.rb
@@ -72,6 +72,12 @@ if Puppet::PUPPETVERSION.to_f >= 3.2
         end
       end
 
+      def find_Program o
+        if o.body
+          do_find(o.body)
+        end
+      end
+
       def find_Object o
         #puts "Unhandled object:#{o}"
       end
@@ -115,7 +121,7 @@ if Puppet::PUPPETVERSION.to_f >= 3.2
               ast_to_value_new value.expr
             when Puppet::Pops::Model::VariableExpression
               "${#{ast_to_value_new value.expr}}"
-            when Puppet::Pops::Model::TypeReference
+            when (Puppet::Pops::Model::TypeReference rescue nil)
               value.value
             when Puppet::Pops::Model::LiteralUndef
               ""

--- a/test/puppet_environment_test.rb
+++ b/test/puppet_environment_test.rb
@@ -32,9 +32,9 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
   def test_uses_puppet_config
     config_reader = mock('config')
     config_reader.expects(:get).returns({:main => {}, :master => {}})
+    Proxy::Puppet::Initializer.expects(:load)
     Proxy::Puppet::Initializer.expects(:config).returns('/foo/puppet.conf').at_least_once
     Proxy::Puppet::ConfigReader.expects(:new).with('/foo/puppet.conf').returns(config_reader)
-    File.expects(:exist?).with('/foo/puppet.conf').returns(true).at_least_once
     Proxy::Puppet::Environment.send(:puppet_environments)
   end
 


### PR DESCRIPTION
I've just added 3.5.0 to the PR test matrix.
