### PR TITLE
Fixes #10639 - stracktrace is reported via log_halt

### DIFF
--- a/lib/proxy/helpers.rb
+++ b/lib/proxy/helpers.rb
@@ -14,6 +14,7 @@ module Proxy::Helpers
         return yield
       end
     rescue => e
+      exception = e
       message += e.message
       code     = code || 400
     end


### PR DESCRIPTION
Before this patch on log_halt block error:

```
E, [2015-05-28T15:53:04.126687 #24243] ERROR -- : Failed to retrieve iPXE template for : undefined method `encoding' for nil:NilClass
```

After this patch:

```
E, [2015-05-28T15:53:04.126687 #24243] ERROR -- : Failed to retrieve iPXE template for : undefined method `encoding' for nil:NilClass
D, [2015-05-28T15:53:04.126827 #24243] DEBUG -- : /home/lzap/.rbenv/versions/2.1.0/lib/ruby/2.1.0/cgi/util.rb:8:in `escape'
/home/lzap/work/smart-proxy/lib/proxy/request.rb:13:in `block in query_string'
/home/lzap/work/smart-proxy/lib/proxy/request.rb:13:in `each'
/home/lzap/work/smart-proxy/lib/proxy/request.rb:13:in `map'
/home/lzap/work/smart-proxy/lib/proxy/request.rb:13:in `query_string'
```
