### PR TITLE
fixes #13575 - Don't fail on missing PXEClient dhcp opt

### DIFF
--- a/modules/dhcp_native_ms/dhcp_native_ms_main.rb
+++ b/modules/dhcp_native_ms/dhcp_native_ms_main.rb
@@ -57,7 +57,11 @@ module Proxy::DHCP::NativeMS
         else
           logger.debug "key: " + key.inspect
           k = Standard[key] || Standard[key.to_sym]
-          execute "scope #{record.subnet.network} set reservedoptionvalue #{record.ip} #{k[:code]} #{k[:kind]} \"#{value}\"", msg, true
+          begin
+            execute "scope #{record.subnet.network} set reservedoptionvalue #{record.ip} #{k[:code]} #{k[:kind]} \"#{value}\"", msg, true
+          rescue Proxy::DHCP::Error => e
+            raise(e) unless key.to_s == "PXEClient"
+          end
         end
       end
       execute("scope #{record.subnet.network} set dnsconfig #{record.ip} 0 0 0 0", 'disable Dynamic DNS', true) if Proxy::DHCP::NativeMS::Plugin.settings.disable_ddns

--- a/test/dhcp_ms_native/server_ms_test.rb
+++ b/test/dhcp_ms_native/server_ms_test.rb
@@ -13,7 +13,6 @@ class DHCPServerMicrosoftTest < Test::Unit::TestCase
     @subnet_service = Proxy::DHCP::SubnetService.new
     @server = Proxy::DHCP::NativeMS::Provider.new.initialize_for_testing(:name => "1.2.3.4",
                                                                          :service => @subnet_service)
-
     @server.stubs(:execute).with("show scope", "Enumerated the scopes on 1.2.3.4").returns('
 ==============================================================================
  Scope Address  - Subnet Mask    - State        - Scope Name          -  Comment
@@ -249,4 +248,29 @@ Command completed successfully.
     assert_equal "brslcs25", parsed[:hostname]
     assert_equal "/vol/solgi_5.10/sol10_hw0910", parsed[:install_path]
   end
+
+  def test_should_add_record
+    to_add = { "hostname" => "test.example.com", "ip" => "192.168.166.11",
+               "mac" => "00:11:bb:cc:dd:ee", "network" => "192.168.166.0/255.255.255.0",
+               "PXEClient" => "pxeclientval" }
+
+    @server.expects(:execute).with('scope 192.168.166.0 add reservedip 192.168.166.11 0011bbccddee test.example.com', 'Added DHCP reservation for test.example.com (192.168.166.11 / 00:11:bb:cc:dd:ee)')
+    @server.expects(:execute).with('scope 192.168.166.0 set reservedoptionvalue 192.168.166.11 12 String "test.example.com"', nil, true)
+    @server.expects(:execute).with('scope 192.168.166.0 set reservedoptionvalue 192.168.166.11 60 String "pxeclientval"', nil, true)
+    @server.add_record(to_add)
+  end
+
+  def test_should_raise_on_option_error
+    to_add = { "hostname" => "test.example.com", "ip" => "192.168.166.11",
+               "mac" => "00:11:bb:cc:dd:ee", "network" => "192.168.166.0/255.255.255.0",
+             }
+
+    @server.expects(:execute).with('scope 192.168.166.0 add reservedip 192.168.166.11 0011bbccddee test.example.com', 'Added DHCP reservation for test.example.com (192.168.166.11 / 00:11:bb:cc:dd:ee)')
+    @server.expects(:execute).with('scope 192.168.166.0 set reservedoptionvalue 192.168.166.11 12 String "test.example.com"', nil, true).raises(Proxy::DHCP::Error)
+    @server.expects(:execute).with('scope 192.168.166.0 set reservedoptionvalue 192.168.166.11 60 String ""', nil, true)
+    assert_raises ::Proxy::DHCP::Error do
+      @server.add_record(to_add)
+    end
+  end
+
 end


### PR DESCRIPTION
Due to #2870 the dhcp_native_ms provider always tries to set the
PXEClient opt to empty. However this does not exist in all DHCP servers
(tested on 2008R2) and in this case we currently fail with:

```
  INFO -- : Added DHCP reservation for foo.example.com(10.0.2.20 / 52:54:00:84:64:03)
 DEBUG -- : key: "PXEClient"
 DEBUG -- : executing: c:\windows\system32\cmd.exe /c c:\Windows\System32\netsh.exe -c dhcp server 127.0.0.1 scope 10.0.0.0 set reservedoptionvalue 10.0.2.20 60 String ""
 INFO -- : Vendor class not found
ERROR -- : Netsh failed:

Changed the current scope context to 10.0.0.0 scope.

The specified option does not exist.

ERROR -- : Unknown error while processing ''
DEBUG -- : Unknown error while processing '' (Proxy::DHCP::Error)
C:/Users/Administrator/Downloads/smart-proxy/modules/dhcp_native_ms/dhcp_native_ms_main.rb:246:in `rescue in report'
C:/Users/Administrator/Downloads/smart-proxy/modules/dhcp_native_ms/dhcp_native_ms_main.rb:223:in `report'
C:/Users/Administrator/Downloads/smart-proxy/modules/dhcp_native_ms/dhcp_native_ms_main.rb:218:in `execute'
C:/Users/Administrator/Downloads/smart-proxy/modules/dhcp_native_ms/dhcp_native_ms_main.rb:59:in `block in add_record'
C:/Users/Administrator/Downloads/smart-proxy/modules/dhcp_native_ms/dhcp_native_ms_main.rb:46:in `each'
C:/Users/Administrator/Downloads/smart-proxy/modules/dhcp_native_ms/dhcp_native_ms_main.rb:46:in `add_record'
C:/Users/Administrator/Downloads/smart-proxy/modules/dhcp/dhcp_api.rb:97:in `block in <class:DhcpApi>'
C:/Users/Administrator/Downloads/smart-proxy/vendor/ruby/2.1.0/gems/sinatra-1.4.7/lib/sinatra/base.rb:1611:in `call'
```

so ignore errors to set that option.
