### PR TITLE
fixes #13522 add correct path to puppet binary

### DIFF
--- a/modules/puppetca/puppetca_main.rb
+++ b/modules/puppetca/puppetca_main.rb
@@ -103,7 +103,7 @@ module Proxy::PuppetCa
         raise "SSL/CA unavailable on this machine"
       end
 
-      default_path = ["/opt/puppet/bin", "/opt/puppet/sbin"]
+      default_path = ["/opt/puppet/bin", "/opt/puppet/sbin", "/opt/puppetlabs/bin"]
 
       # puppetca is the old method of using puppet cert which is new in puppet 2.6
       if Puppet::PUPPETVERSION.to_i < 3


### PR DESCRIPTION
Puppet 4 AIO uses /opt/puppetlabs/bin to store the puppet executable. This allows the smart-proxy to list all the certs that are signed/unsigned/revoked
