### PR TITLE
fixes #12178 - Smart Proxy Plugins do not handle rc versions well

### DIFF
--- a/test/plugin_test.rb
+++ b/test/plugin_test.rb
@@ -69,14 +69,22 @@ class PluginTest < Test::Unit::TestCase
   end
 
   # version number follows core (non-release) standard with -develop, which has special handling
-  class TestPlugin3 < Proxy::Plugin; plugin :test3, '1.5-develop'; end
-  class TestPlugin4 < Proxy::Plugin; plugin :test4, '1.0'; requires :test3, '~> 1.5.0'; end
+  class TestPlugin3a < Proxy::Plugin; plugin :test3a, '1.5-develop'; end
+  class TestPlugin3b < Proxy::Plugin; plugin :test3b, '1.10.0-RC1'; end
+  class TestPlugin4a < Proxy::Plugin; plugin :test4a, '1.0'; requires :test3a, '~> 1.5.0'; end
+  class TestPlugin4b < Proxy::Plugin; plugin :test4b, '1.0'; requires :test3b, '~> 1.10.0'; end
   def test_satisfied_dependency
     assert_nothing_raised do
-      TestPlugin3.new.validate_dependencies!(TestPlugin3.dependencies)
+      TestPlugin3a.new.validate_dependencies!(TestPlugin3a.dependencies)
     end
     assert_nothing_raised do
-      TestPlugin4.new.validate_dependencies!(TestPlugin4.dependencies)
+      TestPlugin3b.new.validate_dependencies!(TestPlugin3b.dependencies)
+    end
+    assert_nothing_raised do
+      TestPlugin4a.new.validate_dependencies!(TestPlugin4a.dependencies)
+    end
+    assert_nothing_raised do
+      TestPlugin4b.new.validate_dependencies!(TestPlugin4b.dependencies)
     end
   end
 


### PR DESCRIPTION
Foreman 1.10.0-rc-1 smart proxy dns feature does not work.

In the Log you see the following error:

E, [2015-10-15T14:00:38.213704 #28260] ERROR -- : Couldn't enable plugin dns_nsupdate: Illformed requirement ["1.10.0-RC1"]:/usr/share/rubygems/rubygems/requirement.rb:90:in `parse'
/usr/share/rubygems/rubygems/requirement.rb:120:in`block in initialize'
/usr/share/rubygems/rubygems/requirement.rb:120:in `map!'
/usr/share/rubygems/rubygems/requirement.rb:120:in`initialize'
/usr/share/rubygems/rubygems/requirement.rb:55:in `new'
/usr/share/rubygems/rubygems/requirement.rb:55:in`create'
/usr/share/rubygems/rubygems/dependency.rb:58:in `initialize'
/usr/share/foreman-proxy/lib/proxy/pluggable.rb:61:in`new'
/usr/share/foreman-proxy/lib/proxy/pluggable.rb:61:in `block in validate_dependencies!'
/usr/share/foreman-proxy/lib/proxy/pluggable.rb:58:in`each'
/usr/share/foreman-proxy/lib/proxy/pluggable.rb:58:in `validate_dependencies!'
/usr/share/foreman-proxy/lib/proxy/pluggable.rb:37:in`validate!'
/usr/share/foreman-proxy/lib/proxy/provider.rb:22:in `configure_plugin'
/usr/share/foreman-proxy/lib/proxy/plugin.rb:28:in`block in configure_loaded_plugins'
/usr/share/foreman-proxy/lib/proxy/plugin.rb:28:in `each'
/usr/share/foreman-proxy/lib/proxy/plugin.rb:28:in`configure_loaded_plugins'
/usr/share/foreman-proxy/lib/launcher.rb:101:in `launch'
/usr/share/foreman-proxy/bin/smart-proxy:6:in`<main>'
