### PR TITLE
Fixes #6689 - Allow nil mac address for TFTP API calls that do not require a MAC

### DIFF
--- a/modules/tftp/tftp_api.rb
+++ b/modules/tftp/tftp_api.rb
@@ -10,7 +10,7 @@ module Proxy::TFTP
     helpers do
       def instantiate variant, mac=nil
         # Filenames must end in a hex representation of a mac address but only if mac is not empty
-        log_halt 403, "Invalid MAC address: #{mac}"                  unless valid_mac?(mac)
+        log_halt 403, "Invalid MAC address: #{mac}"                  unless valid_mac?(mac) or mac.nil?
         log_halt 403, "Unrecognized pxeboot config type: #{variant}" unless defined? variant.capitalize
         eval "Proxy::TFTP::#{variant.capitalize}.new"
       end

--- a/test/tftp/tftp_api_test.rb
+++ b/test/tftp/tftp_api_test.rb
@@ -52,6 +52,12 @@ class TftpApiTest < Test::Unit::TestCase
     assert_equal "Invalid MAC address: aa:bb:cc:00:11:zz", last_response.body
   end
 
+  def test_api_can_create_default
+    params = { :menu => "foobar" }
+    Proxy::TFTP::Syslinux.any_instance.expects(:create_default).with(params[:menu])
+    post "/create_default", params
+  end
+
   private
   attr_reader :args
 


### PR DESCRIPTION
This fixes a regression from #172 which broke TFTP API calls that did not require a MAC address, such as `/create_default`.
