### PR TITLE
Update the tests for Proxy::Util::CommandTask

### DIFF
--- a/lib/proxy/util.rb
+++ b/lib/proxy/util.rb
@@ -14,17 +14,21 @@ module Proxy::Util
       logger.debug "Starting task: #{cmd}"
       @task = Thread.new(cmd) do |cmd|
         begin
+          status = nil
           Open3::popen3(cmd) do |stdin,stdout,stderr,thr|
             # PIDs are not available under Ruby 1.8
-            pid = thr.nil? ? rand(9999) : thr.pid
+            pid = thr.nil? ? '(unknown)' : thr.pid
             stdout.each do |line|
               logger.debug "[#{pid}] #{line}"
             end
             stderr.each do |line|
               logger.debug "[#{pid}] #{line}"
             end
+            # In Ruby 1.8, popen3 always reports an error code of 0 in $?.
+            # In Ruby >= 1.9, call thr.value to wait for a Process::Status object.
+            status = thr.value unless thr.nil?
           end
-          $?
+          status ? status.exitstatus : $?
         ensure
           yield if block_given?
         end

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -16,10 +16,15 @@ class ProxyUtilTest < Test::Unit::TestCase
     assert_equal test_class.new.escape_for_shell("vm.test.com physical.test.com"), 'vm.test.com\ physical.test.com'
   end
 
-  def test_commandtask_with_echo_exec
-    t = Proxy::Util::CommandTask.new('echo test')
-    # ruby 1.9 seems to return nil for $? in open3
-    assert_equal t.join, RUBY_VERSION =~ /1\.8\.\d+/  ? 0 : nil
+  def test_commandtask_with_exit_0
+    t = Proxy::Util::CommandTask.new('true')
+    assert_equal t.join, 0
+  end
+
+  def test_commandtask_with_exit_1
+    t = Proxy::Util::CommandTask.new('false')
+    # In Ruby 1.8, the return code is always 0
+    assert_equal t.join, RUBY_VERSION =~ /^1\.8/ ? 0 : 1
   end
 
   def test_strict_encode64


### PR DESCRIPTION
The `wget` test was hanging for me - I'm running OS X, and `127.0.0.2` is not a default alias of localhost. I couldn't figure out why the test was using `wget` and neither could the FIXME author. So in this update, use `true` and `false` to test $? return codes 0 and 1, respectively.

That said - Ruby 1.8.7 is heading out the door. If Proxy::Util::CommandTask cannot capture $? on current versions of Ruby, that's problem!
