### PR TITLE
Fixes #11310 - added kexec option to BMC shell provider

### DIFF
--- a/lib/proxy/http_downloads.rb
+++ b/lib/proxy/http_downloads.rb
@@ -7,9 +7,9 @@ module Proxy
         lock =  Proxy::FileLock.try_locking(dst)
         unless lock.nil?
           HttpDownload.new(src, dst, lock)
-          return true
+        else
+          false
         end
-        false
       end
     end
   end

--- a/modules/bmc/bmc_api.rb
+++ b/modules/bmc/bmc_api.rb
@@ -290,7 +290,7 @@ module Proxy::BMC
           @bmc = Proxy::BMC::IPMI.new(args)
         when "shell"
           require 'bmc/shell'
-          @bmc = Proxy::BMC::Shell.new
+          @bmc = Proxy::BMC::Shell.new(body_parameters['kernel'], body_parameters['initram'], body_parameters['append'])
         else
           log_halt 400, "Invalid BMC type: #{provider_type}"
       end

--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -115,7 +115,7 @@ module Proxy::TFTP
     # as the dst might contain another sub directory
     FileUtils.mkdir_p destination.parent
 
-    ::Proxy::HttpDownloads.start_download(src.to_s, destination.to_s)
+    ::Proxy::HttpDownloads.start_download(src.to_s, destination.to_s) && true
   end
 
   def self.boot_filename(dst, src)

--- a/test/bmc/bmc_api_test.rb
+++ b/test/bmc/bmc_api_test.rb
@@ -130,6 +130,7 @@ class BmcApiTest < Test::Unit::TestCase
     api = Proxy::BMC::Api.new!
     Proxy::BMC::Plugin.settings.stubs(:bmc_default_provider).returns('freeipmi')
     api.stubs(:params).returns('bmc_provider' => 'shell', :host => :host)
+    api.stubs(:body_parameters).returns({})
     result = api.bmc_setup
     assert_kind_of(Proxy::BMC::Shell,result)
   end


### PR DESCRIPTION
This allows to pass in additional options via BODY. When these are present, the
host will be kexeced instead of rebooted. This is used on
foreman-discovery-image.
