### PR TITLE
fixes #6790 - pin ci_reporter to pre-2.0 for compatibility

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -3,7 +3,7 @@ group :test do
   gem 'rake'
   gem 'rack-test'
   gem 'single_test'
-  gem 'ci_reporter', '>= 1.6.3'
+  gem 'ci_reporter', '>= 1.6.3', '< 2.0.0'
   gem 'rdoc'
   gem 'minitest', '~> 4.7', :platforms => :ruby_19
   gem 'webmock'


### PR DESCRIPTION
Mirrors https://github.com/theforeman/foreman/pull/1617
