### PR TITLE
Fixes #7352 - Missing DNS record should return 404 not 400 for DELETE

### DIFF
--- a/lib/proxy/virsh.rb
+++ b/lib/proxy/virsh.rb
@@ -17,12 +17,12 @@ module Proxy::Virsh
         return e.parent.attributes["ip"]
       end
     end
-    raise Proxy::DNS::Error.new("Cannot find DNS entry for #{host}")
+    raise Proxy::Dns::NotFound.new("Cannot find DNS entry for #{host}")
   rescue Exception => e
-    msg = "DNS virsh provider error: unable to retrive virsh info: #{e}"
+    msg = "DNS virsh provider error: unable to retrieve virsh info: #{e}"
     logger.error msg
     logger.debug xml if defined?(xml)
-    raise Proxy::DNS::Error, msg
+    raise Proxy::Dns::Error, msg
   end
 
   def virsh *params
@@ -51,7 +51,7 @@ module Proxy::Virsh
       "--xml", "'<host ip=\"#{ip}\"><hostname>#{hostname}</hostname></host>'",
       "--live", "--config"
   rescue Exception => e
-    raise Proxy::DNS::Error, "Failed to update DNS: #{e}"
+    raise Proxy::Dns::Error, "Failed to update DNS: #{e}"
   end
 
   def virsh_update_dhcp command, mac, ip, name

--- a/modules/dns/dns.rb
+++ b/modules/dns/dns.rb
@@ -2,6 +2,7 @@ require 'dns/dns_plugin'
 
 module Proxy::Dns
   class Error < RuntimeError; end
+  class NotFound < RuntimeError; end
   class Collision < RuntimeError; end
   class Record
     include Proxy::Log

--- a/modules/dns/dns_api.rb
+++ b/modules/dns/dns_api.rb
@@ -63,6 +63,8 @@ module Proxy::Dns
       begin
         dns_setup({:fqdn => fqdn, :value => value, :type => type})
         @server.remove
+      rescue Proxy::Dns::NotFound => e
+        log_halt 404, e
       rescue => e
         log_halt 400, e
       end


### PR DESCRIPTION
If DNS entry is not found, return 404
