### PR TITLE
Fixes #12254: pinned addressable gem to ~> 2.3.8

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -6,6 +6,7 @@ group :test do
   gem 'ci_reporter', '>= 1.6.3', "< 2.0.0", :require => false
   gem 'rdoc'
   gem 'test-unit' if RUBY_VERSION > "1.8.7"
+  gem 'addressable', '~> 2.3.8' if RUBY_VERSION == '1.8.7' # 2.4.0 drops support for ruby 1.8.7
   gem 'webmock'
   gem 'rubocop-checkstyle_formatter' if RUBY_VERSION > "1.9.2"
 end


### PR DESCRIPTION
  This is the last version to support 1.8.7.
