### PR TITLE
Fixes #12568 - Add module versions to /version

### DIFF
--- a/modules/root/root_api.rb
+++ b/modules/root/root_api.rb
@@ -4,7 +4,6 @@ class Proxy::RootApi < Sinatra::Base
   get "/features" do
     begin
       plugin_names = ::Proxy::Plugins.enabled_plugins.collect(&:plugin_name).collect(&:to_s).sort
-
       @features = plugin_names - ['foreman_proxy']
       if request.accept? 'application/json'
         content_type :json
@@ -19,7 +18,9 @@ class Proxy::RootApi < Sinatra::Base
 
   get "/version" do
     begin
-      {:version => Proxy::VERSION}.to_json
+      content_type :json
+      modules = Hash[::Proxy::Plugins.enabled_plugins.collect {|plugin| [plugin.plugin_name.to_s, plugin.version.to_s]}].reject { |key| key == 'foreman_proxy' }
+      {:version => Proxy::VERSION, :modules => modules}.to_json
     rescue => e
       log_halt 400, e
     end

--- a/test/root/root_api_test.rb
+++ b/test/root/root_api_test.rb
@@ -31,7 +31,10 @@ class RootApiTest < Test::Unit::TestCase
   end
 
   def test_version
+    ::Proxy::Plugins.stubs(:enabled_plugins).returns([TestPlugin2.new, TestPlugin3.new, TestPlugin0.new])
     get "/version"
-    assert_equal({"version" => Proxy::VERSION}, JSON.parse(last_response.body))
+    assert_equal(Proxy::VERSION, JSON.parse(last_response.body)["version"])
+    modules = Hash[::Proxy::Plugins.enabled_plugins.collect {|plugin| [plugin.plugin_name.to_s, plugin.version.to_s]}].reject { |key| key == 'foreman_proxy' }
+    assert_equal(modules, JSON.parse(last_response.body)["modules"])
   end
 end


### PR DESCRIPTION
Adds header `Proxy_version` to RootApi calls (`/features`, `/version`) so it could be later used to display in Foreman see [#12605](http://projects.theforeman.org/issues/12506)
