### PR TITLE
Fixes #12465 -  handle ISC deleted entires correctly

### DIFF
--- a/modules/dhcp/providers/server/isc.rb
+++ b/modules/dhcp/providers/server/isc.rb
@@ -1,5 +1,6 @@
 require 'time'
 require 'dhcp/subnet'
+require 'dhcp/record/deleted_reservation'
 require 'dhcp/record/reservation'
 require 'dhcp/record/lease'
 require 'dhcp/server'
@@ -78,13 +79,13 @@ module Proxy::DHCP
             opts.merge!(parse_record_options(data))
           end
         end
-        begin
-          subnet = @service.find_subnet(opts[:ip])
-          next unless subnet
-          ret_val << Proxy::DHCP::Reservation.new(opts.merge(:subnet => subnet))
-        rescue Exception => e
-          logger.warn "skipped #{hostname} - #{e}"
+        if opts[:deleted]
+          ret_val << Proxy::DHCP::DeletedReservation.new(opts)
+          next
         end
+        subnet = @service.find_subnet(opts[:ip])
+        next unless subnet
+        ret_val << Proxy::DHCP::Reservation.new(opts.merge(:subnet => subnet))
       end
 
       conf.scan(/lease\s+(\S+\s*\{[^}]+\})/) do |lease|
@@ -109,12 +110,11 @@ module Proxy::DHCP
     def initialize_memory_store_with_dhcp_records(records)
       records.each do |record|
         case record
+        when Proxy::DHCP::DeletedReservation
+          record = @service.find_host_by_hostname(record.name)
+          @service.delete_host(record) if record
+          next
         when Proxy::DHCP::Reservation
-          if record.options[:deleted]
-            record = @service.find_host_by_hostname(record.subnet_address, record.name)
-            @service.delete_host(record) if record
-            next
-          end
           if dupe = @service.find_host_by_mac(record.subnet_address, record.mac)
             @service.delete_host(dupe)
           end

--- a/modules/dhcp/record/deleted_reservation.rb
+++ b/modules/dhcp/record/deleted_reservation.rb
@@ -1,0 +1,13 @@
+require 'dhcp/record/reservation'
+
+module Proxy::DHCP
+  # represent a deleted DHCP Record
+  class DeletedReservation < Reservation
+    attr_reader :name
+
+    def initialize options = {}
+      @name = options[:name] || options[:hostname] || raise("Must define a name: #{options.inspect}")
+      @options = options
+    end
+  end
+end

--- a/modules/dhcp/subnet_service.rb
+++ b/modules/dhcp/subnet_service.rb
@@ -60,7 +60,7 @@ class Proxy::DHCP::SubnetService
   def add_host(subnet_address, record)
     @reservations_by_ip[subnet_address, record.ip] = record
     @reservations_by_mac[subnet_address, record.mac] = record
-    @reservations_by_name[subnet_address, record.name] = record
+    @reservations_by_name[record.name] = record
     logger.debug("Added a reservation: #{record.ip}:#{record.mac}:#{record.name}")
   end
 
@@ -73,7 +73,7 @@ class Proxy::DHCP::SubnetService
   def delete_host(record)
     @reservations_by_ip.delete(record.subnet.network, record.ip)
     @reservations_by_mac.delete(record.subnet.network, record.mac)
-    @reservations_by_name.delete(record.subnet.network, record.name)
+    @reservations_by_name.delete(record.name)
     logger.debug("Deleted a reservation: #{record.ip}:#{record.mac}:#{record.name}")
   end
 
@@ -93,15 +93,15 @@ class Proxy::DHCP::SubnetService
     @reservations_by_ip[subnet_address, ip_address]
   end
 
-  def find_host_by_hostname(subnet_address, hostname)
-    @reservations_by_name[subnet_address, hostname]
+  def find_host_by_hostname(hostname)
+    return @reservations_by_name[hostname]
   end
 
   def all_hosts(subnet_address = nil)
     if subnet_address
-      return @reservations_by_name[subnet_address] ? @reservations_by_name.values(subnet_address) : []
+      return @reservations_by_ip[subnet_address] ? @reservations_by_ip.values(subnet_address) : []
     end
-    @reservations_by_name.values
+    @reservations_by_ip.values
   end
 
   def all_leases(subnet_address = nil)

--- a/test/dhcp/dhcp_api_test.rb
+++ b/test/dhcp/dhcp_api_test.rb
@@ -77,6 +77,10 @@ class DhcpApiTest < Test::Unit::TestCase
         "ip"         => "192.168.122.10",
         "mac"        => "10:10:10:10:10:10",
       }, {
+        "hostname"   => "undeleted.example.com",
+        "ip"         => "192.168.122.35",
+        "mac"        => "10:10:10:10:30:30",
+      },{
         "hostname"   => "mac441ea173366b.example.com",
         "ip"         => "192.168.122.44",
         "mac"        => "44:1e:a1:73:36:6b",

--- a/test/dhcp/server_isc_test.rb
+++ b/test/dhcp/server_isc_test.rb
@@ -173,7 +173,11 @@ class ServerIscTest < Test::Unit::TestCase
     @subnet_service.add_subnet(subnet)
     @dhcp.loadSubnetData(subnet)
 
-    assert_equal 7, @subnet_service.all_hosts("192.168.122.0").size + @subnet_service.all_leases("192.168.122.0").size
+    assert_equal 8, @subnet_service.all_hosts("192.168.122.0").size + @subnet_service.all_leases("192.168.122.0").size
+    assert_nil @subnet_service.find_host_by_hostname("deleted.example.com")
+    assert_nil @subnet_service.find_host_by_ip(subnet.network, "192.168.122.0")
+    assert_not_nil @subnet_service.find_host_by_hostname("undeleted.example.com")
+    assert_not_nil @subnet_service.find_host_by_ip(subnet.network, "192.168.122.35")
   end
 
   def test_get_ip_list_from_config_line

--- a/test/dhcp/subnet_service_test.rb
+++ b/test/dhcp/subnet_service_test.rb
@@ -77,7 +77,7 @@ class SubnetServiceTest < Test::Unit::TestCase
 
     assert_equal reservation, @reservations_ip_store["192.168.0.0", "192.168.0.1"]
     assert_equal reservation, @reservations_mac_store["192.168.0.0", "00:11:22:33:44:55"]
-    assert_equal reservation, @reservations_name_store["192.168.0.0", "test"]
+    assert_equal reservation, @reservations_name_store["test"]
   end
 
   def test_delete_lease
@@ -100,7 +100,7 @@ class SubnetServiceTest < Test::Unit::TestCase
 
     assert_nil @reservations_ip_store["192.168.0.0", "192.168.0.1"]
     assert_nil @reservations_mac_store["192.168.0.0", "00:11:22:33:44:55"]
-    assert_nil @reservations_name_store["192.168.0.0", "test"]
+    assert_nil @reservations_name_store["test"]
   end
 
   def test_all_leases
@@ -186,10 +186,10 @@ class SubnetServiceTest < Test::Unit::TestCase
                                                  :mac => "00:11:22:33:44:55", :ip => "192.168.0.1", :name => "test")
     @service.add_host("192.168.0.0", reservation)
 
-    assert_equal reservation, @service.find_host_by_hostname("192.168.0.0", "test")
+    assert_equal reservation, @service.find_host_by_hostname("test", "192.168.0.0")
   end
 
   def test_find_reservation_by_name_returns_nil_for_nonexistent_record
-    assert_nil @service.find_host_by_hostname("192.168.0.0",  "test")
+    assert_nil @service.find_host_by_hostname("test")
   end
 end

--- a/test/fixtures/dhcp/dhcp.leases
+++ b/test/fixtures/dhcp/dhcp.leases
@@ -13,18 +13,32 @@ host ten.example.com {
 }
 
 # Reservation that is deleted
-host deleteme.example.com {
+host deleted.example.com {
   dynamic;
   hardware ethernet 10:10:10:10:20:20;
   fixed-address 192.168.122.20;
   supersede host-name = "deleteme.example.com";
 }
-host deleteme.example.com {
+host deleted.example.com {
   dynamic;
-  hardware ethernet 10:10:10:10:20:20;
-  fixed-address 192.168.122.20;
-  supersede host-name = "deleteme.example.com";
   deleted;
+}
+# Reservation that is deleted and then undeleted with same name
+host undeleted.example.com {
+  dynamic;
+  hardware ethernet 10:10:10:10:30:30;
+  fixed-address 192.168.122.30;
+  supersede host-name = "undeleted.example.com";
+}
+host undeleted.example.com {
+  dynamic;
+  deleted;
+}
+host undeleted.example.com {
+  dynamic;
+  hardware ethernet 10:10:10:10:30:30;
+  fixed-address 192.168.122.35;
+  supersede host-name = "undeleted.example.com";
 }
 
 # The following six leases are from booting a real-world DELL hardware with


### PR DESCRIPTION
~~Fixes #12465 with three changes: ~=
1. Don't catch Exception (the error it surfaced was opaque)
2. Added a test case for a record that doesn't have an IP
3. Skip records without an IP, otherwise they will error on trying to find the subnet~~

Alright, let's try this again correctly. Here's what's happening:
- The proxy creates a DHCP reservation in ISC via omshell. dhcpd.leases will contain an entry:

```
host deletedhost.example.com {
  dynamic;
  hardware ethernet aa:aa:aa:aa:aa:aa;
  fixed-address 192.168.0.10;
        supersede server.filename = "pxelinux.0";
        supersede server.next-server = ff:ff:ff:ff;
        supersede host-name = "deletedhost.example.com";
}
```
- The proxy deletes the host. dhcpd.leases will now contain the original entry _and_ the following at the bottom of the file:

```
host deletedhost.example.com {
  dynamic;
  deleted;
}
```
- Foreman is trying to modify the DHCP reservation, so it calls `DELETE` on `/dhcp/192.168.0.0/aa:aa:aa:aa:aa:aa`.
- The proxy parses dhcpd.leases correctly parsing the first entry and adding it to the in memory database. It fails to parse the deleted entry because it doesn't have an address and since we're catching Exception it moves on.
- The proxy then tries to delete the record that it thinks exists and then #12469 is triggered.
