### PR TITLE
Fixes #10259 - Template proxy does not lookup by MAC address

### DIFF
--- a/modules/templates/handler.rb
+++ b/modules/templates/handler.rb
@@ -7,23 +7,25 @@ module Proxy::Templates
   class Handler < ::Proxy::HttpRequest::ForemanRequest
     extend Proxy::Log
 
-    def get_template(kind, token, static = false)
-      opts = { :token => token,
-               :url   => Proxy::Templates::Plugin.settings.template_url
+    def get_template(kind, params, static = false)
+      opts = {
+        :url => Proxy::Templates::Plugin.settings.template_url
       }
+      opts[:mac]    = params[:mac] if params.has_key?('mac')
+      opts[:token]  = params[:token] if params.has_key?('token')
       opts[:static] = static if static
       request = request_factory.create_get("/unattended/#{kind}", opts)
       res = send_request(request)
 
       # You get a 201 from the 'built' URL
-      raise "Error retrieving #{kind} for #{token} from #{uri.host}: #{res.class}" unless ["200", "201"].include?(res.code)
-      Proxy::Log.logger.info "Template: request for #{kind} using #{token} at #{uri.host}"
+      raise "Error retrieving #{kind} for #{opts.to_json} from #{uri.host}: #{res.class}" unless ["200", "201"].include?(res.code)
+      Proxy::Log.logger.info "Template: request for #{kind} using #{opts.to_json} at #{uri.host}"
       res.body
     end
 
-    def self.get_template kind, token, static = false
+    def self.get_template kind, params, static = false
       @handler ||= Handler.new
-      @handler.get_template(kind,token, static)
+      @handler.get_template(kind, params, static)
     end
   end
 

--- a/modules/templates/templates_api.rb
+++ b/modules/templates/templates_api.rb
@@ -14,8 +14,8 @@ class Proxy::TemplatesApi < Sinatra::Base
   end
 
   get "/:kind" do |kind|
-    log_halt(500, "Failed to retrieve #{kind} template for #{params[:token]}: ") do
-      Proxy::Templates::Handler.get_template(kind, params[:token], params[:static])
+    log_halt(500, "Failed to retrieve #{kind} template for #{params.to_json}: ") do
+      Proxy::Templates::Handler.get_template(kind, params, params[:static])
     end
   end
 end

--- a/test/templates/template_test.rb
+++ b/test/templates/template_test.rb
@@ -17,15 +17,25 @@ class TemplateTest < Test::Unit::TestCase
 
   def test_template_requests_return_data_and_contain_template_url
     @expected_body = "my template"
+    @args = { :token => "test-token" }
     stub_request(:get, @foreman_url+'/unattended/provision?token=test-token&url='+@template_url).to_return(:status => [200, 'OK'], :body => @expected_body)
-    result = Proxy::Templates::Handler.get_template('provision', 'test-token')
+    result = Proxy::Templates::Handler.get_template('provision', @args)
     assert_equal(@expected_body, result)
   end
 
   def test_template_requests_pass_static_flag_to_foreman
     @expected_body = "my template"
+    @args = { :token => "test-token" }
     stub_request(:get, @foreman_url+'/unattended/provision?static=true&token=test-token&url='+@template_url).to_return(:status => [200, 'OK'], :body => @expected_body)
-    result = Proxy::Templates::Handler.get_template('provision', 'test-token', 'true')
+    result = Proxy::Templates::Handler.get_template('provision', @args, 'true')
+    assert_equal(@expected_body, result)
+  end
+
+  def test_template_requests_with_macaddress
+    @expected_body = "my template"
+    @args = { :mac => "aa:bb:cc:dd:ee:ff" }
+    stub_request(:get, @foreman_url+'/unattended/provision?static=true&mac=aa:bb:cc:dd:ee:ff&url='+@template_url).to_return(:status => [200, 'OK'], :body => @expected_body)
+    result = Proxy::Templates::Handler.get_template('provision', @args)
     assert_equal(@expected_body, result)
   end
 end


### PR DESCRIPTION
The native template API (/unattended) can lookup by MAC address (PXElinux?mac=aa:bb:cc:dd:ee:ff) in addition to lookup by token (this is very useful for provisioning Windows, for example). The template proxy feature, so far, can not.

Attached is a pull request with my attempt to fix this issue.
