### PR TITLE
Fixes #9245 - Add override setting to allow mcollective puppet runs to r...

### DIFF
--- a/config/settings.d/puppet.yml.example
+++ b/config/settings.d/puppet.yml.example
@@ -33,6 +33,9 @@
 # Which user to invoke sudo as to run puppet commands
 #:puppet_user: root
 
+# If you want to override the puppet_user above just for mco commands
+#:mcollective_user: peadmin
+
 # URL of the puppet master itself for API requests
 #:puppet_url: https://puppet.example.com:8140
 # SSL certificates used to access the puppet master API

--- a/modules/puppet_proxy/mcollective.rb
+++ b/modules/puppet_proxy/mcollective.rb
@@ -5,14 +5,21 @@ class Proxy::Puppet::MCollective < Proxy::Puppet::Runner
     cmd = []
     cmd.push(which("sudo"))
 
-    if Proxy::Puppet::Plugin.settings.puppet_user
-      cmd.push("-u", Proxy::Puppet::Plugin.settings.puppet_user)
+    # whatever user this is getting the sudo permissions will need to be added to ensure the smart-proxy
+    # can execute the sudo command
+    # For Puppet Enterprise this means
+    # Defaults:foreman-proxy !requiretty
+    # foreman-proxy ALL=(peadmin) NOPASSWD: /opt/puppet/bin/mco *',
+    user = Proxy::Puppet::Plugin.settings.mcollective_user || Proxy::Puppet::Plugin.settings.puppet_user
+    if user
+      cmd.push("-u", user)
     end
 
     cmd.push(which("mco", "/opt/puppet/bin"))
 
     if cmd.include?(false)
       logger.warn "sudo or the mco binary is missing."
+      logger.warn "You must have the correct sudo permissions like: foreman-proxy ALL=(${user}) NOPASSWD: /opt/puppet/bin/mco *'" if user
       return false
     end
 

--- a/test/puppet/mcollective_test.rb
+++ b/test/puppet/mcollective_test.rb
@@ -25,6 +25,23 @@ class MCollectiveTest < Test::Unit::TestCase
     assert @mcollective.run
   end
 
+  def test_run_command_with_mcollective_user_defined
+    @mcollective.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
+    @mcollective.stubs(:which).with("mco", anything).returns("/usr/bin/mco")
+    Proxy::Puppet::Plugin.settings.stubs(:mcollective_user).returns("peadmin")
+    @mcollective.expects(:shell_command).with(["/usr/bin/sudo", "-u", "peadmin", "/usr/bin/mco", "puppet", "runonce", "-I", "host1", "host2"]).returns(true)
+    assert @mcollective.run
+  end
+
+  def test_run_command_with_mcollective_user_should_take_precedence
+    @mcollective.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
+    @mcollective.stubs(:which).with("mco", anything).returns("/usr/bin/mco")
+    Proxy::Puppet::Plugin.settings.stubs(:puppet_user).returns("example")
+    Proxy::Puppet::Plugin.settings.stubs(:mcollective_user).returns("peadmin")
+    @mcollective.expects(:shell_command).with(["/usr/bin/sudo", "-u", "peadmin", "/usr/bin/mco", "puppet", "runonce", "-I", "host1", "host2"]).returns(true)
+    assert @mcollective.run
+  end
+
   def test_run_command_with_missing_sudo
     @mcollective.stubs(:which).with("sudo", anything).returns(false)
     @mcollective.stubs(:which).with("mco", anything).returns("/usr/bin/mco")


### PR DESCRIPTION
- previously we could set the mcollective user via puppet_user setting. However, this could be misleading
   to the user as its not obvious where it was used in the smart proxy.  With the new mcollective user
   setting its pretty clear what the intention of the user is for.  In setups like Puppet Enterprise
   there is usually a user for mco and puppet which we have to keep separate and thus require a different user.
- This adds a new setting to the puppet config called :mcollective_user:
