### PR TITLE
Set default modulepath to '/etc/puppet/modules:/usr/share/puppet/modules'

### DIFF
--- a/modules/puppet_proxy/environment.rb
+++ b/modules/puppet_proxy/environment.rb
@@ -58,7 +58,7 @@ class Proxy::Puppet::Environment
       end
       if env.values.compact.size == 0
         # fall back to defaults - we probably don't use environments
-        env[:production] = conf[:main][:modulepath] || conf[:master][:modulepath] || '/etc/puppet/modules'
+        env[:production] = conf[:main][:modulepath] || conf[:master][:modulepath] || '/etc/puppet/modules:/usr/share/puppet/modules'
         logger.warn "No environments found - falling back to defaults (production - #{env[:production]})"
       end
       if env.size == 1 && env.keys.first == :master && !env.values.first.include?('$environment')


### PR DESCRIPTION
When I setted up puppetmaster by [theforeman/puppet module](https://forge.puppetlabs.com/theforeman/puppet), I got default puppetmaster configuration without _environments_ (there is always _production_ enviromment by default).

As I can see, the Linux distributors placed packaged puppet modules in _/usr/share/puppet/modules/_ directory.

But _smart-proxy_ search modules in _/etc/puppet/modules_ only by default.

It may be usefull to add _/usr/share/puppet/modules/_ into default search path.
