### PR TITLE
fixes #5561 run puppet over ssh

### DIFF
--- a/lib/proxy/puppet/puppet_ssh.rb
+++ b/lib/proxy/puppet/puppet_ssh.rb
@@ -6,10 +6,10 @@ module Proxy::Puppet
       cmd = []
       cmd.push(which('sudo')) if SETTINGS.puppetssh_sudo
       cmd.push(which('ssh'))
-      cmd.push("-l #{SETTINGS.puppetssh_user}") if SETTINGS.puppetssh_user
+      cmd.push("-l#{SETTINGS.puppetssh_user}") if SETTINGS.puppetssh_user
       if (file = SETTINGS.puppetssh_keyfile)
         if File.exists?(file)
-          cmd.push("-i #{file}")
+          cmd.push("-i#{file}")
         else
           logger.warn("Unable to access SSH private key:#{file}, ignoring...")
         end

--- a/lib/proxy/puppet/puppet_ssh.rb
+++ b/lib/proxy/puppet/puppet_ssh.rb
@@ -6,10 +6,10 @@ module Proxy::Puppet
       cmd = []
       cmd.push(which('sudo')) if SETTINGS.puppetssh_sudo
       cmd.push(which('ssh'))
-      cmd.push("-l#{SETTINGS.puppetssh_user}") if SETTINGS.puppetssh_user
+      cmd.push("-l", "#{SETTINGS.puppetssh_user}") if SETTINGS.puppetssh_user
       if (file = SETTINGS.puppetssh_keyfile)
         if File.exists?(file)
-          cmd.push("-i#{file}")
+          cmd.push("-i", "#{file}")
         else
           logger.warn("Unable to access SSH private key:#{file}, ignoring...")
         end

--- a/test/puppetssh_test.rb
+++ b/test/puppetssh_test.rb
@@ -33,8 +33,8 @@ class PuppetSshTest < Test::Unit::TestCase
     @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
     @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
 
-    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-i /root/.ssh/id_rsa", "host1", "/bin/true"], false).returns(true)
-    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-i /root/.ssh/id_rsa", "host2", "/bin/true"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-i", "/root/.ssh/id_rsa", "host1", "/bin/true"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-i", "/root/.ssh/id_rsa", "host2", "/bin/true"], false).returns(true)
     assert @puppetssh.run
   end
 
@@ -56,8 +56,8 @@ class PuppetSshTest < Test::Unit::TestCase
     @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
     @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
 
-    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-l root", "host1", "/bin/true"], false).returns(true)
-    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-l root", "host2", "/bin/true"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-l", "root", "host1", "/bin/true"], false).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "-l", "root", "host2", "/bin/true"], false).returns(true)
     assert @puppetssh.run
   end
 


### PR DESCRIPTION
Running foreman(1.4.3) and foreman-proxy (1.5.0-0) on Rhel 6.2, I found that the only way to get puppet run over ssh to work is to remove the space between -l <user> and -i <keyfile> in puppet_ssh.rb.
