### PR TITLE
fixes #8811 - refactor per-module enabling of http(s) to http(s)_rackup

### DIFF
--- a/lib/proxy/plugin.rb
+++ b/lib/proxy/plugin.rb
@@ -71,7 +71,7 @@ class ::Proxy::Plugin
     end
 
     def http_rackup_path(path)
-      @get_http_rackup_path = path if http_enabled?
+      @get_http_rackup_path = path
     end
 
     def https_enabled?
@@ -79,7 +79,7 @@ class ::Proxy::Plugin
     end
 
     def https_rackup_path(path)
-      @get_https_rackup_path = path if https_enabled?
+      @get_https_rackup_path = path
     end
 
     def dependencies
@@ -134,11 +134,11 @@ class ::Proxy::Plugin
   end
 
   def http_rackup
-    self.class.get_http_rackup_path.nil? ? "" : File.read(self.class.get_http_rackup_path)
+    (self.class.http_enabled? && self.class.get_http_rackup_path) ? File.read(self.class.get_http_rackup_path) : ""
   end
 
   def https_rackup
-    self.class.get_https_rackup_path.nil? ? "" : File.read(self.class.get_https_rackup_path)
+    (self.class.https_enabled? && self.class.get_https_rackup_path) ? File.read(self.class.get_https_rackup_path) : ""
   end
 
   def settings

--- a/test/plugin_test.rb
+++ b/test/plugin_test.rb
@@ -15,7 +15,7 @@ class PluginTest < Test::Unit::TestCase
     assert_equal ':a: a, :b: b, :enabled: false', plugin.log_used_default_settings
   end
 
-  class TestPlugin2 < Proxy::Plugin; end
+  class TestPlugin2 < Proxy::Plugin; plugin :test2, '1.0'; end
   def test_http_rackup_returns_empty_string_with_missing_rackup_path
     assert_equal "", TestPlugin2.new.http_rackup
     assert_equal "", TestPlugin2.new.https_rackup
@@ -81,5 +81,25 @@ class PluginTest < Test::Unit::TestCase
     TestPlugin11.settings = ::Proxy::Settings::Plugin.new({:enabled => 'https'}, {})
     assert TestPlugin11.https_enabled?
     assert !TestPlugin11.http_enabled?
+  end
+
+  class TestPlugin12 < Proxy::Plugin
+    http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
+    https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
+
+    default_settings :enabled => 'https'
+    plugin :test12, '1.0'
+  end
+  
+  def test_plugin_loads_http_rack_path
+    assert !TestPlugin12.http_enabled?
+    assert TestPlugin12.https_enabled?
+    assert TestPlugin12.plugin_name, 'test12'
+    # Ensure that the content is read from 'http_config.ru'
+    File.stubs(:read).returns("require 'test12/test12_api'")
+    plugin = TestPlugin12.new
+    plugin.configure_plugin
+    assert_equal plugin.http_rackup, ''
+    assert_equal plugin.https_rackup, "require 'test12/test12_api'"
   end
 end


### PR DESCRIPTION
Moved checks for http(s)_enabled? to http(s)_rackup methods
