### PR TITLE
refs #8046: Add possibility for dhcp providers to provide own method to load single records

### DIFF
--- a/modules/dhcp/dhcp_api.rb
+++ b/modules/dhcp/dhcp_api.rb
@@ -81,7 +81,7 @@ class Proxy::DhcpApi < ::Sinatra::Base
   get "/:network/:record" do
     begin
       content_type :json
-      record = load_subnet[params[:record]]
+      record = @server.find_record(params[:record])
       log_halt 404, "Record #{params[:network]}/#{params[:record]} not found" unless record
       record.options.to_json
     rescue => e


### PR DESCRIPTION
I recently started working on a infoblox dhcp provider and it takes ages to load single dhcp records without a possiblity to not load whole subnets on requesting a single record :)
