### PR TITLE
Add TFTP option tftp_fetch_boot_file true/false to disable fetching boot files

### DIFF
--- a/config/settings.d/tftp.yml.example
+++ b/config/settings.d/tftp.yml.example
@@ -5,3 +5,6 @@
 #:tftproot: /var/lib/tftpboot
 # Defines the TFTP Servername to use, overrides the name in the subnet declaration
 #:tftp_servername: tftp.domain.com
+
+# Optionally disable fetching TFTP boot files
+#:tftp_fetch_boot_files: false

--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -99,11 +99,15 @@ module Proxy::TFTP
     tftproot    = Pathname.new(Proxy::TFTP::Plugin.settings.tftproot).cleanpath
     raise "TFTP destination outside of tftproot" unless destination.to_s.start_with?(tftproot.to_s)
 
-    # Ensure that our image directory exists
-    # as the dst might contain another sub directory
-    FileUtils.mkdir_p destination.parent
+    if Proxy::TFTP::Plugin.settings.tftp_fetch_boot_files
+      # Ensure that our image directory exists
+      # as the dst might contain another sub directory
+      FileUtils.mkdir_p destination.parent
 
-    ::Proxy::HttpDownloads.start_download(src.to_s, destination.to_s)
+      ::Proxy::HttpDownloads.start_download(src.to_s, destination.to_s)
+    else
+      raise "TFTP boot file does not exist" unless File.exist?(destination)
+    end
   end
 
   def self.boot_filename(dst, src)

--- a/modules/tftp/tftp_plugin.rb
+++ b/modules/tftp/tftp_plugin.rb
@@ -6,5 +6,6 @@ module Proxy::TFTP
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
     default_settings :tftproot => '/var/lib/tftpboot'
+    default_settings :tftp_fetch_boot_files => true
   end
 end


### PR DESCRIPTION
I have a separate mechanism for controlling /var/lib/tftpboot installer binaries, so I'd rather not re-fetch these files on every host build.

In prior versions, Foreman continued to build hosts even though it did not have permissions to overwrite my pxe boot files. In 1.7, which I've just installed, the permissions issue causes a build rollback.

If this looks reasonable I'll file up the tickets and add tests.
