### PR TITLE
Fixes #9974: do not attempt to open settings.d/foreman_proxy.yml

### DIFF
--- a/modules/root/root_plugin.rb
+++ b/modules/root/root_plugin.rb
@@ -4,4 +4,9 @@ class ::Proxy::RootPlugin < ::Proxy::Plugin
 
   http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
   https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
+
+  # this is a special case: 'root' module doesn't have configuration file
+  def self.settings
+    @settings ||= ::Proxy::Settings::Plugin.new(plugin_default_settings, {})
+  end
 end


### PR DESCRIPTION
  'root' module (aka 'foreman_proxy') doesn't have config file and will no longer try to open it on startup.
