### PR TITLE
Refs #4464 - Prefer selinux wrappers

### DIFF
--- a/modules/puppetca/puppetca_main.rb
+++ b/modules/puppetca/puppetca_main.rb
@@ -102,7 +102,8 @@ module Proxy::PuppetCa
         raise "SSL/CA unavailable on this machine"
       end
 
-      default_path = ["/opt/puppet/bin", "/opt/puppet/sbin"]
+      # prefer selinux wrappers or enterprise binaries
+      default_path = ["/usr/bin/start-puppet-ca", "/usr/bin/puppetca", "/opt/puppet/bin", "/opt/puppet/sbin"]
 
       # puppetca is the old method of using puppet cert which is new in puppet 2.6
       if Puppet::PUPPETVERSION.to_i < 3


### PR DESCRIPTION
This is needed to start "puppet ca" command in the correct puppetca_t domain.

RHEL6 has `/usr/bin/puppetca`

RHEL7 currently has no such wrapper and I will be pushing fix to EPEL7 and
Fedora with wrapper (they are named start-puppet-xyz so I will follow this
convention)

Puppet Enterprise is a question mark for now since there are no wrappers - no
SELinux support?
