### PR TITLE
fixes #7015 - to_json passes options through correctly, remove array wrapping

### DIFF
--- a/modules/dhcp/dhcp/record/lease.rb
+++ b/modules/dhcp/dhcp/record/lease.rb
@@ -15,7 +15,7 @@ module Proxy::DHCP
     end
 
     def to_json(*options)
-      Hash[[:ip, :mac, :starts, :ends, :state].map{|s| [s, send(s)]}].to_json(options)
+      Hash[[:ip, :mac, :starts, :ends, :state].map{|s| [s, send(s)]}].to_json(*options)
     end
 
   end

--- a/modules/dhcp/dhcp/record/reservation.rb
+++ b/modules/dhcp/dhcp/record/reservation.rb
@@ -17,7 +17,7 @@ module Proxy::DHCP
     end
 
     def to_json(*options)
-      Hash[[:hostname, :ip, :mac].map{|s| [s, send(s)]}].to_json(options)
+      Hash[[:hostname, :ip, :mac].map{|s| [s, send(s)]}].to_json(*options)
     end
 
   end


### PR DESCRIPTION
The update of ffi-yajl triggers this as it starts checking for something in the options hash, but the bug is in our code which had `{}` passed in as options, but then passed `[{}]` into the next to_json call.

This is a test blocker, again.
