### PR TITLE
Updated tests for Proxy::Puppet::Runner

### DIFF
--- a/test/puppet/runner_test.rb
+++ b/test/puppet/runner_test.rb
@@ -3,11 +3,20 @@ require 'puppet_proxy/runner'
 
 class RunnerTest < Test::Unit::TestCase
   def setup
-    @runner = Proxy::Puppet::Runner.new({})
+    @runner = Proxy::Puppet::Runner.new(:nodes => ['foo', 'bar', 'foo bar'])
   end
 
-  def test_popen
-    @runner.send(:popen, ["echo", "blah"])
-    assert_equal 0, $?.exitstatus
+  def test_shell_escaped_nodes
+    assert_equal ['foo', 'bar', 'foo\ bar'], @runner.send(:shell_escaped_nodes)
+  end
+
+  def test_shell_command_true
+    success = @runner.send(:shell_command, ['true'])
+    assert_equal true, success
+  end
+
+  def test_shell_command_false
+    success = @runner.send(:shell_command, ['false'])
+    assert_equal false, success
   end
 end


### PR DESCRIPTION
The popen test was looking at `$?`, but it wasn't set by the method under test. Testing Ruby's popen method isn't terribly helpful, it's a built-in.

This replaces the popen test with a test for the shell_command wrapper and adds tests for the other methods in Proxy::Puppet::Runner.
