### PR TITLE
Fixes #9852 - REST API violation in BMC smart proxy API

### DIFF
--- a/modules/bmc/bmc_api.rb
+++ b/modules/bmc/bmc_api.rb
@@ -270,8 +270,8 @@ module Proxy::BMC
       case provider_type
         when 'freeipmi', 'ipmitool'
 
-          raise "unauthorized" unless auth.provided?
-          raise "bad_authentication_request" unless auth.basic?
+          log_halt 401, "unauthorized" unless auth.provided?
+          log_halt 401, "bad_authentication_request, credentials are not in auth.basic format" unless auth.basic?
 
           username, password = auth.credentials
 

--- a/test/bmc/bmc_api_test.rb
+++ b/test/bmc/bmc_api_test.rb
@@ -21,6 +21,45 @@ class BmcApiTest < Test::Unit::TestCase
     authorize user, pass
   end
 
+  def test_api_throws_401_error_when_auth_is_not_provided
+    Proxy::BMC::IPMI.stubs(:providers_installed).returns(['freeipmi'])
+    Proxy::BMC::Plugin.settings.stubs(:bmc_default_provider).returns('freeipmi')
+    auth = mock()
+    auth.expects(:provided?).returns(false)
+    Proxy::BMC::Api.any_instance.stubs(:auth).returns(auth)
+    test_args = { :bmc_provider => 'freeipmi' }
+    get "/#{host}/lan/gateway", test_args
+    assert_equal 'unauthorized', last_response.body
+    assert_equal 401, last_response.status
+  end
+
+  def test_api_does_not_throw_401_error_when_auth_is_provided_and_in_basic_format
+    Proxy::BMC::IPMI.stubs(:providers_installed).returns(['freeipmi'])
+    Proxy::BMC::Plugin.settings.stubs(:bmc_default_provider).returns('freeipmi')
+    Proxy::BMC::IPMI.any_instance.stubs(:gateway).returns("192.168.1.1")
+    auth = mock()
+    auth.expects(:provided?).returns(true)
+    auth.expects(:basic?).returns(true)
+    auth.expects(:credentials).returns('username','password')
+    Proxy::BMC::Api.any_instance.stubs(:auth).returns(auth)
+    test_args = { :bmc_provider => 'freeipmi' }
+    get "/#{host}/lan/gateway", test_args
+    assert_equal 200, last_response.status
+  end
+
+  def test_api_throws_401_error_when_auth_is_not_basic
+    Proxy::BMC::IPMI.stubs(:providers_installed).returns(['freeipmi'])
+    Proxy::BMC::Plugin.settings.stubs(:bmc_default_provider).returns('freeipmi')
+    auth = mock()
+    auth.expects(:provided?).returns(true)
+    auth.expects(:basic?).returns(false)
+    Proxy::BMC::Api.any_instance.stubs(:auth).returns(auth)
+    test_args = { :bmc_provider => 'freeipmi' }
+    get "/#{host}/lan/gateway", test_args
+    assert_equal 'bad_authentication_request, credentials are not in auth.basic format', last_response.body
+    assert_equal 401, last_response.status
+  end
+
   def test_api_find_ipmi_provider_logs_warning_when_specified_provider_is_not_installed
     Proxy::BMC::IPMI.stubs(:providers_installed).returns(['freeipmi'])
     Proxy::BMC::IPMI.stubs(:installed?).with('ipmitool').returns(false)
@@ -63,7 +102,6 @@ class BmcApiTest < Test::Unit::TestCase
   def test_api_bmc_setup_returns_new_ipmi_proxy_given_ipmitool
     api = Proxy::BMC::Api.new!
     Proxy::BMC::Plugin.settings.stubs(:bmc_default_provider).returns('freeipmi')
-    Proxy::BMC::Plugin.settings.stubs(:provider_log_level).returns(nil)
     auth = Object.new
     auth.stubs(:provided?).returns(true)
     auth.stubs(:basic?).returns(true)
@@ -78,7 +116,6 @@ class BmcApiTest < Test::Unit::TestCase
   def test_api_bmc_setup_returns_new_ipmi_proxy_given_freeipmi
     api = Proxy::BMC::Api.new!
     Proxy::BMC::Plugin.settings.stubs(:bmc_default_provider).returns('freeipmi')
-    Proxy::BMC::Plugin.settings.stubs(:provider_log_level).returns(nil)
     auth = Object.new
     auth.stubs(:provided?).returns(true)
     auth.stubs(:basic?).returns(true)


### PR DESCRIPTION
```
* authentication errors now return 401 and proper message
```
