### PR TITLE
Fixes #6790: Restrict ci_reporter gem to less than 2.0.0 to fix CI.

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -3,7 +3,7 @@ group :test do
   gem 'rake'
   gem 'rack-test'
   gem 'single_test'
-  gem 'ci_reporter', '>= 1.6.3'
+  gem 'ci_reporter', '>= 1.6.3', "< 2.0.0", :require => false
   gem 'rdoc'
   gem 'minitest', '~> 4.7', :platforms => :ruby_19
   gem 'webmock'


### PR DESCRIPTION
Same as https://github.com/theforeman/foreman/blob/ec0912fc73a276a988128e987203ad5117b97998
