### PR TITLE
Fixes #8006 - added STDOUT proxy log option

### DIFF
--- a/lib/proxy/log.rb
+++ b/lib/proxy/log.rb
@@ -11,8 +11,13 @@ module Proxy
     end
 
     def self.logger
-      # We keep the last 6 10MB log files
-      logger = ::Logger.new(::Proxy::SETTINGS.log_file, 6, 1024*1024*10)
+      log_file = ::Proxy::SETTINGS.log_file
+      if log_file.upcase == 'STDOUT'
+        logger = ::Logger.new(STDOUT)
+      else
+        # We keep the last 6 10MB log files
+        logger = ::Logger.new(log_file, 6, 1024*1024*10)
+      end
       logger.level = ::Logger.const_get(::Proxy::SETTINGS.log_level.upcase)
       logger
     end


### PR DESCRIPTION
Although we have it documented in our example file, this was never working:

```
```

Although one can set this to `/dev/stdout`, this does not work on foreman
discovery image under systemd environment because stdout cannot be reopened
there (Permission error). I would like have the possibility to setup STDOUT
this way, because I want to capture the output into systemd journal in the
discovery image environment.

By default, systemd captures stdout/stderr and adds entries to the journal
under the foreman-proxy tag. Therefore on Fedoras and RHEL7+ we can perhaps
check "proper syslog support" for foreman-proxy as well.
