### PR TITLE
Replace Kernel#open with File.open

### DIFF
--- a/modules/puppetca/puppetca.rb
+++ b/modules/puppetca/puppetca.rb
@@ -24,7 +24,7 @@ module Proxy::PuppetCa
       raise "No such file #{autosign_file}" unless File.exists?(autosign_file)
 
       found = false
-      entries = open(autosign_file, File::RDONLY).readlines.collect do |l|
+      entries = File.open(autosign_file, File::RDONLY).readlines.collect do |l|
         if l.chomp != certname
           l
         else
@@ -33,7 +33,7 @@ module Proxy::PuppetCa
         end
       end.uniq.compact
       if found
-        autosign = open(autosign_file, File::TRUNC|File::RDWR)
+        autosign = File.open(autosign_file, File::TRUNC|File::RDWR)
         autosign.write entries.join("\n")
         autosign.write "\n"
         autosign.close
@@ -49,7 +49,7 @@ module Proxy::PuppetCa
     def autosign certname
       FileUtils.touch(autosign_file) unless File.exist?(autosign_file)
 
-      autosign = open(autosign_file, File::RDWR)
+      autosign = File.open(autosign_file, File::RDWR)
       # Check that we don't have that host already
       found = false
       autosign.each_line { |line| found = true if line.chomp == certname }


### PR DESCRIPTION
Kernel#open (the global `open` method) can be used to open URLs and other interesting things. We don't want that, just the `File`s please! See http://stackoverflow.com/a/1728941/3483097 for a nice writeup.
