### PR TITLE
Fixes #7859 - puppetssh run works on Ruby 1.9+

### DIFF
--- a/modules/puppet_proxy/puppet_ssh.rb
+++ b/modules/puppet_proxy/puppet_ssh.rb
@@ -19,7 +19,8 @@ class Proxy::Puppet::PuppetSSH < Proxy::Puppet::Runner
       return false
     end
 
-    ssh_command = escape_for_shell(Proxy::Puppet::Plugin.settings.puppetssh_command || 'puppet agent --onetime --no-usecacheonfailure')
+    ssh_command = Proxy::Puppet::Plugin.settings.puppetssh_command || 'puppet agent --onetime --no-usecacheonfailure'
+    ssh_command = escape_for_shell(ssh_command) if RUBY_VERSION <= '1.8.7'
     nodes.each do |node|
       shell_command(cmd + [escape_for_shell(node), ssh_command], false)
     end

--- a/modules/puppet_proxy/runner.rb
+++ b/modules/puppet_proxy/runner.rb
@@ -32,7 +32,7 @@ module Proxy::Puppet
 
     def popen(cmd)
       # 1.8.7 note: this assumes that cli options are space-separated
-      cmd = cmd.join(' ') unless RUBY_VERSION > '1.8.7'
+      cmd = cmd.join(' ') if RUBY_VERSION <= '1.8.7'
       logger.debug("about to execute: #{cmd}")
       IO.popen(cmd)
     end

--- a/test/puppet/puppetssh_test.rb
+++ b/test/puppet/puppetssh_test.rb
@@ -11,8 +11,19 @@ class PuppetSshTest < Test::Unit::TestCase
     @puppetssh.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
     @puppetssh.stubs(:which).with("ssh", anything).returns("/usr/bin/ssh")
 
-    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host1", "puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"], false).returns(true)
-    @puppetssh.expects(:shell_command).with(["/usr/bin/ssh", "host2", "puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"], false).returns(true)
+    command = if RUBY_VERSION <= '1.8.7'
+                "puppet\\ agent\\ --onetime\\ --no-usecacheonfailure"
+              else
+                "puppet agent --onetime --no-usecacheonfailure"
+              end
+    @puppetssh.
+        expects(:shell_command).
+        with(["/usr/bin/ssh", "host1", command], false).
+        returns(true)
+    @puppetssh.
+        expects(:shell_command).
+        with(["/usr/bin/ssh", "host2", command], false).
+        returns(true)
     assert @puppetssh.run
   end
 


### PR DESCRIPTION
This replaces Petr's patch: https://github.com/theforeman/smart-proxy/pull/163

Please test this on 1.8.7 as well
