### PR TITLE
Fixes #13346 - revert 'each_line'

### DIFF
--- a/modules/dhcp/providers/server/native_ms.rb
+++ b/modules/dhcp/providers/server/native_ms.rb
@@ -98,7 +98,7 @@ module Proxy::DHCP
 
       to_return = []
       # Extract the data
-      execute(cmd, msg).each_line do |line|
+      execute(cmd, msg).each do |line|
         #     172.29.216.6      -    00-a0-e7-21-41-00-
         if line =~ /^\s+([\w\.]+)\s+-\s+([-a-f\d]+)/
           ip  = $1
@@ -181,7 +181,7 @@ module Proxy::DHCP
       msg = "Enumerated the scopes on #{@name}"
 
       ret_val = []
-      execute(cmd, msg).each_line do |line|
+      execute(cmd, msg).each do |line|
         # 172.29.216.0   - 255.255.254.0  -Active        -DC BRS               -
         if match = line.match(/^\s*([\d\.]+)\s*-\s*([\d\.]+)\s*-\s*(Active|Disabled)/)
           next unless managed_subnet? "#{match[1]}/#{match[2]}"
@@ -252,7 +252,7 @@ module Proxy::DHCP
     def parse_options response
       optionId = nil
       options  = {}
-      response.each_line do |line|
+      response.each do |line|
         line.chomp!
         break if line.match(/^Command completed/)
 

--- a/test/dhcp/server_ms_test.rb
+++ b/test/dhcp/server_ms_test.rb
@@ -27,7 +27,7 @@ class DHCPServerMicrosoftTest < Test::Unit::TestCase
  172.29.216.0   - 255.255.254.0  -Active        -DC BRS               -
 
  Total No. of Scopes = 6
-Command completed successfully.')
+Command completed successfully.'.split("\n"))
     @server.stubs(:execute).with("scope 172.29.205.0 show reservedip", "Enumerated hosts on 172.29.205.0").returns('
 Changed the current scope context to 172.29.205.0 scope.
 
@@ -97,7 +97,7 @@ Changed the current scope context to 172.29.205.0 scope.
 No of ReservedIPs : 57 in the Scope : 172.29.205.0.
 
 Command completed successfully.
-')
+'.split("\n"))
     @server.stubs(:execute).with("scope 172.29.205.0 Show OptionValue", "Queried 172.29.205.0 options").returns('
 Changed the current scope context to 172.29.205.0 scope.
 
@@ -121,7 +121,7 @@ Options for Scope 172.29.205.0:
                 Option Element Type = IPADDRESS
                 Option Element Value = 172.29.205.1
 Command completed successfully.
-    ')
+    '.split("\n"))
     @server.stubs(:execute).with(
         regexp_matches(/^scope 172.29.205.0 Show ReservedOptionValue 172.29.205.25/),
         regexp_matches(/^Queried .+ options/)).returns('
@@ -147,7 +147,7 @@ Options for the Reservation Address 172.29.205.25 in the Scope 172.29.205.0 :
                 Option Element Type = STRING
                 Option Element Value = brslcs25
 Command completed successfully.
-')
+'.split("\n"))
     @server.loadSubnets
   end
 


### PR DESCRIPTION
**Works for me**: Simply reverts `.each_line` to `.each`. 
Maybe we could come up with something more stable if the use of [.readlines](https://github.com/theforeman/smart-proxy/blob/1.10-stable/modules/dhcp/providers/server/native_ms.rb#L211) becomes a sting in ruby =< 2.0.0

Ugly; but should work:

``` ruby
execute(cmd, msg).to_s.split("\n").each do |line|
 # ...
end
```

eg, [here](https://github.com/theforeman/smart-proxy/pull/365/files?diff=split#diff-08c4251c1dbcdc5c20755615254654eaL101)
