### PR TITLE
implements #6788 puppet scanner filter support

### DIFF
--- a/config/settings.d/puppet.yml.example
+++ b/config/settings.d/puppet.yml.example
@@ -37,3 +37,13 @@
 # Override use of Puppet's API to list environments, by default it will use only if
 # environmentpath is given in puppet.conf, else will look for environments in puppet.conf
 #:puppet_use_environment_api: true
+
+# Filter puppet class import and include only modules matching the
+# puppet_include_modules expression
+#:puppet_include_modules: "role_*"
+# Filter puppet class import and exclude directories from module path listed
+# in puppet_ignore_modulefolder.
+#:puppet_ignore_modulefolder:
+# - services
+# - modules
+

--- a/modules/puppet_proxy/class_scanner.rb
+++ b/modules/puppet_proxy/class_scanner.rb
@@ -9,9 +9,17 @@ module Proxy::Puppet
 
         parser = Puppet::Parser::Parser.new Puppet::Node::Environment.new
 
-        Dir.glob("#{directory}/*/manifests/**/*.pp").map do |filename|
-          scan_manifest File.read(filename), parser, filename
-        end.compact.flatten
+        # include modules by their name_schema
+        if Proxy::Puppet::Plugin.settings.puppet_include_modules
+          Dir.glob("#{directory}/#{Proxy::Puppet::Plugin.settings.puppet_include_modules}/manifests/**/*.pp").map do |filename|
+            scan_manifest File.read(filename), parser, filename
+          end.compact.flatten
+        else
+          Dir.glob("#{directory}/*/manifests/**/*.pp").map do |filename|
+            scan_manifest File.read(filename), parser, filename
+          end.compact.flatten
+        end
+
       end
 
       def scan_manifest manifest, parser, filename = ''

--- a/modules/puppet_proxy/class_scanner_eparser.rb
+++ b/modules/puppet_proxy/class_scanner_eparser.rb
@@ -12,9 +12,17 @@ if Puppet::PUPPETVERSION.to_f >= 3.2
         def scan_directory directory
 
           parser = Puppet::Pops::Parser::Parser.new
-          Dir.glob("#{directory}/*/manifests/**/*.pp").map do |filename|
-            scan_manifest File.read(filename), parser, filename
-          end.compact.flatten
+
+          # include modules by their name_schema
+          if Proxy::Puppet::Plugin.settings.puppet_include_modules
+            Dir.glob("#{directory}/#{Proxy::Puppet::Plugin.settings.puppet_include_modules}/manifests/**/*.pp").map do |filename|
+              scan_manifest File.read(filename), parser, filename
+            end.compact.flatten
+          else
+            Dir.glob("#{directory}/*/manifests/**/*.pp").map do |filename|
+              scan_manifest File.read(filename), parser, filename
+            end.compact.flatten
+          end
         end
 
         def scan_manifest manifest, parser, filename = ''

--- a/modules/puppet_proxy/environment.rb
+++ b/modules/puppet_proxy/environment.rb
@@ -88,6 +88,17 @@ class Proxy::Puppet::Environment
         dynamicpath = modulepath.split(":")
 
         modulepath.split(":").each do |base_dir|
+          # remove excluded modulefolders
+          if Proxy::Puppet::Plugin.settings.puppet_ignore_modulefolder
+            Proxy::Puppet::Plugin.settings.puppet_ignore_modulefolder.each do |exclude_folder|
+              if base_dir.include?(exclude_folder)
+                staticpath.delete base_dir
+                dynamicpath.delete base_dir
+              end
+            end
+          end
+
+          # remove dynamic paths from static paths an vice versa
           if base_dir.include?("$environment")
             # remove this entry from the static paths
             staticpath.delete base_dir


### PR DESCRIPTION
implements #6788 puppet scanner filter support (kudos to Daniel Bäurer, too)

With

```
:puppet_include_modules: "role_*"
```

only modules following a certain naming schema will be included, the module path will be assembled like this:

$MODULEPATH/puppet_include_modules/manifests/*.pp

With

```
:puppet_ignore_modulefolder:
 - services
 - modules
```

directories in the Modulepath will be excluded:

if $MODULEPATH contains services or modules remove it from list to scan for puppet
modules
