### PR TITLE
Remove implicit test ordering from DHCP API test

### DIFF
--- a/test/dhcp/dhcp_api_test.rb
+++ b/test/dhcp/dhcp_api_test.rb
@@ -11,11 +11,6 @@ ENV['RACK_ENV'] = 'test'
 class DhcpApiTest < Test::Unit::TestCase
   include Rack::Test::Methods
 
-  # Run tests in alphabetical order for this file
-  def self.test_order
-    :sorted # default is random order
-  end
-
   def app
     Proxy::DhcpApi.new
   end


### PR DESCRIPTION
I had an conflict with test-unit on my system.

test-unit uses alphabetic by default, only minitest supports
"sorted", which is default there.

refs #8948 - Problem with implicit test ordering from DHCP API test
