### PR TITLE
Fixes #9061: pinned rack version to < 1.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'http://rubygems.org'
 
 gem 'json'
 gem 'sinatra'
-gem 'rack', '>= 1.1'
+gem 'rack', '>= 1.1', '< 1.6'
 
 Dir["#{File.dirname(__FILE__)}/bundler.d/*.rb"].each do |bundle|
  # puts "adding custom gem file #{bundle}"


### PR DESCRIPTION
This is a workaround until newer version of Sinatra is released.
