### PR TITLE
Fixes #5712: Limit DHCP subnets for ISC if necessary

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -52,7 +52,7 @@
 #   - native_ms (Microsoft native implementation)
 #   - virsh (simple implementation for libvirt)
 :dhcp_vendor: isc
-# dhcp_subnets is a Native MS implementation setting. It restricts the subnets queried to a
+# dhcp_subnets is an ISC &  Native MS implementation setting. It restricts the subnets queried to a
 # subset, so as to reduce the query time.
 #:dhcp_subnets: [192.168.205.0/255.255.255.128, 192.168.205.128/255.255.255.128]
 # Settings for Ubuntu ISC

--- a/lib/proxy/dhcp/server/isc.rb
+++ b/lib/proxy/dhcp/server/isc.rb
@@ -92,6 +92,8 @@ module Proxy::DHCP
       super
       @config.each_line do |line|
         if line =~ /^\s*subnet\s+([\d\.]+)\s+netmask\s+([\d\.]+)/
+          next if (managed_subnets = SETTINGS.dhcp_subnets) and !managed_subnets.include? "#{$1}/#{$2}"
+
           Proxy::DHCP::Subnet.new(self, $1, $2)
         end
       end


### PR DESCRIPTION
Implementation copied from 700e96b
