### PR TITLE
Use Enumerable#find instead of each where possible

### DIFF
--- a/modules/puppet_proxy/environment.rb
+++ b/modules/puppet_proxy/environment.rb
@@ -13,8 +13,7 @@ class Proxy::Puppet::Environment
     end
 
     def find name
-      all.each { |e| return e if e.name == name }
-      nil
+      all.find { |e| e.name == name }
     end
 
     private

--- a/modules/puppetca/puppetca.rb
+++ b/modules/puppetca/puppetca.rb
@@ -51,9 +51,8 @@ module Proxy::PuppetCa
 
       autosign = open(autosign_file, File::RDWR)
       # Check that we don't have that host already
-      found = false
-      autosign.each_line { |line| found = true if line.chomp == certname }
-      autosign.puts certname if found == false
+      found = autosign.readlines.find { |line| line.chomp == certname }
+      autosign.puts certname unless found
       autosign.close
       logger.info "Added #{certname} to autosign"
     end


### PR DESCRIPTION
Following up from #175 I found two more places where `.each` is better served by `.find`.
