### PR TITLE
Refs #8267 - pass template_url in call to foreman

### DIFF
--- a/config/settings.d/templates.yml.example
+++ b/config/settings.d/templates.yml.example
@@ -5,10 +5,16 @@
 # This lets the plugin know how to obtain the templates from foreman.
 
 # This allows the proxy to define how hosts that are being provisioned where to
-# obtain the templates from.
+# obtain the templates from. Most installers don't support https, so it's recommended
+# to enable an http port listener in the main config file too, and use it in
+# the url below
+#
+# :template_url is the URL the host should use to contact the proxy for a template.
 # The default protocol is http on port 80 unless otherwise specified in the url.
 # Examples:
-# smart-proxy.example.com:8080
-# https://smart-proxy.example.com
-# http://1.2.3.4:3000
-#:template_url: https://smart-proxy.example.com:8443
+# https://1.2.3.4:8443            # default proxy https port
+# http://1.2.3.4:8000             # default proxy http port
+# https://smart-proxy.example.com # assumes port 443
+# http://smart-proxy.example.com  # assumes port 80
+# smart-proxy.example.com:8080    # assumes http
+#:template_url: http://smart-proxy.example.com:8000

--- a/modules/templates/handler.rb
+++ b/modules/templates/handler.rb
@@ -7,8 +7,12 @@ module Proxy::Templates
   class Handler < ::Proxy::HttpRequest::ForemanRequest
     extend Proxy::Log
 
-    def get_template(kind, token)
-      request = request_factory.create_get("/unattended/#{kind}", :token=> token)
+    def get_template(kind, token, static = false)
+      opts = { :token => token,
+               :url   => Proxy::Templates::Plugin.settings.template_url
+      }
+      opts[:static] = static if static
+      request = request_factory.create_get("/unattended/#{kind}", opts)
       res = send_request(request)
 
       # You get a 201 from the 'built' URL
@@ -17,9 +21,9 @@ module Proxy::Templates
       res.body
     end
 
-    def self.get_template kind, token
+    def self.get_template kind, token, static = false
       @handler ||= Handler.new
-      @handler.get_template(kind,token)
+      @handler.get_template(kind,token, static)
     end
   end
 

--- a/modules/templates/templates_api.rb
+++ b/modules/templates/templates_api.rb
@@ -16,7 +16,7 @@ class Proxy::TemplatesApi < Sinatra::Base
 
   get "/:kind" do |kind|
     log_halt(500, "Failed to retrieve #{kind} template for #{params[:token]}: ") do
-      Proxy::Templates::Handler.get_template(kind, params[:token])
+      Proxy::Templates::Handler.get_template(kind, params[:token], params[:static])
     end
   end
 end

--- a/test/templates/template_test.rb
+++ b/test/templates/template_test.rb
@@ -11,12 +11,21 @@ class TemplateTest < Test::Unit::TestCase
   def setup
     @foreman_url = 'https://foreman.example.com'
     Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+    @template_url = 'http://proxy.lan:8443'
+    Proxy::Templates::Plugin.settings.stubs(:template_url).returns(@template_url)
   end
 
-  def test_template_requests_return_data
+  def test_template_requests_return_data_and_contain_template_url
     @expected_body = "my template"
-    stub_request(:get, @foreman_url+'/unattended/provision?token=test-token').to_return(:status => [200, "OK"], :body => @expected_body)
-    result =  Proxy::Templates::Handler.get_template('provision', 'test-token')
+    stub_request(:get, @foreman_url+'/unattended/provision?token=test-token&url='+@template_url).to_return(:status => [200, 'OK'], :body => @expected_body)
+    result = Proxy::Templates::Handler.get_template('provision', 'test-token')
+    assert_equal(@expected_body, result)
+  end
+
+  def test_template_requests_pass_static_flag_to_foreman
+    @expected_body = "my template"
+    stub_request(:get, @foreman_url+'/unattended/provision?static=true&token=test-token&url='+@template_url).to_return(:status => [200, 'OK'], :body => @expected_body)
+    result = Proxy::Templates::Handler.get_template('provision', 'test-token', 'true')
     assert_equal(@expected_body, result)
   end
 end


### PR DESCRIPTION
Also passes the ?static parameter on correctly.

@witlessbird @dustints could you comment and/or test?

See also: https://github.com/theforeman/foreman/pull/1902
