### PR TITLE
fixes #5522 - future parser can be set in puppet.conf [main]

### DIFF
--- a/lib/proxy/puppet/environment.rb
+++ b/lib/proxy/puppet/environment.rb
@@ -125,7 +125,7 @@ module Proxy::Puppet
     def classes
       Initializer.load
       conf = ConfigReader.new(Initializer.config).get
-      eparser = conf[:master] && conf[:master][:parser] == 'future'
+      eparser = (conf[:main] && conf[:main][:parser] == 'future') || (conf[:master] && conf[:master][:parser] == 'future')
 
       paths.map {|path| PuppetClass.scan_directory path, eparser}.flatten
     end

--- a/test/puppet_class_test.rb
+++ b/test/puppet_class_test.rb
@@ -28,4 +28,17 @@ class PuppetClassTest < Test::Unit::TestCase
     klass = Proxy::Puppet::PuppetClass.new "foreman_proxy::install"
     assert_kind_of Proxy::Puppet::PuppetClass, klass
   end
+
+  def test_scan_directory_loads_scanner
+    Proxy::Puppet::Initializer.expects(:load)
+    Proxy::Puppet::ClassScanner.expects(:scan_directory).with('/foo')
+    Proxy::Puppet::PuppetClass.scan_directory('/foo', nil)
+  end
+
+  def test_scan_directory_loads_eparser_scanner
+    return unless Puppet::PUPPETVERSION.to_f >= 3.2
+    Proxy::Puppet::Initializer.expects(:load)
+    Proxy::Puppet::ClassScannerEParser.expects(:scan_directory).with('/foo')
+    Proxy::Puppet::PuppetClass.scan_directory('/foo', true)
+  end
 end

--- a/test/puppet_environment_test.rb
+++ b/test/puppet_environment_test.rb
@@ -38,6 +38,30 @@ class PuppetEnvironmentTest < Test::Unit::TestCase
     Proxy::Puppet::Environment.send(:puppet_environments)
   end
 
+  def test_classes_calls_scan_directory
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns({})
+    env = Proxy::Puppet::Environment.new(:name => 'production', :paths => ['/etc/puppet/modules', '/etc/puppet/production'])
+    Proxy::Puppet::PuppetClass.expects(:scan_directory).with('/etc/puppet/modules', nil)
+    Proxy::Puppet::PuppetClass.expects(:scan_directory).with('/etc/puppet/production', nil)
+    env.classes
+  end
+
+  def test_classes_calls_scan_directory_with_eparser_master
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns({:master => {:parser => 'future'}})
+    env = Proxy::Puppet::Environment.new(:name => 'production', :paths => ['/etc/puppet/modules', '/etc/puppet/production'])
+    Proxy::Puppet::PuppetClass.expects(:scan_directory).with('/etc/puppet/modules', true)
+    Proxy::Puppet::PuppetClass.expects(:scan_directory).with('/etc/puppet/production', true)
+    env.classes
+  end
+
+  def test_classes_calls_scan_directory_with_eparser_main
+    Proxy::Puppet::ConfigReader.any_instance.stubs(:get).returns({:main => {:parser => 'future'}})
+    env = Proxy::Puppet::Environment.new(:name => 'production', :paths => ['/etc/puppet/modules', '/etc/puppet/production'])
+    Proxy::Puppet::PuppetClass.expects(:scan_directory).with('/etc/puppet/modules', true)
+    Proxy::Puppet::PuppetClass.expects(:scan_directory).with('/etc/puppet/production', true)
+    env.classes
+  end
+
   def test_single_static_env
     config = {
         :main => {},


### PR DESCRIPTION
This'll fail PR tests on 3.5.0 because the preceding PR's not yet merged.
