### PR TITLE
Fixes #7860 - added puppetssh_wait option

### DIFF
--- a/config/settings.d/puppet.yml.example
+++ b/config/settings.d/puppet.yml.example
@@ -20,6 +20,10 @@
 :puppetssh_sudo: false
 # the command which will be sent to the host
 :puppetssh_command: /usr/bin/puppet agent --onetime --no-usecacheonfailure
+# wait for the command to finish (and capture exit code), or detach process and return 0
+# Note: enabling this option causes the Foreman web UI to be blocked when executing puppetrun,
+# with timeout from the Browser and/or Foreman's REST client after 60 seconds.
+:puppetssh_wait: false
 # With which user should the proxy connect
 #:puppetssh_user: root
 #:puppetssh_keyfile: /etc/foreman-proxy/id_rsa

--- a/modules/puppet_proxy/puppet_ssh.rb
+++ b/modules/puppet_proxy/puppet_ssh.rb
@@ -21,7 +21,7 @@ class Proxy::Puppet::PuppetSSH < Proxy::Puppet::Runner
 
     ssh_command = escape_for_shell(Proxy::Puppet::Plugin.settings.puppetssh_command || 'puppet agent --onetime --no-usecacheonfailure')
     nodes.each do |node|
-      shell_command(cmd + [escape_for_shell(node), ssh_command], false)
+      shell_command(cmd + [escape_for_shell(node), ssh_command], Proxy::Puppet::Plugin.settings.puppetssh_wait || false)
     end
   end
 end

--- a/test/puppet/puppetssh_test.rb
+++ b/test/puppet/puppetssh_test.rb
@@ -72,6 +72,17 @@ class PuppetSshTest < Test::Unit::TestCase
     assert @puppetssh.run
   end
 
+  def test_command_line_with_puppetssh_wait
+    Proxy::Puppet::Plugin.settings.stubs(:puppetssh_command).returns('/bin/true')
+    Proxy::Puppet::Plugin.settings.stubs(:puppetssh_wait).returns(true)
+    @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
+    @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
+
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host1", "/bin/true"], true).returns(true)
+    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host2", "/bin/true"], true).returns(true)
+    assert @puppetssh.run
+  end
+
   def test_missing_sudo
     Proxy::Puppet::Plugin.settings.stubs(:puppetssh_sudo).returns(true)
     @puppetssh.stubs(:which).with("sudo", anything).returns(false)


### PR DESCRIPTION
Little history: we're implementing a deployment pipeline in Jenkins using The Foreman APIv2 and puppet. The pipeline is currently broken at the point where we execute a puppet run via Foreman API in a deployment job and directly trigger the webtests job. At that time puppet is still busy updating the deployment.

Currently the puppetssh command is detached followed by a return 0. Waiting for the command to finish fixes our pipeline "race condition".

This PR adds a new config option for puppetssh to make this configurable, defaulting to false (so, no waiting, no change from previous behaviour).
