### PR TITLE
fixes #5675 - expect dns_key setting to be nil if not set

### DIFF
--- a/lib/proxy/dns/nsupdate.rb
+++ b/lib/proxy/dns/nsupdate.rb
@@ -9,7 +9,7 @@ module Proxy::DNS
     attr_reader :resolver
 
     def initialize options = {}
-      raise "Unable to find Key file - check your dns_key settings" unless SETTINGS.dns_key == false or File.exists?(SETTINGS.dns_key)
+      raise "Unable to find Key file - check your dns_key settings" unless SETTINGS.dns_key.nil? or File.exists?(SETTINGS.dns_key)
       super(options)
     end
 

--- a/test/nsupdate_test.rb
+++ b/test/nsupdate_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+require 'proxy/dns'
+require 'proxy/dns/nsupdate'
+
+class NsupdateTest < Test::Unit::TestCase
+  def test_initialize_nsupdate_returns_no_error_with_missing_key_setting
+    SETTINGS.stubs(:dns_key).returns(nil)
+    assert Proxy::DNS::Nsupdate.new(:fqdn => 'example.com')
+  end
+
+  def test_initialize_nsupdate_returns_error_with_missing_key_file
+    SETTINGS.stubs(:dns_key).returns('./no-such-key')
+    assert_raise RuntimeError do
+      Proxy::DNS::Nsupdate.new(:fqdn => 'example.com')
+    end
+  end
+end


### PR DESCRIPTION
Regression from 3824d18, as the default for a setting changed from false to nil, so the check for SETTING.dns_key == false is no longer correct.

Untested....
