### PR TITLE
Fixes #10324 - Slow serial lookup in Puppet CA module

### DIFF
--- a/modules/puppetca/puppetca_main.rb
+++ b/modules/puppetca/puppetca_main.rb
@@ -1,5 +1,6 @@
 require 'openssl'
 require 'puppet'
+require 'set'
 
 module Proxy::PuppetCa
   extend ::Proxy::Log
@@ -182,7 +183,7 @@ module Proxy::PuppetCa
       raise "Unable to find CRL" unless File.exist?(crl)
 
       crl = OpenSSL::X509::CRL.new(File.read(crl))
-      crl.revoked.collect {|r| r.serial}
+      Set.new(crl.revoked.collect {|r| r.serial})
     end
 
     def puppetca mode, certname


### PR DESCRIPTION
I'm not able to test this in our production environment, but a quick `Benchmark.measure` with dummy data seems to suggest what you would assume, that `Set#include?` look-up is much faster than `Array#include?`.
