### PR TITLE
Refactor trusted_hosts handling

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -9,11 +9,18 @@
 
 # Hosts which the proxy accepts connections from
 # commenting the following lines would mean every verified SSL connection allowed
+# HTTPS: test the certificate CN
+# HTTP: test the reverse DNS entry of the remote IP
 #:trusted_hosts:
 #- foreman.prod.domain
 #- foreman.dev.domain
 #to deny access to all hosts use:
 #:trusted_hosts: []
+
+# verify a DNS reverse lookup against it's forward lookup
+# 1.1.1.1 -> foreman.mycompany.com -> 1.1.1.1
+# (default: true)
+#:forward_verify: true
 
 #:foreman_url: http://127.0.0.1:3000
 

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -6,7 +6,8 @@ module ::Proxy::Settings
       :log_file => "/var/log/foreman-proxy/proxy.log",
       :log_level => "ERROR",
       :daemon => false,
-      :daemon_pid => "/var/run/foreman-proxy/foreman-proxy.pid"
+      :daemon_pid => "/var/run/foreman-proxy/foreman-proxy.pid",
+      :forward_verify => true
     }
 
     attr_reader :used_defaults

--- a/lib/sinatra/trusted_hosts.rb
+++ b/lib/sinatra/trusted_hosts.rb
@@ -1,22 +1,27 @@
-require 'resolv'
-
 module Sinatra
   module TrustedHosts
     def authorize_with_trusted_hosts
       helpers ::Proxy::Helpers
 
       before do
-        # When :trusted_hosts is given, check the reverse DNS entry of the remote IP and ensure it's listed
-        if Proxy::SETTINGS.trusted_hosts
-          begin
-            remote_fqdn = Resolv.new.getname(request.env["REMOTE_ADDR"])
-          rescue Resolv::ResolvError => e
-            log_halt 403, "Unable to resolve hostname for connecting client - #{request.env["REMOTE_ADDR"]}. If it's to be a trusted host, ensure it has a reverse DNS entry."  +
-            "\n\n" + "#{e.message}"
+        # When :trusted_hosts is given, we check the client against the list
+        # HTTPS: test the certificate CN
+        # HTTP: test the reverse DNS entry of the remote IP
+        trusted_hosts = Proxy::SETTINGS.trusted_hosts
+        if trusted_hosts
+          logger.debug "verifying remote client #{request.env['REMOTE_ADDR']} against trusted_hosts #{trusted_hosts}"
+
+          if [ 'yes', 'on', 1 ].include? request.env['HTTPS'].to_s
+            fqdn = https_cert_cn
+          else
+            fqdn = remote_fqdn(Proxy::SETTINGS.forward_verify)
           end
-          if !Proxy::SETTINGS.trusted_hosts.include?(remote_fqdn.downcase)
-            log_halt 403, "Untrusted client #{remote_fqdn.downcase} attempted to access #{request.path_info}. Check :trusted_hosts: in settings.yml"
+          fqdn = fqdn.downcase
+
+          unless Proxy::SETTINGS.trusted_hosts.include?(fqdn)
+            log_halt 403, "Untrusted client #{fqdn} attempted to access #{request.path_info}. Check :trusted_hosts: in settings.yml"
           end
+
         end
       end
     end

--- a/test/sinatra/trusted_hosts_test.rb
+++ b/test/sinatra/trusted_hosts_test.rb
@@ -28,24 +28,66 @@ class TrustedHostsTest < Test::Unit::TestCase
     assert last_response.forbidden?
   end
 
-  def test_trusted_hosts_matches
+  def test_trusted_hosts_http_matches
     Proxy::SETTINGS.expects(:trusted_hosts).at_least_once.returns(['host.example.org'])
     Resolv.any_instance.expects(:getname).with('10.0.0.1').returns('host.example.org')
+    Resolv.any_instance.expects(:getaddresses).with('host.example.org').returns(['10.0.0.1'])
     get '/test', nil, 'REMOTE_ADDR' => '10.0.0.1'
     assert last_response.ok?
   end
 
-  def test_trusted_hosts_forbids_access
+  def test_trusted_hosts_http_no_forward_verify
+    Proxy::SETTINGS.expects(:forward_verify).at_least_once.returns(false)
+    Proxy::SETTINGS.expects(:trusted_hosts).at_least_once.returns(['noreverse.example.org'])
+    Resolv.any_instance.expects(:getname).with('10.0.0.1').returns('noreverse.example.org')
+    # would be nice, but does not work
+    # see: http://pbrisbin.com/posts/beware_never_expectations/
+    #Resolv.any_instance.expects(:getaddresses).with('noreverse.example.org').never()
+    get '/test', nil, 'REMOTE_ADDR' => '10.0.0.1'
+    assert last_response.ok?
+  end
+
+  def test_trusted_hosts_http_forbid_forward_verify
+    Proxy::SETTINGS.expects(:trusted_hosts).at_least_once.returns(['host.example.org'])
+    Resolv.any_instance.expects(:getname).with('10.0.0.1').returns('host.example.org')
+    Resolv.any_instance.expects(:getaddresses).with('host.example.org').returns(['10.0.0.2'])
+    get '/test', nil, 'REMOTE_ADDR' => '10.0.0.1'
+    assert last_response.forbidden?
+  end
+
+  def test_trusted_hosts_http_forbids_access
     Proxy::SETTINGS.expects(:trusted_hosts).at_least_once.returns(['host.example.org'])
     Resolv.any_instance.expects(:getname).with('10.0.0.1').returns('eve.example.org')
     get '/test', nil, 'REMOTE_ADDR' => '10.0.0.1'
     assert last_response.forbidden?
   end
 
-  def test_trusted_hosts_failed_resolv
+  def test_trusted_hosts_http_failed_resolv
     Proxy::SETTINGS.expects(:trusted_hosts).at_least_once.returns(['host.example.org'])
     Resolv.any_instance.expects(:getname).with('10.0.0.1').raises(Resolv::ResolvError, 'no name')
     get '/test', nil, 'REMOTE_ADDR' => '10.0.0.1'
+    assert last_response.forbidden?
+  end
+
+  def test_trusted_hosts_https_matches
+    Proxy::SETTINGS.expects(:trusted_hosts).at_least_once.returns(['host.example.org'])
+    OpenSSL::X509::Certificate.stubs(:new).returns(OpenSSL::X509::Certificate)
+    OpenSSL::X509::Certificate.expects(:subject).at_least_once.returns('CN=host.example.org,...')
+    get '/test', nil, 'REMOTE_ADDR' => '10.0.0.1', 'HTTPS' => 'on', 'SSL_CLIENT_CERT' => 'FOOBAR'
+    assert last_response.ok?
+  end
+
+  def test_trusted_hosts_https_invalid_cert
+    Proxy::SETTINGS.expects(:trusted_hosts).at_least_once.returns(['host.example.org'])
+    get '/test', nil, 'REMOTE_ADDR' => '10.0.0.1', 'HTTPS' => 'on', 'SSL_CLIENT_CERT' => 'FOOBAR'
+    assert last_response.forbidden?
+  end
+
+  def test_trusted_hosts_https_forbids_access
+    Proxy::SETTINGS.expects(:trusted_hosts).at_least_once.returns(['host.example.org'])
+    OpenSSL::X509::Certificate.stubs(:new).returns(OpenSSL::X509::Certificate)
+    OpenSSL::X509::Certificate.expects(:subject).at_least_once.returns('CN=eve.example.org,...')
+    get '/test', nil, 'REMOTE_ADDR' => '10.0.0.1', 'HTTPS' => 'on', 'SSL_CLIENT_CERT' => 'FOOBAR'
     assert last_response.forbidden?
   end
 


### PR DESCRIPTION
On HTTPS we will get the FQDN from the client certificate and check against the
list.

While on HTTP we will perform both reverse DNS and forward DNS lookup to verify
the client may talk to us.

Refs #7849
