### PR TITLE
fixes dhcp server virsh.rb to interpret prefix

### DIFF
--- a/modules/dhcp/dhcp/monkey_patches.rb
+++ b/modules/dhcp/dhcp/monkey_patches.rb
@@ -1,6 +1,11 @@
 require 'ipaddr'
 
 class IPAddr
+  # Returns a dot-decimal netmask representation
+  def to_mask
+    return _to_string(@mask_addr)
+  end
+
   # Returns the successor to the ipaddr.
   def succ
     return self.clone.set(@addr + 1, @family)

--- a/modules/dhcp/dhcp/providers/server/virsh.rb
+++ b/modules/dhcp/dhcp/providers/server/virsh.rb
@@ -43,7 +43,7 @@ module Proxy::DHCP
       begin
         doc = REXML::Document.new xml = dump_xml
         REXML::XPath.each(doc, "//network/ip[not(@family) or @family='ipv4']/dhcp/host") do |e|
-          Proxy::DHCP::Record.new(:subnet => subnet,
+          Proxy::DHCP::Reservation.new(:subnet => subnet,
                                   :ip => e.attributes["ip"],
                                   :mac => e.attributes["mac"],
                                   :hostname => e.attributes["name"])

--- a/modules/dhcp/dhcp/providers/server/virsh.rb
+++ b/modules/dhcp/dhcp/providers/server/virsh.rb
@@ -18,8 +18,15 @@ module Proxy::DHCP
         doc = REXML::Document.new xml = dump_xml
         doc.elements.each("network/ip") do |e|
           next if e.attributes["family"] == "ipv6"
-          netmask = e.attributes["netmask"]
           gateway = e.attributes["address"]
+
+          if e.attributes["netmask"].nil? then
+            # converts a prefix/cidr notation to octets
+            netmask = IPAddr.new(gateway).mask(e.attributes["prefix"]).to_mask
+          else
+            netmask = e.attributes["netmask"]
+          end
+
           network = IPAddr.new(gateway).mask(netmask).to_s
           subnet = Proxy::DHCP::Subnet.new(self, network, netmask)
         end


### PR DESCRIPTION
The virsh.rb loadSubnets method was only looking for a definition of a netmask inside the libvirt network XML, despite netmask not being there in case a prefix attribute was defined. netmask and prefix are mutually exclusive by libvirt definition.

Also the ipaddr library has no easy way of retrieving a readable netmask from a prefix, albeit this functionality is provided by the inspect method, in this case the same thing was done as in inspect.
