### PR TITLE
Allows chef node and client deletion

### DIFF
--- a/bundler.d/chef.rb
+++ b/bundler.d/chef.rb
@@ -1,3 +1,4 @@
 group :chef do
   gem 'chef', ">= 11.6.2"
+  gem 'chef-api'
 end

--- a/config/settings.d/chef.yml.example
+++ b/config/settings.d/chef.yml.example
@@ -2,7 +2,22 @@
 :enabled: false
 # :chef_authenticate_nodes: true
 # :chef_server_url: "https://chef.example.net"
-# smart-proxy client node needs to have some admin right on chef-server
+
+# smart-proxy client node needs to have admin rights on chef-server
 # in order to retrive all nodes public keys
 # :chef_smartproxy_clientname: 'host.example.net'
 # :chef_smartproxy_privatekey: '/etc/chef/client.pem'
+
+# by default ssl verification of request to you chef server is enabled,
+# you're supposed to install CA certificate yourself
+# this usually consist of two steps
+#   download the CA cert to /etc/pki/tls/certs/, e.g. ca-cert-root.pem
+#   ln -s ca-cert-root.pem $( openssl x509 -hash -noout -in ca-cert-root.pem )".0"
+# you can use self-signed certificate (see below) or disable verification
+# which is definitely not recommended for production
+# :chef_ssl_verify: true
+
+# if you're using self-signed certificate for you chef server, you can specify
+# the certificate file here or leave it empty (default)
+# :chef_ssl_pem_file: '/etc/chef/chef.example.com.pem'
+

--- a/modules/chef_proxy/chef_api.rb
+++ b/modules/chef_proxy/chef_api.rb
@@ -1,5 +1,7 @@
 require 'proxy/request'
 require 'chef_proxy/authentication'
+require 'chef_proxy/resources/node'
+require 'chef_proxy/resources/client'
 
 module Proxy::Chef
   class Api < ::Sinatra::Base
@@ -15,15 +17,59 @@ module Proxy::Chef
     end
 
     post "/hosts/facts" do
+      logger.debug 'facts upload request received'
       Proxy::Chef::Authentication.new.authenticated(request) do |content|
         Proxy::HttpRequest::Facts.new.post_facts(content)
       end
     end
 
     post "/reports" do
+      logger.debug 'report upload request received'
       Proxy::Chef::Authentication.new.authenticated(request) do |content|
         Proxy::HttpRequest::Reports.new.post_report(content)
       end
+    end
+
+    get "/chefproxy/nodes/:fqdn" do
+      logger.debug "Showing node #{params[:fqdn]}"
+
+      content_type :json
+      if (node = Proxy::Chef::Resources::Node.new.show(params[:fqdn]))
+        node.to_json
+      else
+        log_halt 404, "Node #{params[:fqdn]} not found"
+      end
+    end
+
+    get "/chefproxy/clients/:fqdn" do
+      logger.debug "Showing client #{params[:fqdn]}"
+
+      content_type :json
+      if (node = Proxy::Chef::Resources::Client.new.show(params[:fqdn]))
+        node.to_json
+      else
+        log_halt 404, "Client #{params[:fqdn]} not found"
+      end
+    end
+
+    delete "/chefproxy/nodes/:fqdn" do
+      logger.debug "Starting deletion of node #{params[:fqdn]}"
+
+      result = Proxy::Chef::Resources::Node.new.delete(params[:fqdn])
+      log_halt 400, "Node #{params[:fqdn]} could not be deleteded" unless result
+
+      logger.debug "Node #{params[:fqdn]} deleted"
+      { :result => result }.to_json
+    end
+
+    delete "/chefproxy/clients/:fqdn" do
+      logger.debug "Starting deletion of client #{params[:fqdn]}"
+
+      result = Proxy::Chef::Resources::Client.new.delete(params[:fqdn])
+      log_halt 400, "Client #{params[:fqdn]} could not be deleted" unless result
+
+      logger.debug "Client #{params[:fqdn]} deleted"
+      { :result => result }.to_json
     end
   end
 end

--- a/modules/chef_proxy/chef_plugin.rb
+++ b/modules/chef_proxy/chef_plugin.rb
@@ -4,6 +4,10 @@ module Proxy::Chef
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
   
     settings_file "chef.yml"
+    default_settings :chef_authenticate_nodes => true,
+                     :chef_smartproxy_privatekey => '/etc/chef/client.pem',
+                     :chef_ssl_verify => true,
+                     :chef_ssl_pem_file => nil
     plugin :chefproxy, ::Proxy::VERSION
   end
 end

--- a/modules/chef_proxy/resources/base.rb
+++ b/modules/chef_proxy/resources/base.rb
@@ -1,0 +1,20 @@
+require 'chef-api'
+
+module Proxy::Chef
+  module Resources
+    class Base
+      def initialize
+        @connection = ChefAPI::Connection.new(
+            :endpoint => Proxy::Chef::Plugin.settings.chef_server_url,
+            :client => Proxy::Chef::Plugin.settings.chef_smartproxy_clientname,
+            :key => Proxy::Chef::Plugin.settings.chef_smartproxy_privatekey,
+        )
+        @connection.ssl_verify = Proxy::Chef::Plugin.settings.chef_ssl_verify
+        self_signed = Proxy::Chef::Plugin.settings.chef_ssl_pem_file
+        if !self_signed.nil? && !self_signed.empty?
+          @connection.ssl_pem_file = self_signed
+        end
+      end
+    end
+  end
+end

--- a/modules/chef_proxy/resources/client.rb
+++ b/modules/chef_proxy/resources/client.rb
@@ -1,0 +1,18 @@
+require 'chef_proxy/resources/base'
+
+module Proxy::Chef::Resources
+  class Client < Base
+    def initialize
+      super
+      @base = @connection.clients
+    end
+
+    def delete(fqdn)
+       @base.delete(fqdn)
+    end
+
+    def show(fqdn)
+      @base.fetch(fqdn)
+    end
+  end
+end

--- a/modules/chef_proxy/resources/node.rb
+++ b/modules/chef_proxy/resources/node.rb
@@ -1,0 +1,18 @@
+require 'chef_proxy/resources/base'
+
+module Proxy::Chef::Resources
+  class Node < Base
+    def initialize
+      super
+      @base = @connection.nodes
+    end
+
+    def delete(fqdn)
+      @base.delete(fqdn)
+    end
+
+    def show(fqdn)
+      @base.fetch(fqdn)
+    end
+  end
+end


### PR DESCRIPTION
These changes are required for new foreman-chef feature allowing user to delete nodes and clients (host certificates in puppet terminology) upon host deletion in foreman. I'm starting to wonder whether we should extract chef into a separate proxy plugin soon.
