### PR TITLE
Fixes/refs #10264 - omapi port not evaluated.

### DIFF
--- a/config/settings.d/dhcp.yml.example
+++ b/config/settings.d/dhcp.yml.example
@@ -21,3 +21,4 @@
 #:dhcp_leases: /var/lib/dhcpd/dhcpd.leases
 #:dhcp_key_name: secret_key_name
 #:dhcp_key_secret: secret_key
+#:dhcp_omapi_port: 7911

--- a/modules/dhcp/dhcp_plugin.rb
+++ b/modules/dhcp/dhcp_plugin.rb
@@ -2,6 +2,6 @@ class Proxy::DhcpPlugin < ::Proxy::Plugin
   http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
   https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
-  default_settings :dhcp_provider => 'isc'
+  default_settings :dhcp_provider => 'isc', :dhcp_omapi_port => '7911'
   plugin :dhcp, ::Proxy::VERSION
 end

--- a/modules/dhcp/providers/server/isc.rb
+++ b/modules/dhcp/providers/server/isc.rb
@@ -188,6 +188,7 @@ module Proxy::DHCP
         @om = IO.popen("/bin/sh -c '#{om_binary} 2>&1'", "r+")
         @om.puts "key #{Proxy::DhcpPlugin.settings.dhcp_key_name} \"#{Proxy::DhcpPlugin.settings.dhcp_key_secret}\"" if Proxy::DhcpPlugin.settings.dhcp_key_name && Proxy::DhcpPlugin.settings.dhcp_key_secret
         @om.puts "server #{name}"
+        @om.puts "port #{Proxy::DhcpPlugin.settings.dhcp_omapi_port}" if Proxy::DhcpPlugin.settings.dhcp_omapi_port
         @om.puts "connect"
         @om.puts "new host"
       elsif cmd == "disconnect"

--- a/test/dhcp/dhcp_config_test.rb
+++ b/test/dhcp/dhcp_config_test.rb
@@ -5,5 +5,6 @@ class DhcpConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
     Proxy::DhcpPlugin.load_test_settings({})
     assert_equal 'isc', Proxy::DhcpPlugin.settings.dhcp_provider
+    assert_equal '7911', Proxy::DhcpPlugin.settings.dhcp_omapi_port
   end
 end


### PR DESCRIPTION
This pull request adds the omapi-port (default 7911) to the omshell command line http://projects.theforeman.org/issues/10264
