### PR TITLE
fixes #9102 - remove trusted_hosts check from templates module

### DIFF
--- a/modules/templates/templates_api.rb
+++ b/modules/templates/templates_api.rb
@@ -1,7 +1,6 @@
 require 'templates/handler'
 class Proxy::TemplatesApi < Sinatra::Base
   helpers ::Proxy::Helpers
-  authorize_with_trusted_hosts
 
   # When template feature is used, foreman uses this end-point to provide basse url for hosts to fetch templates.
   # It will also modify the rendering of the foreman_url specified in the templates.


### PR DESCRIPTION
trusted_hosts limits which hosts can access provisioning templates, this turns off checking trusted_hosts for the templates module.

Access control is handled by Foreman tokens.
