### PR TITLE
Fixes #10504 - customrun_args nil -> string

### DIFF
--- a/modules/puppet_proxy/customrun.rb
+++ b/modules/puppet_proxy/customrun.rb
@@ -8,6 +8,6 @@ class Proxy::Puppet::CustomRun < Proxy::Puppet::Runner
       return false
     end
 
-    shell_command( [ escape_for_shell(cmd), Proxy::Puppet::Plugin.settings.customrun_args, shell_escaped_nodes ] )
+    shell_command( [ escape_for_shell(cmd), Proxy::Puppet::Plugin.settings.customrun_args || '', shell_escaped_nodes.join(' ') ] )
   end
 end


### PR DESCRIPTION
```
    customrun was broken in two places
        1) customrun_args - nil
        2) hosts array to string
```
