### PR TITLE
Fixes #8748 - Allow per-module enabling of http(s)

### DIFF
--- a/config/settings.d/bmc.yml.example
+++ b/config/settings.d/bmc.yml.example
@@ -1,5 +1,7 @@
 ---
+# Can be true, false, or http/https to enable just one of the protocols
 :enabled: false
+
 # Available providers:
 # - freeipmi / ipmitool - requires the appropriate package installed, and the rubyipmi gem
 # - shell - for local reboot control (requires sudo access to /sbin/shutdown for the proxy user)

--- a/config/settings.d/dhcp.yml.example
+++ b/config/settings.d/dhcp.yml.example
@@ -1,5 +1,7 @@
 ---
+# Can be true, false, or http/https to enable just one of the protocols
 :enabled: false
+
 # valid vendors:
 #   - isc
 #   - native_ms (Microsoft native implementation)

--- a/config/settings.d/dns.yml.example
+++ b/config/settings.d/dns.yml.example
@@ -1,5 +1,7 @@
 ---
+# Can be true, false, or http/https to enable just one of the protocols
 :enabled: false 
+
 # Valid providers:
 #   nsupdate
 #   nsupdate_gss (for GSS-TSIG support)

--- a/config/settings.d/facts.yml.example
+++ b/config/settings.d/facts.yml.example
@@ -1,2 +1,3 @@
 ---
+# Can be true, false, or http/https to enable just one of the protocols
 :enabled: false

--- a/config/settings.d/puppet.yml.example
+++ b/config/settings.d/puppet.yml.example
@@ -1,5 +1,7 @@
 ---
+# Can be true, false, or http/https to enable just one of the protocols
 :enabled: false
+
 # valid providers:
 #   puppetrun   (for puppetrun/kick, deprecated in Puppet 3)
 #   mcollective (uses mco puppet)

--- a/config/settings.d/puppetca.yml.example
+++ b/config/settings.d/puppetca.yml.example
@@ -1,5 +1,7 @@
 ---
+# Can be true, false, or http/https to enable just one of the protocols
 :enabled: false
+
 #:ssldir: /var/lib/puppet/ssl
 #:puppetdir: /etc/puppet
 #:puppetca_use_sudo: true

--- a/config/settings.d/realm.yml.example
+++ b/config/settings.d/realm.yml.example
@@ -1,4 +1,5 @@
 ---
+# Can be true, false, or http/https to enable just one of the protocols
 :enabled: false
 
 # Available providers:

--- a/config/settings.d/templates.yml.example
+++ b/config/settings.d/templates.yml.example
@@ -1,4 +1,6 @@
-# Set this to true if the Proxy should handle template requests on behalf of Foreman
+---
+# Enable this if the Proxy should handle template requests on behalf of Foreman
+# Can be true, false, or http/https to enable just one of the protocols
 :enabled: false
 
 # This plugin also requires that :foreman_url: be set in the main settings.yml

--- a/config/settings.d/tftp.yml.example
+++ b/config/settings.d/tftp.yml.example
@@ -1,5 +1,7 @@
 ---
+# Can be true, false, or http/https to enable just one of the protocols
 :enabled: false
+
 #:tftproot: /var/lib/tftpboot
 # Defines the TFTP Servername to use, overrides the name in the subnet declaration
 #:tftp_servername: tftp.domain.com

--- a/lib/proxy/plugin.rb
+++ b/lib/proxy/plugin.rb
@@ -66,12 +66,20 @@ class ::Proxy::Plugin
       @after_activation_blk = blk
     end
 
+    def http_enabled?
+      [true,'http'].include?(self.settings.enabled)
+    end
+
     def http_rackup_path(path)
-      @get_http_rackup_path = path
+      @get_http_rackup_path = path if http_enabled?
+    end
+
+    def https_enabled?
+      [true,'https'].include?(self.settings.enabled)
     end
 
     def https_rackup_path(path)
-      @get_https_rackup_path = path
+      @get_https_rackup_path = path if https_enabled?
     end
 
     def dependencies

--- a/test/plugin_test.rb
+++ b/test/plugin_test.rb
@@ -68,4 +68,18 @@ class PluginTest < Test::Unit::TestCase
     Proxy::Plugins.expects(:disable_plugin).never
     plugin.configure_plugin
   end
+
+  class TestPlugin10 < Proxy::Plugin; plugin :test10, '1.0'; end
+  def test_enable_of_only_http_is_successful
+    TestPlugin10.settings = ::Proxy::Settings::Plugin.new({:enabled => 'http'}, {})
+    assert TestPlugin10.http_enabled?
+    assert !TestPlugin10.https_enabled?
+  end
+
+  class TestPlugin11 < Proxy::Plugin; plugin :test11, '1.0'; end
+  def test_enable_of_only_https_is_successful
+    TestPlugin11.settings = ::Proxy::Settings::Plugin.new({:enabled => 'https'}, {})
+    assert TestPlugin11.https_enabled?
+    assert !TestPlugin11.http_enabled?
+  end
 end


### PR DESCRIPTION
Defaults to http=off and https=on for all except the templates module which is the reverse. Not added to RootPlugin as that should always be on anyway.

I'm wondering if it makes sense to do something more condensed like `:enabled = http|https|true(both)|false(none)` ?
