### PR TITLE
Tests and HTTP 404 for PR 174

### DIFF
--- a/modules/dhcp/dhcp/dhcp_api.rb
+++ b/modules/dhcp/dhcp/dhcp_api.rb
@@ -113,6 +113,8 @@ class Proxy::DhcpApi < ::Sinatra::Base
       else
         redirect "/dhcp/#{params[:network]}"
       end
+    rescue Proxy::DHCP::InvalidRecord
+      log_halt 404, "Record #{params[:network]}/#{params[:record]} not found"
     rescue Exception => e
       log_halt 400, e
     end

--- a/modules/dhcp/dhcp/subnet.rb
+++ b/modules/dhcp/dhcp/subnet.rb
@@ -181,7 +181,7 @@ module Proxy::DHCP
 
     def delete record
       if @records.delete(record).nil?
-        raise Proxy::DHCP::Error, "Removing a Proxy::DHCP Record which doesn't exist"
+        raise Proxy::DHCP::InvalidRecord, "Removing a Proxy::DHCP Record which doesn't exist"
       end
     end
 

--- a/test/dhcp/subnet_test.rb
+++ b/test/dhcp/subnet_test.rb
@@ -122,6 +122,14 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
     assert_equal @subnet.size, counter-1
   end
 
+  def test_should_raise_remove_nonexistent_record
+    counter = @subnet.size
+    assert_raise Proxy::DHCP::InvalidRecord do
+      @server.delRecord @subnet, "1.2.3.4"
+    end
+    assert_equal @subnet.size, counter
+  end
+
   def test_should_reuse_ip_if_from_same_subnet
     @subnet.stubs(:has_mac?).returns(stub(:ip => '192.168.0.10'))
     @subnet.stubs(:icmp_pingable?)


### PR DESCRIPTION
Updates PR #174 with `log_halt 404` if the record to remove is not found, and a test as suggested. @pccowboy if you want to merge-and-squash these into your PR #174 that would be great (I'll ping you directly on Monday!)
