### PR TITLE
Fixes #12211 - Improve DHCP subnets parsing to get more informations …

### DIFF
--- a/modules/dhcp/dhcp_api.rb
+++ b/modules/dhcp/dhcp_api.rb
@@ -22,7 +22,7 @@ class Proxy::DhcpApi < ::Sinatra::Base
         require 'dhcp/providers/server/virsh'
         @server = Proxy::DHCP::Virsh.instance_with_default_parameters
       else
-        log_halt 400, "Unrecognized or missing DHCP vendor type: #{Proxy::DhcpPlugin.settings.dhcp_vendor.nil? ? "MISSING" : Proxy::DhcpPlugin.settings.dhcp_vendor}"
+        log_halt 400, "Unrecognized or missing DHCP vendor type: #{Proxy::DhcpPlugin.settings.dhcp_vendor.nil? ? 'MISSING' : Proxy::DhcpPlugin.settings.dhcp_vendor}"
       end
 
       @server.loadSubnets
@@ -49,7 +49,7 @@ class Proxy::DhcpApi < ::Sinatra::Base
         content_type :json
 
         log_halt 404, "No subnets found on server @{name}" unless @server.subnets
-        @server.subnets.map{|s| {:network => s.network, :netmask => s.netmask }}.to_json
+        @server.subnets.map{|s| {:network => s.network, :netmask => s.netmask, :options => s.options}}.to_json
       else
         erb :"dhcp/index"
       end

--- a/modules/dhcp/server.rb
+++ b/modules/dhcp/server.rb
@@ -53,9 +53,9 @@ module Proxy::DHCP
 
     def find_record(subnet_address, an_address)
       @service.find_host_by_ip(subnet_address, an_address) ||
-          @service.find_host_by_mac(subnet_address, an_address) ||
-          @service.find_lease_by_ip(subnet_address, an_address) ||
-          @service.find_lease_by_mac(subnet_address, an_address)
+        @service.find_host_by_mac(subnet_address, an_address) ||
+        @service.find_lease_by_ip(subnet_address, an_address) ||
+        @service.find_lease_by_mac(subnet_address, an_address)
     end
 
     def unused_ip(subnet, mac_address, from_address, to_address)

--- a/modules/dhcp/subnet.rb
+++ b/modules/dhcp/subnet.rb
@@ -17,11 +17,19 @@ module Proxy::DHCP
     include Proxy::Log
     include Proxy::Validations
 
-    def initialize network, netmask
-      @network   = validate_ip network
-      @netmask   = validate_ip netmask
-      @options   = {}
-      @timestamp = Time.now
+    def initialize network, netmask, options = {}
+      @network = validate_ip network
+      @netmask = validate_ip netmask
+      @options = {}
+
+      @options[:routers] = options[:routers].each{|ip| validate_ip ip } if options[:routers]
+      @options[:domain_name] = options[:domain_name] if options[:domain_name]
+      @options[:domain_name_servers] = options[:domain_name_servers].each{|ip| validate_ip ip } if options[:domain_name_servers]
+      @options[:ntp_servers] = options[:ntp_servers].each{|ip| validate_ip ip } if options[:ntp_servers]
+      @options[:interface_mtu] = options[:interface_mtu].to_i if options[:interface_mtu]
+      @options[:range] = options[:range] if options[:range] && options[:range][0] && options[:range][1] && valid_range(:from => options[:range][0], :to => options[:range][1])
+
+      @timestamp     = Time.now
     end
 
     def include? ip

--- a/test/dhcp/dhcp_api_test.rb
+++ b/test/dhcp/dhcp_api_test.rb
@@ -37,8 +37,31 @@ class DhcpApiTest < Test::Unit::TestCase
     get "/"
     assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
     data = JSON.parse(last_response.body)
-    expected = [{"network"=>"192.168.122.0", "netmask"=>"255.255.255.0"}]
-    assert_equal expected, data
+    expected = [{
+        "network"=>"192.168.122.0",
+        "netmask"=>"255.255.255.0",
+        "options"=>{"routers"=>["192.168.122.250"]}
+      },{
+        "network"=>"192.168.123.0",
+        "netmask"=>"255.255.255.192",
+        "options"=>{
+          "routers"=>["192.168.123.1"],
+          "domain_name_servers"=>["192.168.123.1"],
+          "range"=>["192.168.123.2", "192.168.123.62"]
+        }
+      },{
+        "network"=>"192.168.124.0",
+        "netmask"=>"255.255.255.0",
+        "options"=>{
+          "routers"=>["192.168.124.1", "192.168.124.2"],
+          "domain_name_servers"=>["192.168.123.1", "192.168.122.250"]
+        }
+      },{
+         "network"=>"192.168.1.0",
+         "netmask"=>"255.255.255.128",
+         "options" => {}
+    }].to_set
+    assert_equal expected, data.to_set
   end
 
   def test_api_02_get_network

--- a/test/dhcp/subnet_test.rb
+++ b/test/dhcp/subnet_test.rb
@@ -5,7 +5,6 @@ require 'dhcp/subnet'
 require 'dhcp/record/reservation'
 
 class Proxy::DHCPSubnetTest < Test::Unit::TestCase
-
   def setup
     @network = "192.168.0.0"
     @netmask = "255.255.255.0"
@@ -23,6 +22,39 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
   def test_should_not_save_invalid_network_addresses
     assert_raise Proxy::Validations::Error do
       Proxy::DHCP::Subnet.new("1..1.1", @netmask)
+    end
+  end
+
+  def test_should_not_save_invalid_router_addresses
+    assert_raise Proxy::Validations::Error do
+      Proxy::DHCP::Subnet.new(@network, @netmask, :routers => ["192.168..1"])
+    end
+  end
+
+  def test_should_not_save_invalid_domain_name_servers_addresses
+    assert_raise Proxy::Validations::Error do
+      Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name_servers => ["192.168.1.."])
+    end
+    assert_raise Proxy::Validations::Error do
+      Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name_servers => ["192.168.1.1", "192.1068.13"])
+    end
+  end
+
+  def test_should_not_save_invalid_range
+    assert_raise Proxy::Validations::Error do
+      Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.0..", "192.168.0.50"])
+    end
+    assert_raise Proxy::Validations::Error do
+      Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.0.3", "192.168.0.."])
+    end
+    assert_raise Proxy::DHCP::Error do
+      Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.0.3", "192.168.1.100"])
+    end
+    assert_raise Proxy::DHCP::Error do
+      Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.1.3", "192.168.0.100"])
+    end
+    assert_raise Proxy::DHCP::Error do
+      Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.0.100", "192.168.0.3"])
     end
   end
 

--- a/test/fixtures/dhcp/dhcp_subnets.conf
+++ b/test/fixtures/dhcp/dhcp_subnets.conf
@@ -1,6 +1,25 @@
+# This is a comment.
+
 subnet 192.168.122.0 netmask 255.255.255.0 {
-  option routers 192.168.122.250;
+  option routers 192.168.122.250; # This is an inline comment
   next-server 192.168.122.251;
+}
+
+subnet 192.168.123.0 netmask 255.255.255.192 {
+  option subnet-mask 255.255.255.192;
+  option routers 192.168.123.1;
+  option domain-name-servers 192.168.123.1;
+  option domain-name example.com;
+  range 192.168.123.2 192.168.123.62;
+}
+
+subnet 192.168.124.0 netmask 255.255.255.0 {
+  option domain-name foo.example.com;
+  option routers 192.168.124.1, 192.168.124.2;
+  option domain-name-servers 192.168.123.1, 192.168.122.250;
+}
+
+subnet 192.168.1.0 netmask 255.255.255.128 {
 }
 
 host test.example.com {


### PR DESCRIPTION
…from DHCP server

Add ability to parse some subnet options and provides them to the foreman to enhance subnet imports.

This modify the dhcp smart-proxy API (adding options hash).
