### PR TITLE
Fixes #7543 - allow additional rubyipmi connection options to be passed through

### DIFF
--- a/modules/bmc/bmc_api.rb
+++ b/modules/bmc/bmc_api.rb
@@ -283,8 +283,8 @@ module Proxy::BMC
           # to execute ipmi commands and has nothing to do with authorization
           # of using smart-proxy. Its simply a tunnel to pass credentials through,
           # since we are essentially remotely executing ipmi commands using Rubyipmi.
-          args = { :host     => params[:host], :username     => username,
-                   :password => password,      :bmc_provider => provider_type }
+          args = { :host     => params[:host], :username     => username, :options => params[:options],
+                   :password => password, :bmc_provider => provider_type }
           @bmc = Proxy::BMC::IPMI.new(args)
         when "shell"
           require 'bmc/shell'

--- a/modules/bmc/ipmi.rb
+++ b/modules/bmc/ipmi.rb
@@ -65,7 +65,7 @@ module Proxy
       end
 
       def connect(args = { })
-        Rubyipmi.connect(args[:username], args[:password], args[:host], args[:bmc_provider])
+        Rubyipmi.connect(args[:username], args[:password], args[:host], args[:bmc_provider], args[:options] || {})
       end
 
       # returns boolean true if connection to device is successful


### PR DESCRIPTION
- allows the user to pass additional rubyipmi options that were not exposed through smart proxy before.
- replaces some stubs with mock in other tests
