### PR TITLE
Fixes #12319: fixed race condition in templates module

### DIFF
--- a/modules/templates/template_proxy_request.rb
+++ b/modules/templates/template_proxy_request.rb
@@ -32,11 +32,6 @@ module Proxy::Templates
       logger.warn "Unable to extract request headers: #{e}"
       {}
     end
-
-    def self.get_template(kind, env, params)
-      @handler ||= TemplateProxyRequest.new
-      @handler.get_template(kind, env, params)
-    end
   end
 
 end

--- a/modules/templates/templates_api.rb
+++ b/modules/templates/templates_api.rb
@@ -16,7 +16,7 @@ class Proxy::TemplatesApi < Sinatra::Base
 
   get "/:kind" do |kind|
     log_halt(500, "Failed to retrieve #{kind} template for #{params.inspect}: ") do
-      Proxy::Templates::TemplateProxyRequest.get_template(kind, request.env, params)
+      Proxy::Templates::TemplateProxyRequest.new.get_template(kind, request.env, params)
     end
   end
 end

--- a/test/templates/template_api_test.rb
+++ b/test/templates/template_api_test.rb
@@ -24,7 +24,7 @@ class TemplateApiTest < Test::Unit::TestCase
   end
 
   def test_api_can_ask_for_a_template
-    Proxy::Templates::TemplateProxyRequest.stubs(:get_template).returns("An API template")
+    Proxy::Templates::TemplateProxyRequest.any_instance.expects(:get_template).returns("An API template")
     get "/provision", @args
     assert last_response.ok?, "Last response was not ok"
     assert_match("An API template", last_response.body)

--- a/test/templates/template_proxy_request_test.rb
+++ b/test/templates/template_proxy_request_test.rb
@@ -40,7 +40,7 @@ class TemplateProxyRequestTest < Test::Unit::TestCase
     @expected_body = "my template"
     args = { :token => "test-token" }
     stub_request(:get, @foreman_url+'/unattended/provision?token=test-token&url='+@template_url).to_return(:status => [200, 'OK'], :body => @expected_body)
-    result = Proxy::Templates::TemplateProxyRequest.get_template('provision', @request_env, args)
+    result = Proxy::Templates::TemplateProxyRequest.new.get_template('provision', @request_env, args)
     assert_equal(@expected_body, result)
   end
 
@@ -48,7 +48,7 @@ class TemplateProxyRequestTest < Test::Unit::TestCase
     @expected_body = "my template"
     args = { :token => "test-token", :static => "true" }
     stub_request(:get, @foreman_url+'/unattended/provision?static=true&token=test-token&url='+@template_url).to_return(:status => [200, 'OK'], :body => @expected_body)
-    result = Proxy::Templates::TemplateProxyRequest.get_template('provision', @request_env, args)
+    result = Proxy::Templates::TemplateProxyRequest.new.get_template('provision', @request_env, args)
     assert_equal(@expected_body, result)
   end
 
@@ -56,7 +56,7 @@ class TemplateProxyRequestTest < Test::Unit::TestCase
     @expected_body = "my template"
     args = { :mac => "aa:bb:cc:dd:ee:ff" }
     stub_request(:get, @foreman_url+'/unattended/provision?mac=aa:bb:cc:dd:ee:ff&url='+@template_url).to_return(:status => [200, 'OK'], :body => @expected_body)
-    result = Proxy::Templates::TemplateProxyRequest.get_template('provision', @request_env, args)
+    result = Proxy::Templates::TemplateProxyRequest.new.get_template('provision', @request_env, args)
     assert_equal(@expected_body, result)
   end
 
@@ -67,7 +67,7 @@ class TemplateProxyRequestTest < Test::Unit::TestCase
     stub_request(:get, @foreman_url+'/unattended/provision?token=test-token&url='+@template_url).
       with(:headers => {'X-Forwarded-For'=>'1.2.3.4, proxy.lan', 'X-Rhn-Provisioning-Mac-0'=>'aa:bb:cc:dd:ee:ff'}).
       to_return(:status => [200, 'OK'], :body => @expected_body)
-    result = Proxy::Templates::TemplateProxyRequest.get_template('provision', @request_env, args)
+    result = Proxy::Templates::TemplateProxyRequest.new.get_template('provision', @request_env, args)
     assert_equal(@expected_body, result)
   end
 end


### PR DESCRIPTION
  Multiple simultaneous requests to /unattended/template_type no longer fail.
