### PR TITLE
refs #12715 - update default values of log_buffer settings

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -57,7 +57,7 @@
 # WARN, DEBUG, ERROR, FATAL, INFO, UNKNOWN
 #:log_level: ERROR
 
-# Log buffer size and extra buffer size (for errors). Defaults to 1500 messages in total,
-# which is about 250 kB request.
-#:log_buffer: 1000
-#:log_buffer_errors: 500
+# Log buffer size and extra buffer size (for errors). Defaults to 3000 messages in total,
+# which is about 500 kB request.
+#:log_buffer: 2000
+#:log_buffer_errors: 1000

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -12,7 +12,6 @@ module ::Proxy::Settings
       :virsh_network => 'default',
       :log_buffer => 2000,
       :log_buffer_errors => 1000,
-      :log_buffer_level => "INFO"
     }
 
     HOW_TO_NORMALIZE = {


### PR DESCRIPTION
Removed log_buffer_level from default settings as it appears to be
unused.
