### PR TITLE
Fixes #10527 - DHCP/TFTP support for Cisco POAP

### DIFF
--- a/modules/dhcp/providers/server/isc.rb
+++ b/modules/dhcp/providers/server/isc.rb
@@ -46,6 +46,7 @@ module Proxy::DHCP
 
       statements += solaris_options_statements(options)
       statements += ztp_options_statements(options)
+      statements += poap_options_statements(options)
 
       omcmd "set statements = \"#{statements.join(" ")}\""      unless statements.empty?
       omcmd "create"
@@ -379,6 +380,17 @@ module Proxy::DHCP
         opt150 = ip2hex validate_ip(options[:nextServer])
         statements << "option option-150 = #{opt150};"
         statements << "option FM_ZTP.config-file-name = \\\"#{options[:filename]}\\\";"
+      end
+      statements
+    end
+
+    # Cisco NX-OS POAP requires special DHCP options
+    def poap_options_statements(options)
+      statements = []
+      if options[:filename] && options[:filename].match(/^poap.cfg.*/i)
+        logger.debug "setting POAP options"
+        statements << "option tftp-server-name = #{options[:nextServer]};"
+        statements << "option bootfile-name = \\\"#{options[:filename]}\\\";"
       end
       statements
     end

--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -92,6 +92,18 @@ module Proxy::TFTP
     end
   end
 
+  class Poap < Server
+    def pxeconfig_dir
+      "#{path}/poap.cfg"
+    end
+    def pxe_default
+      pxeconfig_dir
+    end
+    def pxeconfig_file mac
+      "#{pxeconfig_dir}/"+mac.gsub(/:/,"").upcase
+    end
+  end
+
   def self.fetch_boot_file dst, src
 
     filename    = boot_filename(dst, src)

--- a/test/dhcp/server_isc_test.rb
+++ b/test/dhcp/server_isc_test.rb
@@ -75,4 +75,13 @@ class ServerIscTest < Test::Unit::TestCase
     assert_equal ['option option-150 = c0:a8:7a:01;', 'option FM_ZTP.config-file-name = \\"ztp.cfg\\";'],
                  dhcp.send(:ztp_options_statements, :filename => 'ztp.cfg', :nextServer => '192.168.122.1')
   end
+
+  def test_poap_quirks
+    dhcp = Proxy::DHCP::Server::ISC.new(:name => '192.168.122.1', :config => './test/fixtures/dhcp/dhcp.conf', :leases => './test/fixtures/dhcp/dhcp.leases')
+    assert_equal [], dhcp.send(:poap_options_statements, {})
+    assert_equal [], dhcp.send(:poap_options_statements, :filename => 'foo.cfg')
+
+    assert_equal ['option tftp-server-name = 192.168.122.1;', 'option bootfile-name = \\"poap.cfg/something.py\\";'],
+                 dhcp.send(:poap_options_statements, :filename => 'poap.cfg/something.py', :nextServer => '192.168.122.1')
+  end
 end


### PR DESCRIPTION
This adds support for Cisco POAP at the DHCP and TFTP proxies, working together with pull request #2464 for Foreman.
