### PR TITLE
Fixes #12573 - disable TLSv1

### DIFF
--- a/lib/poodles-fix.rb
+++ b/lib/poodles-fix.rb
@@ -51,6 +51,7 @@ module OpenSSL
             opts |= OpenSSL::SSL::OP_NO_COMPRESSION if defined?(OpenSSL::SSL::OP_NO_COMPRESSION)
             opts |= OpenSSL::SSL::OP_NO_SSLv2 if defined?(OpenSSL::SSL::OP_NO_SSLv2)
             opts |= OpenSSL::SSL::OP_NO_SSLv3 if defined?(OpenSSL::SSL::OP_NO_SSLv3)
+            opts |= OpenSSL::SSL::OP_NO_TLSv1 if defined?(OpenSSL::SSL::OP_NO_TLSv1)
             opts |= OpenSSL::SSL::OP_CIPHER_SERVER_PREFERENCE if defined?(OpenSSL::SSL::OP_CIPHER_SERVER_PREFERENCE)
             opts
           end.call


### PR DESCRIPTION
> [root@host smart-proxy]# cat /etc/redhat-release
> CentOS release 6.7 (Final)
> [root@host smart-proxy]# ruby -v
> ruby 1.8.7 (2013-06-27 patchlevel 374) [x86_64-linux]

Even on CentOS 6 (both Foreman and Smart-Proxy) with Ruby 1.8.7 we have TLSv1.1 and TLSv1.2 support.
