### PR TITLE
Fixes #13421 - dnscmd now adds/removes records in sub zones

### DIFF
--- a/test/dns_dnscmd/dnscmd_test.rb
+++ b/test/dns_dnscmd/dnscmd_test.rb
@@ -2,7 +2,25 @@ require 'test_helper'
 require 'dns_dnscmd/dns_dnscmd'
 require 'dns_dnscmd/dns_dnscmd_main'
 
+class DnscmdForTesting < Proxy::Dns::Dnscmd::Record
+  def initialize(dns_zones)
+    @enum_zones = dns_zones
+  end
+  attr_accessor :enum_zones
+end
+
 class DnsCmdTest < Test::Unit::TestCase
+  def setup
+    @server = DnscmdForTesting.new([
+      "_msdcs.bar.domain.local",
+      "168.192.in-addr.arpa",
+      "33.168.192.in-addr.arpa",
+      "e.e.d.8.b.d.0.1.0.0.2.ip6.arpa",
+      "bar.domain.local",
+      "domain.local",
+      "TrustAnchors"])
+  end
+
   def test_dnscmd_provider_initialization
     Proxy::Dns::Dnscmd::Plugin.load_test_settings(:dns_server => 'a_server')
     Proxy::Dns::Plugin.load_test_settings(:dns_ttl => 999)
@@ -12,64 +30,110 @@ class DnsCmdTest < Test::Unit::TestCase
     assert_equal 999, server.ttl
   end
 
-  def test_create_address_record
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.domain').returns(false)
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/RecordAdd domain host.domain. A 192.168.33.33', anything).returns(true)
-    assert Proxy::Dns::Dnscmd::Record.new.create_a_record('host.domain', '192.168.33.33')
+  def test_create_address_record_with_longest_zone_match
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.foo.bar.domain.local').returns(false)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/RecordAdd bar.domain.local host.foo.bar.domain.local. A 192.168.33.33', anything).returns(true)
+    assert @server.create_a_record('host.foo.bar.domain.local', '192.168.33.33')
   end
 
-  def test_overwrite_address_record
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.domain').returns('192.168.33.33')
-    Proxy::Dns::Dnscmd::Record.new.create_a_record('host.domain', '192.168.33.33')
+  def test_overwrite_address_record_with_longest_zone_match
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.foo.bar.domain.local').returns('192.168.33.33')
+    @server.create_a_record('host.foo.bar.domain.local', '192.168.33.33')
   end
 
   def test_create_duplicate_address_record_fails
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.domain').returns('192.168.33.34')
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.foo.bar.domain.local').returns('192.168.33.34')
 
     assert_raise Proxy::Dns::Collision do
-      Proxy::Dns::Dnscmd::Record.new.create_a_record('host.domain', '192.168.33.33')
+      @server.create_a_record('host.foo.bar.domain.local', '192.168.33.33')
     end
   end
 
   def test_create_ptr_record
     Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('192.168.33.33').returns(false)
-    assert Proxy::Dns::Dnscmd::Record.new.create_ptr_record('host.domain', '192.168.33.33')
+    assert @server.create_ptr_record('host.foo.bar.domain.local', '192.168.33.33')
   end
 
   def test_overwrite_ptr_record
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('192.168.33.33').returns('host.domain')
-    Proxy::Dns::Dnscmd::Record.new.create_ptr_record('host.domain', '192.168.33.33')
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('192.168.33.33').returns('host.foo.bar.domain.local')
+    @server.create_ptr_record('host.foo.bar.domain.local', '192.168.33.33')
   end
 
   def test_create_duplicate_ptr_record_fails
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('192.168.33.33').returns('another.host.domain')
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('192.168.33.33').returns('another.host.foo.bar.domain.local')
     assert_raise Proxy::Dns::Collision do
-      Proxy::Dns::Dnscmd::Record.new.create_ptr_record('host.domain', '192.168.33.33')
+      @server.create_ptr_record('host.foo.bar.domain.local', '192.168.33.33')
     end
   end
 
-  def test_remove_address_record
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.domain').returns(true)
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/RecordDelete domain host.domain. A /f', anything).returns(true)
-    assert Proxy::Dns::Dnscmd::Record.new.remove_a_record('host.domain')
+  def test_remove_address_record_with_longest_zone_match
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.foo.bar.domain.local').returns(true)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/RecordDelete bar.domain.local host.foo.bar.domain.local. A /f', anything).returns(true)
+    assert @server.remove_a_record('host.foo.bar.domain.local')
   end
 
   def test_remove_non_existent_address_record_raises_exception
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.domain').returns(false)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.foo.bar.domain.local').returns(false)
     assert_raise Proxy::Dns::NotFound do
-      Proxy::Dns::Dnscmd::Record.new.remove_a_record('host.domain')
+      @server.remove_a_record('host.foo.bar.domain.local')
     end
   end
 
   def test_remove_ptr_record
     Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('192.168.33.33').returns(true)
-    assert Proxy::Dns::Dnscmd::Record.new.remove_ptr_record('192.168.33.33')
+    assert @server.remove_ptr_record('192.168.33.33')
   end
 
   def test_remove_nonexistent_ptr_record_raises_exception
     Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('192.168.33.33').returns(false)
     assert_raise Proxy::Dns::NotFound do
-      Proxy::Dns::Dnscmd::Record.new.remove_ptr_record('192.168.33.33')
+      @server.remove_ptr_record('192.168.33.33')
     end
+  end
+
+  def test_dns_zone_matches_second_best_match_if_zone_name_equals_host_name
+    assert_equal('33.168.192.in-addr.arpa', @server.match_zone('33.33.168.192.in-addr.arpa'))
+    assert_equal('domain.local', @server.match_zone('bar.domain.local'))
+  end
+
+  def test_dns_zone_matches_sole_available_zone
+    server = DnscmdForTesting.new(["sole.domain"])
+    assert_equal('sole.domain', server.match_zone('host.foo.bar.sole.domain'))
+  end
+
+  def test_dns_zone_no_match_raises_exception
+    assert_raise Proxy::Dns::NotFound do
+      @server.match_zone('host.foo.bar.domain.com')
+    end
+  end
+
+  def test_dnscmd_enum_zones_parses_primary_zones_only
+    to_parse = '
+Enumerated zone list:
+        Zone count = 8
+
+ Zone name                      Type       Storage         Properties
+
+ .                              Cache      AD-Domain
+ _msdcs.bar.domain.local        Primary    AD-Forest       Secure
+ 168.192.in-addr.arpa           Primary    AD-Domain       Rev
+ 33.168.192.in-addr.arpa        Primary    AD-Domain       Secure Rev Aging
+ e.e.d.8.b.d.0.1.0.0.2.ip6.arpa Primary    AD-Domain       Secure Rev
+ bar.domain.local               Primary    AD-Domain       Secure Aging
+ domain.local                   Primary    AD-Domain       Secure
+ domain.com                     Secondary    File
+ TrustAnchors                   Primary    AD-Forest
+
+
+Command completed successfully.'.split("\n")
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumZones').returns(to_parse)
+    assert_equal [
+      "_msdcs.bar.domain.local",
+      "168.192.in-addr.arpa",
+      "33.168.192.in-addr.arpa",
+      "e.e.d.8.b.d.0.1.0.0.2.ip6.arpa",
+      "bar.domain.local",
+      "domain.local",
+      "TrustAnchors"], Proxy::Dns::Dnscmd::Record.new.enum_zones
   end
 end


### PR DESCRIPTION
I could only test this on my production env running 1.10-stable, but this seems to work now running the same patch. 

Please advice reading from setting `::Proxy::Dns::Plugin.settings.dns_domain` directly...
Also, I never ever ran Windows DNS without AD, hence I cannot really tell if the old regex method works in this case. 
But in case of AD, for sure the `zonename` parameter has to match the active directory zone and must not contain any sub zone.

Also, as I stated in the ticket, I can think of no reliable way to determine this zone name apart from a setting - witch means better ideas welcome!
(Ok, not true, we could use `dnscmd /EnumZones`, parse it and select the best match... but I really think this would overdue it, aka I do not like to be the one implementing this ;)

That said a better fallback could be the second level domain?

```
D, [2016-01-27T23:36:54.516411 #3676] DEBUG -- : executing: c:\windows\system32\cmd.exe /c c:\Windows\System32\dnscmd.exe localhost /RecordAdd domain.com testdns2.sec.domain.com. A 192.168.0.155
I, [2016-01-27T23:36:54.563119 #3676]  INFO -- : Added DNS entry testdns2.sec.domain.com => 192.168.0.155
I, [2016-01-27T23:36:54.563119 #3676]  INFO -- : 2001:dbff:2c2c::15 - - [27/Jan/2016 23:36:54] "POST /dns/ HTTP/1.1" 200 - 0.0936
```
