### PR TITLE
fixes #7822 - forbid HTTPS requests with no client SSL certificate

### DIFF
--- a/lib/sinatra/ssl_client_verification.rb
+++ b/lib/sinatra/ssl_client_verification.rb
@@ -1,0 +1,13 @@
+require 'sinatra/base'
+
+::Sinatra::Base.helpers ::Proxy::Helpers
+::Sinatra::Base.helpers ::Proxy::Log
+::Sinatra::Base.before do
+  if ['yes', 'on', '1'].include? request.env['HTTPS'].to_s
+    if request.env['SSL_CLIENT_CERT'].to_s.empty?
+      log_halt 403, "No client SSL certificate supplied"
+    end
+  else
+    logger.debug('require_ssl_client_verification: skipping, non-HTTPS request')
+  end
+end

--- a/lib/smart_proxy.rb
+++ b/lib/smart_proxy.rb
@@ -24,6 +24,7 @@ Proxy::BundlerHelper.require_groups(:default)
 
 require 'rack-patch' if Rack.release < "1.3"
 require 'sinatra-patch'
+require 'sinatra/ssl_client_verification'
 require 'sinatra/trusted_hosts'
 
 module Proxy

--- a/lib/smart_proxy_for_testing.rb
+++ b/lib/smart_proxy_for_testing.rb
@@ -11,6 +11,7 @@ require 'proxy/plugin'
 require 'proxy/error'
 
 require 'sinatra/base'
+require 'sinatra/ssl_client_verification'
 require 'sinatra/trusted_hosts'
 
 Proxy::SETTINGS = ::Proxy::Settings::Global.new(:log_file => './logs/test.log', :log_level => 'DEBUG')

--- a/test/sinatra/ssl_client_verification_test.rb
+++ b/test/sinatra/ssl_client_verification_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+require 'json'
+require 'sinatra/base'
+
+ENV['RACK_ENV'] = 'test'
+
+class SSLClientVerificationTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    TestApp.new
+  end
+
+  def test_http
+    get '/test'
+    assert last_response.ok?
+  end
+
+  ['yes', 'on', '1'].each do |yes|
+    define_method("test_https_no_cert_https_#{yes}") do
+      get '/test', {}, {'HTTPS' => yes}
+      assert last_response.forbidden?
+    end
+  end
+
+  def test_https_cert
+    get '/test', {}, {'HTTPS' => 'on', 'SSL_CLIENT_CERT' => '...'}
+    assert last_response.ok?
+  end
+
+  private
+
+  class TestApp < ::Sinatra::Base
+    get '/test' do
+      'success'
+    end
+  end
+end


### PR DESCRIPTION
Please review as a priority, and test heavily.  It seems that OpenSSL correctly refuses connections when the certificate presented isn't trusted by the CA that the server is using (note, we don't have separate client/server CAs), and the problem is only when no client cert is presented.

I can't see a way to check that relying on OpenSSL for bad verification is always solid.  The closest I've found is that the socket that WEBrick sees has an OpenSSL verification result attached (http://ruby-doc.org/stdlib-1.9.3/libdoc/openssl/rdoc/OpenSSL/SSL/SSLSocket.html) but I can't see a way to get at that.  In any case, it only seems to reach the smart proxy when there's either no cert or it validates and in both cases the verify_result was "OK".

Lastly, I'm looking at more tests in the 7822-ssl-verify branch which test Proxy::Launcher's https_app by spinning up the rack/WEBrick app and then make requests, but this will take more refactoring.  I will probably follow up with this in another ticket, and only to develop (not 1.6 etc).

No CVE assigned yet - will add it to commit message before it's merged.
