### PR TITLE
added support for testing of plugins

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/packagetask'
 require 'rdoc/task'
-require 'rubygems/package_task'
 load 'tasks/proxy_tasks.rake'
 load 'tasks/jenkins.rake'
 load 'tasks/pkg.rake'
@@ -37,31 +35,4 @@ Rake::RDocTask.new(:rdoc) do |rdoc|
   rdoc.options << '--line-numbers' << '--inline-source'
   rdoc.rdoc_files.include('README')
   rdoc.rdoc_files.include('lib/**/*.rb')
-end
-
-spec = Gem::Specification.new do |s|
-  s.name = "foreman_proxy"
-  s.version = "1.1RC1"
-  s.author = "Ohad Levy"
-  s.email = "ohadlevy@gmail.com"
-  s.homepage = "http://theforeman.org/"
-  s.platform = Gem::Platform::RUBY
-  s.summary = "Foreman Proxy Agent, manage remote DHCP, DNS, TFTP and Puppet servers"
-  s.files = FileList["{bin,public,config,views,lib}/**/*"].to_a
-  s.default_executable = 'bin/smart_proxy.rb'
-  s.require_path = "lib"
-  s.test_files = FileList["{test}/**/*test.rb"].to_a
-  s.has_rdoc = true
-  s.extra_rdoc_files = ["README"]
-  s.add_dependency 'json'
-  s.add_dependency 'sinatra'
-  s.rubyforge_project = 'rake'
-  s.description = <<EOF
-Foreman Proxy is used via The Foreman Project, it allows Foreman to manage
-Remote DHCP, DNS, TFTP and Puppet servers via a REST API
-EOF
-end
-
-Gem::PackageTask.new(spec) do |pkg|
-    pkg.need_tar_gz = true
 end

--- a/lib/smart_proxy_for_testing.rb
+++ b/lib/smart_proxy_for_testing.rb
@@ -1,0 +1,20 @@
+require 'proxy'
+require 'checks'
+require 'proxy/log'
+require 'proxy/settings'
+require 'proxy/settings/plugin'
+require 'proxy/settings/global'
+require 'proxy/util'
+require 'proxy/http_downloads'
+require 'proxy/helpers'
+require 'proxy/plugin'
+require 'proxy/error'
+
+Proxy::SETTINGS = ::Proxy::Settings::Global.new(:log_file => './logs/test.log', :log_level => 'DEBUG')
+Proxy::VERSION = File.read(File.join(File.dirname(__FILE__), '../VERSION')).chomp
+
+class ::Proxy::Plugin
+  def self.load_test_settings(a_hash)
+    @settings = ::Proxy::Settings::Plugin.new(plugin_default_settings, a_hash)
+  end
+end

--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -1,0 +1,27 @@
+require 'rake'
+
+spec = Gem::Specification.new do |s|
+  s.name = "smart_proxy"
+  s.version = File.read(File.join(File.dirname(__FILE__), 'VERSION')).chomp.gsub('-', '.')
+  s.author = "Ohad Levy"
+  s.email = "ohadlevy@gmail.com"
+  s.homepage = "http://theforeman.org/"
+  s.platform = Gem::Platform::RUBY
+  s.summary = "Foreman Proxy Agent, manage remote DHCP, DNS, TFTP and Puppet servers"
+  s.files = FileList["{bin,public,config,views,lib,modules}/**/*", "VERSION"].to_a
+  s.default_executable = 'bin/smart_proxy.rb'
+  s.require_paths = ["lib", "modules"]
+  s.test_files = FileList["{test}/**/*test.rb"].to_a
+  s.license = 'GPLv3'
+  s.has_rdoc = true
+  s.extra_rdoc_files = ["README"]
+  s.add_dependency 'json', '~> 1.8'
+  s.add_dependency 'rack', '~> 1.5'
+  s.add_dependency 'sinatra', '~> 1.4'
+  s.rubyforge_project = 'rake'
+  s.description = <<EOF
+Foreman Proxy is used via The Foreman Project, it allows Foreman to manage
+Remote DHCP, DNS, TFTP and Puppet servers via a REST API
+EOF
+end
+

--- a/test/fixtures/test_settings.yml
+++ b/test/fixtures/test_settings.yml
@@ -1,4 +1,0 @@
----
-:log_file: './logs/test.log'
-:log_level: DEBUG
-

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,27 +5,7 @@ $: << File.join(File.dirname(__FILE__), '..', 'modules')
 logdir = File.join(File.dirname(__FILE__), '..', 'logs')
 FileUtils.mkdir_p(logdir) unless File.exists?(logdir)
 
-require 'proxy'
-require 'checks'
-require 'proxy/log'
-require 'proxy/settings'
-require 'proxy/settings/plugin'
-require 'proxy/settings/global'
-require 'proxy/util'
-require 'proxy/http_downloads'
-require 'proxy/helpers'
-require 'proxy/plugin'
-require 'proxy/error'
-
-
 require "mocha/setup"
 require "rack/test"
 
-Proxy::SETTINGS = Proxy::Settings.load_global_settings(File.expand_path("fixtures/test_settings.yml", File.dirname(__FILE__)))
-Proxy::VERSION = File.read(File.join(File.dirname(__FILE__), '../VERSION')).chomp
-
-class ::Proxy::Plugin
-  def self.load_test_settings(a_hash)
-    @settings = ::Proxy::Settings::Plugin.new(plugin_default_settings, a_hash)
-  end
-end
+require 'smart_proxy_for_testing'


### PR DESCRIPTION
The idea is to add 'smart_proxy' as a development dependency for a plugin, and then `require 'smart_proxy_for_testing'` in tests. gemspec may need a bit more love, esp. around dependencies though.
