### PR TITLE
Fixes #10116 - BMC is not able to use parameters passed in through body

### DIFF
--- a/bundler.d/bmc.rb
+++ b/bundler.d/bmc.rb
@@ -1,3 +1,3 @@
 group :bmc do
-  gem 'rubyipmi', '>= 0.9.2'
+  gem 'rubyipmi', '>= 0.10.0'
 end

--- a/modules/bmc/ipmi.rb
+++ b/modules/bmc/ipmi.rb
@@ -65,7 +65,12 @@ module Proxy
       end
 
       def connect(args = { })
-        Rubyipmi.connect(args[:username], args[:password], args[:host], args[:bmc_provider], args[:options] || {})
+        if args[:options].instance_of?(Hash)
+          options = args[:options]
+        else
+          options = {}     # catches nil and empty string cases
+        end
+        Rubyipmi.connect(args[:username], args[:password], args[:host], args[:bmc_provider], options)
       end
 
       # returns boolean true if connection to device is successful


### PR DESCRIPTION
- increase rubyipmi version to 0.10.0 which defaults to lan20 driver
- fixes a issue where parameters in a JSON encoded body were being ignored
- adds content type json to response header
