### PR TITLE
Refs #7849 - Avoid OpenSSL deprecation

### DIFF
--- a/lib/proxy/helpers.rb
+++ b/lib/proxy/helpers.rb
@@ -1,4 +1,4 @@
-require 'openssl/x509'
+require 'openssl'
 require 'resolv'
 
 module Proxy::Helpers


### PR DESCRIPTION
deprecated openssl/x509 use: require "openssl" instead of "openssl/x509"
