### PR TITLE
fixes #6522 - move request code out of chef module

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -15,6 +15,13 @@
 
 #:foreman_url: http://127.0.0.1:3000
 
+# SSL settings for client authentication against Foreman. If undefined, the values
+# from general SSL options are used instead. Mainly useful when Foreman uses
+# different certificates for its web UI and for smart-proxy requests.
+#:foreman_ssl_ca: ssl/certs/ca.pem
+#:foreman_ssl_cert: ssl/certs/fqdn.pem
+#:foreman_ssl_key: ssl/private_keys/fqdn.pem
+
 # by default smart_proxy runs in the foreground. To enable running as a daemon, uncomment 'daemon' setting
 #:daemon: true
 # Only used when 'daemon' is set to true.

--- a/modules/chef_proxy/chef_api.rb
+++ b/modules/chef_proxy/chef_api.rb
@@ -1,4 +1,4 @@
-require 'chef_proxy/chef_request'
+require 'proxy/request'
 require 'chef_proxy/authentication'
 
 module Proxy::Chef
@@ -15,13 +15,13 @@ module Proxy::Chef
 
     post "/hosts/facts" do
       Proxy::Chef::Authentication.new.authenticated(request) do |content|
-        Proxy::Chef::Facts.new.post_facts(content)
+        Proxy::HttpRequest::Facts.new.post_facts(content)
       end
     end
 
     post "/reports" do
       Proxy::Chef::Authentication.new.authenticated(request) do |content|
-        Proxy::Chef::Reports.new.post_report(content)
+        Proxy::HttpRequest::Reports.new.post_report(content)
       end
     end
   end

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -1,19 +1,17 @@
 require 'test_helper'
-require 'chef_proxy/chef_plugin'
-require 'chef_proxy/chef_request'
+require 'proxy/request'
 require 'webmock/test_unit'
 
-class ChefProxyTest < Test::Unit::TestCase
+class ProxyRequestTest < Test::Unit::TestCase
   def setup
     @foreman_url = 'https://foreman.example.com'
     Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
-    Proxy::Chef::Plugin::settings.stubs(:chef_authenticate_nodes).returns(false)
   end
 
   def test_post_facts
     facts = {'fact' => "sample"}
     stub_request(:post, @foreman_url+'/api/hosts/facts')
-    result = Proxy::Chef::Facts.new.post_facts(facts)
+    result = Proxy::HttpRequest::Facts.new.post_facts(facts)
 
     assert(result.is_a? Net::HTTPOK)
   end
@@ -21,7 +19,7 @@ class ChefProxyTest < Test::Unit::TestCase
   def test_post_reports
     report = {'report' => "sample"}
     stub_request(:post, @foreman_url+'/api/reports')
-    result = Proxy::Chef::Reports.new.post_report(report)
+    result = Proxy::HttpRequest::Reports.new.post_report(report)
 
     assert(result.is_a? Net::HTTPOK)
   end


### PR DESCRIPTION
The patch also removes foreman_ssl_ca, foreman_ssl_cert and
foreman_ssl_key config options as they don't appear to be used or
documented. Existing ssl_\* options are used instead.

(Please let me know if you'd prefer to track this change in separate ticket.)
