### PR TITLE
Fixes #13326 - Sending feature list to Foreman on startup

### DIFF
--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -1,6 +1,7 @@
 require 'proxy/log'
 require 'proxy/settings'
 require 'proxy/signal_handler'
+require 'proxy/startup_info'
 
 module Proxy
   class Launcher
@@ -122,6 +123,7 @@ module Proxy
       t1 = Thread.new { https_app.start } unless https_app.nil?
       t2 = Thread.new { http_app.start } unless http_app.nil?
 
+      Proxy::StartupInfo.new.put_features
       Proxy::SignalHandler.install_traps
 
       (t1 || t2).join

--- a/lib/proxy/request.rb
+++ b/lib/proxy/request.rb
@@ -39,6 +39,13 @@ module Proxy::HttpRequest
       req.body = body
       req
     end
+
+    def create_put(path, body, headers = {})
+      req = Net::HTTP::Put.new(uri(path).path)
+      req = add_headers(req, headers)
+      req.body = body
+      req
+    end
   end
 
   class ForemanRequest

--- a/lib/proxy/startup_info.rb
+++ b/lib/proxy/startup_info.rb
@@ -1,0 +1,16 @@
+require 'proxy/request'
+require 'socket'
+
+module Proxy
+  class StartupInfo < Proxy::HttpRequest::ForemanRequest
+    include Proxy::Log
+
+    def put_features
+      params = { :proxy_name => Socket.gethostname, :startup_refresh => true }.to_json
+      req = request_factory.create_put("/api/v2/smart_proxies/startup_refresh", params)
+      response = send_request(req)
+      logger.warn "Failed to notify Foreman on startup. Received response: #{response.code} #{response.msg}" unless response.code == "200"
+      response
+    end
+  end
+end

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -37,4 +37,11 @@ class RequestTest < Test::Unit::TestCase
     result = @request.send_request(proxy_req)
     assert_equal("body", result.body)
   end
+
+  def test_put
+    stub_request(:put, @foreman_url+'/path').with(:body => "body").to_return(:status => [200, 'OK'], :body => "body")
+    proxy_req = @request.request_factory.create_put("/path", "body")
+    result = @request.send_request(proxy_req)
+    assert_equal("body", result.body)
+  end
 end

--- a/test/startup_info_test.rb
+++ b/test/startup_info_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'net/http'
+require 'mocha'
+require 'webmock/test_unit'
+require 'proxy/startup_info'
+
+class StartupInfoTest < Test::Unit::TestCase
+  def setup
+    @foreman_url = 'https://foreman.example.com'
+    Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+  end
+
+  def test_put_features
+    proxy_name = "test-proxy.example.com"
+    Socket.stubs(:gethostname).returns("test-proxy.example.com")
+    stub_request(:put, @foreman_url+'/api/v2/smart_proxies/startup_refresh').to_return(:status => [200, 'OK'],
+                                                                                       :body => proxy_name)
+    result = Proxy::StartupInfo.new.put_features
+    assert_equal proxy_name, result.body
+  end
+end


### PR DESCRIPTION
On startup, Smart proxy prods Foreman to ask for a feature list. 
