### PR TITLE
Fixes #12217: support older versions of bundler

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -5,7 +5,7 @@ group :test do
   gem 'single_test'
   gem 'ci_reporter', '>= 1.6.3', "< 2.0.0", :require => false
   gem 'rdoc'
-  gem 'test-unit', :platforms => [:ruby_19, :ruby_20, :ruby_21, :ruby_22]
+  gem 'test-unit' if RUBY_VERSION > "1.8.7"
   gem 'webmock'
   gem 'rubocop-checkstyle_formatter' if RUBY_VERSION > "1.9.2"
 end


### PR DESCRIPTION
  No longer rely on :platforms to install test-unit dependency
