### PR TITLE
Fixes #12597: remove extraneous method definition in the DNS API tests

### DIFF
--- a/modules/dns/dns_api.rb
+++ b/modules/dns/dns_api.rb
@@ -28,7 +28,6 @@ module Proxy::Dns
     end
 
     delete "/:value" do
-      log_halt(400, "'remove' requires value parameter") if params[:value].nil?
       type = params[:value].match(/\.(in-addr|ip6)\.arpa$/) ? "PTR" : "A"
 
       begin

--- a/test/dns/dns_api_test.rb
+++ b/test/dns/dns_api_test.rb
@@ -78,9 +78,7 @@ class DnsApiTest < Test::Unit::TestCase
   end
 
   def test_delete_returns_error_if_value_is_missing
-    def test_create_returns_error_if_type_is_missing
-      delete '/'
-      assert_equal 400, last_response.status
-    end
+    delete '/'
+    assert_equal 404, last_response.status
   end
 end


### PR DESCRIPTION
http://projects.theforeman.org/issues/12597
