### PR TITLE
PR for AWS route53 support in smart_proxy

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@ source 'http://rubygems.org'
 
 gem 'json'
 gem 'sinatra'
+gem 'route53'
 gem 'rack', '>= 1.1', '< 1.6'
 
 Dir["#{File.dirname(__FILE__)}/bundler.d/*.rb"].each do |bundle|

--- a/config/settings.d/dns.yml.example
+++ b/config/settings.d/dns.yml.example
@@ -7,6 +7,7 @@
 #   nsupdate_gss (for GSS-TSIG support)
 #   virsh
 #   dnscmd
+#   aws
 #:dns_provider: nsupdate
 #:dns_key: /etc/rndc.key
 # use this setting if you are managing a dns server which is not localhost though this proxy
@@ -17,3 +18,7 @@
 # Secure Dynamic Updates, or BIND as used in FreeIPA.  Set dns_provider to nsupdate_gss.
 #:dns_tsig_keytab: /usr/share/foreman-proxy/dns.keytab
 #:dns_tsig_principal: DNS/host.example.com@EXAMPLE.COM
+#
+# For AWS users add the following settings for the AWS credentials
+#:dns_aws_accesskey: "ABCDEF123456"
+#:dns_aws_secretkey: "ABCDEF123456!@#$"

--- a/modules/dns/dns_api.rb
+++ b/modules/dns/dns_api.rb
@@ -7,42 +7,48 @@ module Proxy::Dns
     def dns_setup(opts)
       raise "Smart Proxy is not configured to support DNS" unless Proxy::Dns::Plugin.settings.enabled
       case Proxy::Dns::Plugin.settings.dns_provider
-      when "dnscmd"
-        require 'dns/providers/dnscmd'
-        @server = Proxy::Dns::Dnscmd.new(opts.merge(
-          :server => Proxy::Dns::Plugin.settings.dns_server,
-          :ttl => Proxy::Dns::Plugin.settings.dns_ttl
-        ))
-      when "nsupdate"
-        require 'dns/providers/nsupdate'
-        @server = Proxy::Dns::Nsupdate.new(opts.merge(
-          :server => Proxy::Dns::Plugin.settings.dns_server,
-          :ttl => Proxy::Dns::Plugin.settings.dns_ttl
-        ))
-      when "nsupdate_gss"
-        require 'dns/providers/nsupdate_gss'
-        @server = Proxy::Dns::NsupdateGSS.new(opts.merge(
-          :server => Proxy::Dns::Plugin.settings.dns_server,
-          :ttl => Proxy::Dns::Plugin.settings.dns_ttl,
-          :tsig_keytab => Proxy::Dns::Plugin.settings.dns_tsig_keytab,
-          :tsig_principal => Proxy::Dns::Plugin.settings.dns_tsig_principal
-        ))
-      when "virsh"
-        require 'dns/providers/virsh'
-        @server = Proxy::Dns::Virsh.new(opts.merge(
-          :virsh_network => Proxy::SETTINGS.virsh_network
-        ))
-      else
-        log_halt 400, "Unrecognized or missing DNS provider: #{Proxy::Dns::Plugin.settings.dns_provider || "MISSING"}"
+        when "dnscmd"
+          require 'dns/providers/dnscmd'
+          @server = Proxy::Dns::Dnscmd.new(opts.merge(
+                                               :server => Proxy::Dns::Plugin.settings.dns_server,
+                                               :ttl => Proxy::Dns::Plugin.settings.dns_ttl
+                                           ))
+        when "nsupdate"
+          require 'dns/providers/nsupdate'
+          @server = Proxy::Dns::Nsupdate.new(opts.merge(
+                                                 :server => Proxy::Dns::Plugin.settings.dns_server,
+                                                 :ttl => Proxy::Dns::Plugin.settings.dns_ttl
+                                             ))
+        when "nsupdate_gss"
+          require 'dns/providers/nsupdate_gss'
+          @server = Proxy::Dns::NsupdateGSS.new(opts.merge(
+                                                    :server => Proxy::Dns::Plugin.settings.dns_server,
+                                                    :ttl => Proxy::Dns::Plugin.settings.dns_ttl,
+                                                    :tsig_keytab => Proxy::Dns::Plugin.settings.dns_tsig_keytab,
+                                                    :tsig_principal => Proxy::Dns::Plugin.settings.dns_tsig_principal
+                                                ))
+        when "virsh"
+          require 'dns/providers/virsh'
+          @server = Proxy::Dns::Virsh.new(opts.merge(
+                                              :virsh_network => Proxy::SETTINGS.virsh_network
+                                          ))
+        when "aws"
+          require "dns/providers/aws"
+          @server = Proxy::Dns::Aws.new(opts.merge(
+                  :dns_aws_accesskey => Proxy::Dns::Plugin.settings.dns_aws_accesskey,
+                  :dns_aws_secretkey => Proxy::Dns::Plugin.settings.dns_aws_secretkey
+                                        ))
+        else
+          log_halt 400, "Unrecognized or missing DNS provider: #{Proxy::Dns::Plugin.settings.dns_provider || "MISSING"}"
       end
     rescue => e
       log_halt 400, e
     end
 
     post "/?" do
-      fqdn  = params[:fqdn]
+      fqdn = params[:fqdn]
       value = params[:value]
-      type  = params[:type]
+      type = params[:type]
       begin
         dns_setup(:fqdn => fqdn, :value => value, :type => type)
         @server.create
@@ -55,11 +61,11 @@ module Proxy::Dns
 
     delete "/:value" do
       case params[:value]
-      when /\.(in-addr|ip6)\.arpa$/
-        type = "PTR"
-        value = params[:value]
-      else
-        fqdn = params[:value]
+        when /\.(in-addr|ip6)\.arpa$/
+          type = "PTR"
+          value = params[:value]
+        else
+          fqdn = params[:value]
       end
       begin
         dns_setup(:fqdn => fqdn, :value => value, :type => type)

--- a/modules/dns/dns_api.rb
+++ b/modules/dns/dns_api.rb
@@ -36,7 +36,8 @@ module Proxy::Dns
           require "dns/providers/aws"
           @server = Proxy::Dns::Aws.new(opts.merge(
                   :dns_aws_accesskey => Proxy::Dns::Plugin.settings.dns_aws_accesskey,
-                  :dns_aws_secretkey => Proxy::Dns::Plugin.settings.dns_aws_secretkey
+                  :dns_aws_secretkey => Proxy::Dns::Plugin.settings.dns_aws_secretkey,
+                  :ttl => Proxy::Dns::Plugin.settings.dns_ttl
                                         ))
         else
           log_halt 400, "Unrecognized or missing DNS provider: #{Proxy::Dns::Plugin.settings.dns_provider || "MISSING"}"

--- a/modules/dns/providers/aws.rb
+++ b/modules/dns/providers/aws.rb
@@ -1,0 +1,91 @@
+require 'resolv'
+require 'route53'
+
+module Proxy::Dns
+  class Aws < Record
+    include Proxy::Util
+    attr_reader :resolver
+
+    def initialize options = {}
+      @server = "8.8.8.8"
+      @dns_aws_accesskey = options[:dns_aws_accesskey]
+      @dns_aws_secretkey = options[:dns_aws_secretkey]
+      raise "Route53: dns_aws_secretkey and dns_aws_accesskey must be set." unless defined? @dns_aws_accesskey and defined? @dns_aws_secretkey
+      super(options)
+    end
+
+    #create({ :fqdn => "node1.cloud.vormetric.com", :value => '1.1.1.1'})
+    # create({ :fqdn => "node01.lab", :value => "3.100.168.192.in-addr.arpa",
+    #          :type => "PTR"}a)
+    def create
+
+      conn = Route53::Connection.new(@dns_aws_accesskey , @dns_aws_secretkey)
+      @resolver = Resolv::DNS.new
+      case @type
+        when "A"
+          domain = @fqdn.split('.', 2).last + '.'
+          zone = conn.get_zones(name=domain)[0]
+
+          if ip = dns_find(@fqdn)
+            raise(Proxy::DNS::Collision, "#{@fqdn} is already used by #{ip}") unless ip == @value
+          else
+            new_record = Route53::DNSRecord.new(@fqdn, 'A', @ttl, [@value], zone)
+            resp = new_record.create
+            raise "AWS Response Error: #{resp}" if resp.error?
+          end
+        when "PTR"
+          domain = @value.split('.', 2).last + '.'
+          zone = conn.get_zones(name=domain)[0]
+          if name == dns_find(@value)
+            raise(Proxy::DNS::Collision, "#{@value} is already used by #{name}") unless name == @fqdn
+          else
+            new_record = Route53::DNSRecord.new(@value, 'PTR', @ttl, [@fqdn], zone)
+            resp = new_record.create
+            raise "AWS Response Error: #{resp}" if resp.error?
+          end
+      end
+    end
+
+    # remove({ :fqdn => "node01.lab", :value => "192.168.100.2"}
+    def remove
+
+      conn = Route53::Connection.new(@dns_aws_accesskey, @dns_aws_secretkey)
+      case @type
+        when "A"
+          domain = @fqdn.split('.', 2).last + '.'
+          zone = conn.get_zones(name=domain)[0]
+          recordset = zone.get_records
+          recordset.each do |rec|
+            if rec.name == @fqdn + '.'
+              resp = rec.delete
+              raise "AWS Response Error: #{resp}" if resp.error?
+              return
+            end
+          end
+        when "PTR"
+          domain = @value.split('.', 2).last + '.'
+          zone = conn.get_zones(name=domain)[0]
+          recordset = zone.get_records
+          recordset.each do |rec|
+            if rec.name == @value + '.'
+              resp = rec.delete
+              raise "AWS Response Error: #{resp}" if resp.error?
+              return
+            end
+          end
+      end
+    end
+
+    private
+    def dns_find key
+      puts key
+      if match = key.match(/(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})/)
+        resolver.getname(match[1..4].reverse.join(".")).to_s
+      else
+        resolver.getaddress(key).to_s
+      end
+    rescue Resolv::ResolvError
+      false
+    end
+  end
+end

--- a/modules/dns/providers/aws.rb
+++ b/modules/dns/providers/aws.rb
@@ -7,16 +7,12 @@ module Proxy::Dns
     attr_reader :resolver
 
     def initialize options = {}
-      @server = "8.8.8.8"
       @dns_aws_accesskey = options[:dns_aws_accesskey]
       @dns_aws_secretkey = options[:dns_aws_secretkey]
       raise "Route53: dns_aws_secretkey and dns_aws_accesskey must be set." unless defined? @dns_aws_accesskey and defined? @dns_aws_secretkey
       super(options)
     end
 
-    #create({ :fqdn => "node1.cloud.vormetric.com", :value => '1.1.1.1'})
-    # create({ :fqdn => "node01.lab", :value => "3.100.168.192.in-addr.arpa",
-    #          :type => "PTR"}a)
     def create
 
       conn = Route53::Connection.new(@dns_aws_accesskey , @dns_aws_secretkey)
@@ -46,7 +42,6 @@ module Proxy::Dns
       end
     end
 
-    # remove({ :fqdn => "node01.lab", :value => "192.168.100.2"}
     def remove
 
       conn = Route53::Connection.new(@dns_aws_accesskey, @dns_aws_secretkey)


### PR DESCRIPTION
This PR adds support for AWS route53 as a DNS provilder.  

The config/settings.d/dns.yml.example has an added section in the comments for how to add your AWS credentials to the dns.yml file.

Please let us know if you run into any issues or questions.
