### PR TITLE
Fixes #12138 Add require statements

### DIFF
--- a/lib/smart_proxy.rb
+++ b/lib/smart_proxy.rb
@@ -30,7 +30,10 @@ require 'proxy/request'
 require 'bundler_helper'
 Proxy::BundlerHelper.require_groups(:default)
 
+require 'json'
+require 'rack'
 require 'rack-patch' if Rack.release < "1.3"
+require 'sinatra'
 require 'sinatra-patch'
 require 'sinatra/authorization'
 require 'poodles-fix'

--- a/lib/smart_proxy_for_testing.rb
+++ b/lib/smart_proxy_for_testing.rb
@@ -1,5 +1,8 @@
 require 'proxy'
 require 'checks'
+require 'json'
+require 'rack'
+require 'sinatra'
 require 'proxy/log'
 require 'proxy/settings'
 require 'proxy/settings/plugin'


### PR DESCRIPTION
Adding these allows smart_proxy to be run from bundler.
