### PR TITLE
Fixes #9482 - introduced path patterns to authorize_with_trusted_hosts

### DIFF
--- a/lib/sinatra/authorization.rb
+++ b/lib/sinatra/authorization.rb
@@ -1,9 +1,9 @@
 module Sinatra
   module Authorization
-    def authorize_with_trusted_hosts
+    def authorize_with_trusted_hosts pattern=nil
       helpers ::Proxy::Helpers
 
-      before do
+      before pattern do
         # When :trusted_hosts is given, we check the client against the list
         # HTTPS: test the certificate CN
         # HTTP: test the reverse DNS entry of the remote IP
@@ -26,11 +26,11 @@ module Sinatra
       end
     end
 
-    def authorize_with_ssl_client
+    def authorize_with_ssl_client pattern=nil
       helpers ::Proxy::Helpers
       helpers ::Proxy::Log
 
-      before do
+      before pattern do
         if ['yes', 'on', '1'].include? request.env['HTTPS'].to_s
           if request.env['SSL_CLIENT_CERT'].to_s.empty?
             log_halt 403, "No client SSL certificate supplied"


### PR DESCRIPTION
Foreman discovery proxy plugin needs to specify for which paths it will
authorize. Since Sinatra supports patters for filters
(http://www.sinatrarb.com/intro.html#Filters) it is relatively easy to
implement this so plugins can take advantage of this. This change will NOT
break the API, by default filters will apply to all paths (nil).

For https://github.com/theforeman/smart_proxy_discovery/pull/6
