### PR TITLE
Fixes #11997 - DHCP option for NX-OS should be quoted

### DIFF
--- a/modules/dhcp/providers/server/isc.rb
+++ b/modules/dhcp/providers/server/isc.rb
@@ -403,7 +403,7 @@ module Proxy::DHCP
       statements = []
       if options[:filename] && options[:filename].match(/^poap.cfg.*/i)
         logger.debug "setting POAP options"
-        statements << "option tftp-server-name = #{options[:nextServer]};"
+        statements << "option tftp-server-name = \\\"#{options[:nextServer]}\\\";"
         statements << "option bootfile-name = \\\"#{options[:filename]}\\\";"
       end
       statements

--- a/test/dhcp/server_isc_test.rb
+++ b/test/dhcp/server_isc_test.rb
@@ -75,7 +75,7 @@ class ServerIscTest < Test::Unit::TestCase
     assert_equal [], @dhcp.send(:poap_options_statements, {})
     assert_equal [], @dhcp.send(:poap_options_statements, :filename => 'foo.cfg')
 
-    assert_equal ['option tftp-server-name = 192.168.122.1;', 'option bootfile-name = \\"poap.cfg/something.py\\";'],
+    assert_equal ['option tftp-server-name = \\"192.168.122.1\\";', 'option bootfile-name = \\"poap.cfg/something.py\\";'],
                  @dhcp.send(:poap_options_statements, :filename => 'poap.cfg/something.py', :nextServer => '192.168.122.1')
   end
 


### PR DESCRIPTION
This fixes the lack of quotes for DHCP option `tftp-server-name`, when a Cisco NX-OS switch is being provisioned via POAP.
