### PR TITLE
fixes #5856 - use public initializer for Puppet settings

### DIFF
--- a/lib/proxy/puppet/initializer.rb
+++ b/lib/proxy/puppet/initializer.rb
@@ -20,11 +20,7 @@ module Proxy::Puppet
         logger.info "Initializing from Puppet config file: #{config}"
 
         if Puppet::PUPPETVERSION.to_i >= 3
-          # Initializing Puppet directly and not via the Faces API, so indicate
-          # the run mode to parse [master].  Don't use --run_mode=master or
-          # bug #17492 is hit and Puppet can't parse it.
-          Puppet.settings.initialize_global_settings(['--config', config, '--run_mode', 'master'])
-          Puppet.settings.initialize_app_defaults(Puppet::Settings.app_defaults_for_run_mode(Puppet::Util::RunMode['master']))
+          Puppet.initialize_settings
         else
           Puppet.parse_config
         end


### PR DESCRIPTION
This PR swaps calling fairly private methods with calling the public API for initialising settings.

The reason we used to do this when adding support for Puppet 3 was that we relied on Puppet itself to parse its config file, and then pulled the parsed data structure out of its settings object.  Since Puppet reads a different config file depending on which "run mode" it's in (master, agent, user (misc)), we had to force it into master so it read the same puppet.conf that the puppet master itself would be using.

Recently I replaced the code that pulled the parsed config out of Puppet with an Augeas-based implementation in dd374005, so we no longer have a requirement to load Puppet in master mode.  Now the default "user" mode (used for programs 'requiring' Puppet and non-agent/master Puppet apps) will suffice, because we generally don't care about where it loads settings from.

Puppet 3.6 now broke this initialisation code because it added a new step internally ("context") that we weren't initialising.  You can see this here: https://github.com/puppetlabs/puppet/blob/3.6.0/lib/puppet.rb#L150-L153

So the upshot of this is that we might as well KISS and go back to the public API for initialising settings, forgetting all about run modes: https://github.com/puppetlabs/puppet/blob/3.6.0/lib/puppet.rb#L127-L132

I've tested this on Puppet 3.6.0 and 3.0.0 and with the following puppet.conf files:
- default foreman-installer config
- http://projects.theforeman.org/issues/5856#note-3
- https://groups.google.com/d/msg/foreman-users/Wn6QjyI0qQs/0E_c0FWrnq0J
- https://groups.google.com/d/msg/foreman-users/Wn6QjyI0qQs/l7w8L-fV778J

Jenkins will also test a large number of Puppet versions.
