### PR TITLE
Fixes #9713: restore WIN32 service support

### DIFF
--- a/bin/smart-proxy-win
+++ b/bin/smart-proxy-win
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+
+$LOAD_PATH.unshift(*Dir[File.expand_path("../../lib", __FILE__), File.expand_path("../../modules", __FILE__)])
+
+require 'smart_proxy'
+
+if ARGV[0] == "--service"
+  raise "The service flag is used only in a windows environment" unless PLATFORM =~ /mingw/
+    begin
+      require 'win32/daemon'
+      include Win32
+
+      # Logfile must be absolute on windows
+      logfile = "../../tmp/proxy.log"
+      $stdout.reopen(logfile, "a")
+      $stdout.sync = true
+      $stderr.reopen($stdout)
+      puts "#{Time.now}: Service is starting"
+
+      class Daemon
+        def service_init
+          puts "#{Time.now}: Service is initializing"
+        end
+
+        def service_main(*args)
+          puts "#{Time.now}: Service is running"
+          Proxy::Launcher.new.launch
+          puts "#{Time.now}: Service is terminating"
+        end
+
+        def service_stop
+          puts "#{Time.now}: Service stopped"
+          exit!(true)
+        end
+      end
+
+      daemon = Daemon.new
+      daemon.mainloop
+    rescue Exception => err
+      File.open(logfile, (File::APPEND|File::CREAT|File::WRONLY)){ |f| f.puts " ***Daemon failure #{Time.now} err=#{err}" }
+      raise
+    end
+else
+  Proxy::Launcher.new.launch
+end


### PR DESCRIPTION
This pull request is intended for discussion on restoring WIN32 service support for foreman smart-proxy. The logfile should not be hardcoded, we have to pass it from configuration somehow.

Another point is that we need to revert 296617acd29db1759cc5b5bfffad39398e3773a4 (PXEClient) for DHCP to work.
