### PR TITLE
Add support for 64-bit MAC addresses, fixes #6341

### DIFF
--- a/lib/proxy/validations.rb
+++ b/lib/proxy/validations.rb
@@ -1,18 +1,27 @@
 module Proxy::Validations
 
+  MAC_REGEXP_48BIT = /\A([a-f0-9]{1,2}:){5}[a-f0-9]{1,2}\z/i
+  MAC_REGEXP_64BIT = /\A([a-f0-9]{1,2}:){19}[a-f0-9]{1,2}\z/i
+
   class Error < RuntimeError; end
   private
+
+  def valid_mac? mac
+    return false if mac.nil?
+    return true if mac =~ MAC_REGEXP_48BIT or mac =~ MAC_REGEXP_64BIT
+    false
+  end
 
   # validates the ip address
   def validate_ip ip
     raise Error, "Invalid IP Address #{ip}" unless ip =~ /(\d{1,3}\.){3}\d{1,3}/
-      ip
+    ip
   end
 
   # validates the mac
   def validate_mac mac
-    raise Error, "Invalid MAC #{mac}" unless mac =~ /([a-f0-9]{1,2}:){5}[a-f0-9]{1,2}/i
-      mac.downcase
+    raise Error, "Invalid MAC #{mac}" unless valid_mac?(mac)
+    mac.downcase
   end
 
   def validate_subnet subnet

--- a/modules/tftp/tftp_api.rb
+++ b/modules/tftp/tftp_api.rb
@@ -1,14 +1,16 @@
 require 'tftp/server'
+require 'proxy/validations'
 
 module Proxy::TFTP
   class Api < ::Sinatra::Base
     include ::Proxy::Log
     helpers ::Proxy::Helpers
+    include ::Proxy::Validations
 
     helpers do
       def instantiate variant, mac=nil
         # Filenames must end in a hex representation of a mac address but only if mac is not empty
-        log_halt 403, "Invalid MAC address: #{mac}"                  unless mac =~ /^(?:[\da-f][\da-f][:-]?){6}$/i or mac.nil?
+        log_halt 403, "Invalid MAC address: #{mac}"                  unless valid_mac?(mac)
         log_halt 403, "Unrecognized pxeboot config type: #{variant}" unless defined? variant.capitalize
         eval "Proxy::TFTP::#{variant.capitalize}.new"
       end

--- a/test/tftp/tftp_api_test.rb
+++ b/test/tftp/tftp_api_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+require 'json'
+require 'sinatra'
+require 'tftp/tftp_plugin'
+require 'tftp/tftp_api'
+
+ENV['RACK_ENV'] = 'test'
+
+class TftpApiTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Proxy::TFTP::Api.new
+  end
+
+  def setup
+    Proxy::TFTP::Plugin.settings.stubs(:tftproot).returns("/some/root")
+    @args = { :pxeconfig => "foo" }
+  end
+
+  def test_api_can_fetch_boot_file
+    Proxy::Util::CommandTask.stubs(:new).returns(true)
+    FileUtils.stubs(:mkdir_p).returns(true)
+    Proxy::TFTP.expects(:fetch_boot_file).with('/some/root/boot/file','http://localhost/file').returns(true)
+    post "/fetch_boot_file", {:prefix => '/some/root/boot/file', :path => 'http://localhost/file'}
+    assert last_response.ok?
+  end
+
+  def test_api_can_create_syslinux_tftp_reservation
+    mac = "aa:bb:cc:00:11:22"
+    mac_filename = "aa-bb-cc-dd-ee-ff-00-11-22"
+    FileUtils.stubs(:mkdir_p).returns(true)
+    File.stubs(:open).with("/some/root/pxelinux.cfg/#{mac_filename}", 'w').returns(true)
+    Proxy::TFTP::Syslinux.any_instance.expects(:set).with(mac, args[:pxeconfig])
+    post "/#{mac}", args
+    assert last_response.ok?
+  end
+
+  def test_api_can_create_syslinux_tftp_reservation_for_64bit_mac
+    mac = "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd"
+    mac_filename = "aa-bb-cc-dd-ee-ff-00-11-22-33-44-55-66-77-88-99-aa-bb-cc-dd"
+    FileUtils.stubs(:mkdir_p).returns(true)
+    File.stubs(:open).with("/some/root/pxelinux.cfg/#{mac_filename}", 'w').returns(true)
+    Proxy::TFTP::Syslinux.any_instance.expects(:set).with(mac, args[:pxeconfig])
+    post "/#{mac}", args
+    assert last_response.ok?
+  end
+
+  def test_api_returns_error_when_invalid_mac
+    post "/aa:bb:cc:00:11:zz", args
+    assert !last_response.ok?
+    assert_equal "Invalid MAC address: aa:bb:cc:00:11:zz", last_response.body
+  end
+
+  private
+  attr_reader :args
+
+end

--- a/test/validations_test.rb
+++ b/test/validations_test.rb
@@ -1,0 +1,55 @@
+require 'test_helper'
+require 'proxy/validations'
+
+class ProxyValidationsTest < Test::Unit::TestCase
+  include Proxy::Validations
+
+  def test_should_be_valid_mac
+    assert valid_mac?("aa:bb:cc:00:11:22")
+    assert valid_mac?("AA:bb:CC:00:11:22")
+    assert valid_mac?("aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd")
+    assert valid_mac?("AA:BB:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd")
+  end
+
+  def test_should_not_be_valid_mac
+    assert !valid_mac?("aa:bb:cc:00:11:zz")
+    assert !valid_mac?("aa:bb:cc:00:11:22:33")
+    assert !valid_mac?("aa:bb:cc:00:11")
+  end
+
+  def test_should_validate_ip
+    assert_equal "192.168.1.1", validate_ip("192.168.1.1")
+  end
+
+  def test_should_not_return_invalid_ip
+    assert_raise Error do
+      validate_ip "192.168.1"
+    end
+    assert_raise Error do
+      validate_ip "192.168.1.i"
+    end
+  end
+
+  def test_should_validate_48bit_mac
+    mac = "aa:bb:cc:00:11:22"
+    mac_upcase = "AA:bb:CC:00:11:22"
+    assert_equal mac, validate_mac(mac)
+    assert_equal mac, validate_mac(mac_upcase)
+  end
+
+  def test_should_validate_64bit_mac
+    mac = "aa:bb:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd"
+    mac_upcase = "AA:BB:cc:dd:ee:ff:00:11:22:33:44:55:66:77:88:99:aa:bb:cc:dd"
+    assert_equal mac, validate_mac(mac)
+    assert_equal mac, validate_mac(mac_upcase)
+  end
+
+  def test_should_not_return_invalid_mac
+    assert_raise Error do
+      validate_mac "aa:bb:cc:00:11:22:33"
+    end
+    assert_raise Error do
+      validate_mac "aa:bb:cc:00:11:zz"
+    end
+  end
+end


### PR DESCRIPTION
Expands validation of MAC addresses to include 64bit MAC addresses.  This is related to theforeman/foreman#1470.
