### PR TITLE
Match the DHCP specification of last-wins leases

### DIFF
--- a/lib/dhcp_api.rb
+++ b/lib/dhcp_api.rb
@@ -104,7 +104,7 @@ class SmartProxy < Sinatra::Base
   # delete a record from a network
   delete "/dhcp/:network/:record" do
     begin
-      record = load_subnet[params[:record]]
+      record = load_subnet.reservation_for(params[:record])
       log_halt 404, "Record #{params[:network]}/#{params[:record]} not found" unless record
       @server.delRecord @subnet, record
       if request.accept? 'application/json'

--- a/test/server_test.rb
+++ b/test/server_test.rb
@@ -6,6 +6,7 @@ class DHCPServerTest < Test::Unit::TestCase
   def setup
     @server = Proxy::DHCP::Server.new("testcase")
     @subnet = Proxy::DHCP::Subnet.new(@server, "192.168.0.0", "255.255.255.0")
+    @subnet.load
     @record = Proxy::DHCP::Record.new(:subnet => @subnet, :ip => "192.168.0.11", :mac => "aa:bb:cc:dd:ee:ff")
   end
 

--- a/test/subnet_test.rb
+++ b/test/subnet_test.rb
@@ -8,6 +8,7 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
     @netmask = "255.255.255.0"
     @server = Proxy::DHCP::Server.new("testcase")
     @subnet = Proxy::DHCP::Subnet.new @server, @network, @netmask
+    @subnet.load
   end
 
   def test_subnet_should_have_a_server
@@ -67,27 +68,16 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
     assert_equal @subnet.range, "192.168.0.1-192.168.0.254"
   end
 
-  def add_record
-    ip = "192.168.0.50"
-    mac = "aa:bb:cc:dd:ee:Ff"
-    @subnet.add_record Proxy::DHCP::Record.new(:subnet =>@subnet, :ip => ip, :mac => mac)
+  def add_record opts = {}
+    ip = opts[:ip] || "192.168.0.50"
+    mac = opts[:mac] || "aa:bb:cc:dd:ee:ff"
+    Proxy::DHCP::Record.new(:subnet =>@subnet, :ip => ip, :mac => mac)
   end
 
   def test_should_add_records
     counter = @subnet.size
     add_record
     assert_equal @subnet.size, counter+1
-  end
-
-  def test_should_not_import_the_same_record_twice
-    begin
-      add_record
-    rescue
-       nil
-    end
-    counter = @subnet.size
-    add_record
-    assert_equal @subnet.size, counter
   end
 
   def test_should_clear_records
@@ -106,6 +96,11 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
   def test_it_should_be_possible_to_find_subnet_record_based_on_ip
     add_record
     assert_kind_of Proxy::DHCP::Record, @subnet["192.168.0.50"]
+  end
+
+  def test_it_should_be_possible_to_find_subnet_record_based_on_mac
+    add_record
+    assert_kind_of Proxy::DHCP::Record, @subnet["aa:bb:cc:dd:ee:ff"]
   end
 
   def test_should_remove_records

--- a/test/subnet_test.rb
+++ b/test/subnet_test.rb
@@ -103,6 +103,18 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
     assert_kind_of Proxy::DHCP::Record, @subnet["aa:bb:cc:dd:ee:ff"]
   end
 
+  def test_it_should_be_possible_to_find_subnet_reservations_when_subsequent_records_exist
+    Proxy::DHCP::Reservation.new(:subnet =>@subnet, :ip => '192.168.0.50', :mac => 'aa:bb:cc:dd:ee:ff', :hostname => "foo.com")
+    add_record
+    assert_equal 'reservation', @subnet.reservation_for("aa:bb:cc:dd:ee:ff").kind
+  end
+
+  def test_it_should_be_possible_to_find_subnet_leases_when_subsequent_records_exist
+    Proxy::DHCP::Lease.new(:subnet =>@subnet, :ip => '192.168.0.50', :mac => 'aa:bb:cc:dd:ee:ff', :state => "active")
+    add_record
+    assert_equal 'lease', @subnet.lease_for("aa:bb:cc:dd:ee:ff").kind
+  end
+
   def test_should_remove_records
     add_record
     counter = @subnet.size
@@ -129,7 +141,7 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
     @subnet.stubs(:icmp_pingable?)
     @subnet.stubs(:tcp_pingable?)
     params = {:mac => '0', :from => '192.168.0.1', :to => '192.168.0.30'}
-    assert_not_equal '192.168.0.250', @subnet.unused_ip(params)  
+    assert_not_equal '192.168.0.250', @subnet.unused_ip(params)
   end
 
 end


### PR DESCRIPTION
Just sending this PR mainly to get the tests to run on Jenkins - I'm not entirely happy with it yet...

Discussion of the issue can be found here: http://projects.theforeman.org/issues/5648

This attempts to preserve the current proxy behaviour of indexing DHCP records by IP, and only re-indexes by mac (thus updating/removing duplicates) when specifically searching for a mac record.
