### PR TITLE
Fix escaping of spaces on Ruby 1.9+ when invoking puppetrun

### DIFF
--- a/lib/proxy/puppet.rb
+++ b/lib/proxy/puppet.rb
@@ -39,7 +39,7 @@ module Proxy::Puppet
 
     def popen(cmd)
       # 1.8.7 note: this assumes that cli options are space-separated
-      cmd = cmd.join(' ') unless RUBY_VERSION > '1.8.7'
+      cmd = cmd.join(' ') if RUBY_VERSION <= '1.8.7'
       logger.debug("about to execute: #{cmd}")
       IO.popen(cmd)
     end

--- a/lib/proxy/puppet/puppet_ssh.rb
+++ b/lib/proxy/puppet/puppet_ssh.rb
@@ -20,7 +20,12 @@ module Proxy::Puppet
         return false
       end
 
-      ssh_command = escape_for_shell(SETTINGS.puppetssh_command || 'puppet agent --onetime --no-usecacheonfailure')
+
+      ssh_command = begin
+        command = SETTINGS.puppetssh_command || 'puppet agent --onetime --no-usecacheonfailure'
+        (RUBY_VERSION <= '1.8.7') ? escape_for_shell(command) : command
+      end
+
       nodes.each do |node|
         shell_command(cmd + [escape_for_shell(node), ssh_command], false)
       end

--- a/test/puppetssh_test.rb
+++ b/test/puppetssh_test.rb
@@ -10,8 +10,19 @@ class PuppetSshTest < Test::Unit::TestCase
     @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
     @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
 
-    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host1", "puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"], false).returns(true)
-    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host2", "puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"], false).returns(true)
+    command = if RUBY_VERSION <= '1.8.7'
+                "puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"
+              else
+                "puppet agent --onetime --no-usecacheonfailure"
+              end
+    @puppetssh.
+        expects(:shell_command).
+        with(["/usr/bin/ssh", "host1", command], false).
+        returns(true)
+    @puppetssh.
+        expects(:shell_command).
+        with(["/usr/bin/ssh", "host2", command], false).
+        returns(true)
     assert @puppetssh.run
   end
 


### PR DESCRIPTION
When invoking `puppetrun` via ssh the command to be executed is not properly escaped and fails. 
- pushing for review 
- to get CI running (could not get test run locally)
