### PR TITLE
WIP/Feature #4917 - active direcory realmprovider

### DIFF
--- a/bundler.d/windows.rb
+++ b/bundler.d/windows.rb
@@ -1,4 +1,5 @@
 group :windows do
   gem 'highline', :platforms => [:mingw, :x64_mingw]
   gem 'win32-service', :platforms => [:mingw, :x64_mingw]
+  gem 'winrm', '~> 1.6'
 end

--- a/config/settings.d/realm_ad.yml.example
+++ b/config/settings.d/realm_ad.yml.example
@@ -1,0 +1,25 @@
+---
+# Can be true, false, or http/https to enable just one of the protocols
+:enabled: false
+
+# Available providers:
+#   freeipa
+#   activedirectory
+:realm_provider: activedirectory
+
+# The OU computer accounts are added to. Defaults to domain default computer container
+# Warning: Fails if target DN does not exist
+#:computer_container: 'DN=computer,DC=domain,DC=com'
+
+# Syncs hostgroups to sub OUs inside :computer_container
+# Example: host 'a' in hostgroup sample/host/group will be created in 'OU=group,OU=host,OU=sample,DN=computer,DC=domain,DC=com'
+# Warning: Fails if target DN does not exist
+#:hostgroup_sync: false
+
+# Windows Remote Management endpoint: domain controller
+:winrm_endpoint: = 'http://localhost:5985/wsman'
+:winrm_user: administrator
+:winrm_password: P@55w0rd
+
+# command timeout in seconds
+#:winrm_timeout: 15

--- a/modules/realm/activedirectory.rb
+++ b/modules/realm/activedirectory.rb
@@ -1,0 +1,143 @@
+require 'winrm'
+require 'json'
+require 'realm/client'
+
+module Proxy::Realm
+  class  ActiveDirectory < Client
+    include Proxy::Util
+
+    def initialize
+      errors = []
+      errors << "WinRM endpoint not configured" unless Proxy::Realm::Plugin.settings.winrm_endpoint
+      errors << "WinRM user / password not configured #{Proxy::Realm::Plugin.settings.winrm_user}" unless Proxy::Realm::Plugin.settings.winrm_user && Proxy::Realm::Plugin.settings.winrm_password
+
+      logger.info "active directory: WinRM endpoint is '#{Proxy::Realm::Plugin.settings.winrm_endpoint}'"
+
+      if errors.empty?
+        begin
+          @winrm_endpoint = WinRM::WinRMWebService.new(
+              Proxy::Realm::Plugin.settings.winrm_endpoint,
+              :negotiate,
+              :user => Proxy::Realm::Plugin.settings.winrm_user,
+              :pass => Proxy::Realm::Plugin.settings.winrm_password
+          )
+          @import_cmdlets = 'Import-Module ActiveDirectory -cmdlet New-ADComputer,Get-ADComputer,Get-ADDomain,Remove-ADComputer,Get-ADOrganizationalUnit,Move-ADObject'
+          ad_domain = parse_wimrm(execute('Get-AdDomain'))
+          @realm_name = ad_domain[:Name] # we could also use :NetBIOSName
+          logger.info "active directory: using realm #{@realm_name}"
+          @winrm_execution_timeout = Proxy::Realm::Plugin.settings.winrm_timeout
+          @computer_container = Proxy::Realm::Plugin.settings.computer_container || ad_domain[:ComputersContainer]
+          logger.info "active directory: using computer container #{@computer_container}"
+          @sync_hostgroups = Proxy::Realm::Plugin.settings.hostgroup_sync || false
+          logger.info "syncing hostgroups to #{@computer_container}" if @sync_hostgroups
+        end
+      else
+        raise Proxy::Realm::Error.new errors.join(", ")
+      end
+    end
+
+    def check_realm realm
+      raise Proxy::Realm::Error.new "Unknown realm #{realm}" unless realm.casecmp(@realm_name).zero?
+    end
+
+    # find by dns hostname; return host object or false
+    def find hostname
+      # This might be a hard one: associating the right computer account
+      # using ldap results in a zero exit code but might not find the correct host, though it should at least not result
+      # in dubs. We could also guess the SamAccountName here using "#{params[:hostname].split('.').first}$"
+      host = execute "Get-Adcomputer -LDAPFilter \"(DNSHostname=#{hostname})\"" unless hostname.nil?
+      parse_wimrm(host) if host[:data].any?
+    end
+
+    def create realm, params
+      check_realm realm
+      host = find params[:hostname]
+      hostgroup = params[:userclass]
+      sam_acc_name = "#{params[:hostname].split('.').first}"
+      if @sync_hostgroups
+        container = hostgroup_to_dn hostgroup
+      else
+        container = @computer_container
+      end
+      require_otp = false
+      otp = (0...99).map { ('a'..'z').to_a[rand(26)] }.join
+      ps_script = nil
+
+      # Determine if we're updating a host or creating a new one
+      if host.nil? # create a new host
+        logger.debug "Creating new active directory object '#{params[:hostname]}'"
+        ps_script = "New-AdComputer -Name #{sam_acc_name} -DNSHostName #{params[:hostname]} -Path \"#{container}\" -AccountPassword (ConvertTo-SecureString \"#{otp}\" -asplaintext -force) -PassThru"
+        require_otp = true
+      elsif host && params[:rebuild] == "true" # rebuild host
+        logger.debug "Resetting existing active directory object '#{params[:hostname]}'"
+        ps_script = "Set-ADAccountPassword -Identity \"#{host[:DistinguishedName]}\" -Reset -NewPassword (ConvertTo-SecureString -AsPlainText \"#{otp}\" -Force) -PassThru"
+        require_otp = true
+      elsif host && @sync_hostgroups && container != host[:DistinguishedName] # move host to new OU
+        logger.debug "Moving host '#{params[:hostname]}' to target ou '#{container}'"
+        ps_script = "Move-ADObject -Identity \"#{host[:DistinguishedName]}\" -TargetPath \"#{container}\" -PassThru"
+      else
+        result = {:message => "Nothing to do"}
+      end
+      if ps_script
+        result = parse_wimrm(execute(ps_script)) if check_ou container
+        result.merge!(:randompassword => otp) if require_otp
+      end
+      JSON.pretty_generate(result)
+    end
+
+    def delete realm, hostname
+      check_realm realm
+      host = find hostname
+      raise Proxy::Realm::NotFound, "Host #{hostname} not found in realm!" unless host
+      begin
+        execute "Remove-ADComputer -Identity #{host[:ObjectGUID]} -confirm:$false"
+      end
+      JSON.pretty_generate(:message => "Deleted #{hostname} realm #{realm}")
+    end
+
+    def execute ps_script, strict_error_checking = true
+      con_secs = 5
+      exec_secs = @winrm_execution_timeout || 15
+      result = nil
+      complete_ps_script = "try {#{@import_cmdlets}; #{ps_script}|ConvertTo-Json} catch {'winrm_error'}"
+      begin
+        timeout(con_secs) do
+          @executor = @winrm_endpoint.create_executor # actually connect to winrm endpoint
+        end
+        timeout(exec_secs) do
+          logger.debug "Running powershell script: '#{complete_ps_script.gsub(/\(.*ConvertTo-SecureString.*\)/, '(XXX)')}'"
+          result = @executor.run_powershell_script(complete_ps_script) # run our command
+        end
+        if strict_error_checking && result.stdout == 'winrm_error'
+          raise Proxy::Realm::Error.new "Error executing powershell script"
+        end
+      rescue TimeoutError
+        raise Proxy::Realm::Error.new "Timeout connecting to WinRM endpoint: '#{Proxy::Realm::Plugin.settings.winrm_endpoint}'"
+      rescue => e
+        raise Proxy::Realm::Error.new "General command execution error '#{Proxy::Realm::Plugin.settings.winrm_endpoint}': #{e.message}"
+      end
+      nil if result.stdout == 'winrm_error'
+      result
+    end
+
+    def parse_wimrm executor
+      JSON.parse(executor.stdout, :symbolize_names => true)
+    end
+
+    def hostgroup_to_dn hostgroup
+      result = ''
+      hostgroup.split('/').reverse.each do |group|
+        result << "OU=#{group},"
+      end
+      "#{result}#{@computer_container}"
+    end
+
+    def check_ou container_dn
+      ou = execute "Get-ADOrganizationalUnit -Identity \"#{container_dn}\"", false
+      if ou.nil?
+        raise Proxy::Realm::Error.new "Container does not exist: #{container_dn}"
+      end
+      true
+    end
+  end
+end

--- a/modules/realm/realm_api.rb
+++ b/modules/realm/realm_api.rb
@@ -11,6 +11,9 @@ module Proxy::Realm
         when "freeipa"
           require 'realm/freeipa'
           @realm = Proxy::Realm::FreeIPA.new
+        when "activedirectory"
+          require 'realm/activedirectory'
+          @realm = Proxy::Realm::ActiveDirectory.new
         else
           log_halt 400, "Unrecognized Realm provider: #{Proxy::Realm::Plugin.settings.realm_provider}"
       end

--- a/test/realm_ad/realm_ad_config_test.rb
+++ b/test/realm_ad/realm_ad_config_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+#require 'dns_dnscmd/dns_dnscmd_plugin'
+
+class RealmADConfigTest < Test::Unit::TestCase
+  def test_default_config
+    #::Proxy::Dns::Dnscmd::Plugin.load_test_settings({})
+    #assert_equal 'localhost', ::Proxy::Dns::Dnscmd::Plugin.settings.dns_server
+  end
+end

--- a/test/realm_ad/realm_ad_test.rb
+++ b/test/realm_ad/realm_ad_test.rb
@@ -1,0 +1,39 @@
+require 'test_helper'
+require 'realm/activedirectory'
+
+class RealmAd < Test::Unit::TestCase
+  def test_realm_ad_provider_initialization
+#    Proxy::Dns::Dnscmd::Plugin.load_test_settings(:dns_server => 'a_server')
+#    Proxy::Dns::Plugin.load_test_settings(:dns_ttl => 999)
+#    server = Proxy::Dns::Dnscmd::Record.new
+#
+#    assert_equal "a_server", server.server
+#    assert_equal 999, server.ttl
+  end
+
+  def test_create_computer_account
+    #Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.domain').returns(false)
+    #Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/RecordAdd domain host.domain. A 192.168.33.33', anything).returns(true)
+    #assert Proxy::Dns::Dnscmd::Record.new.create_a_record('host.domain', '192.168.33.33')
+  end
+
+  def test_remove_computer_account
+    #Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.domain').returns('192.168.33.33')
+    #Proxy::Dns::Dnscmd::Record.new.create_a_record('host.domain', '192.168.33.33')
+  end
+
+  def test_create_duplicate_computer_account_raises_exception
+    #Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.domain').returns('192.168.33.34')
+
+    #assert_raise Proxy::Dns::Collision do
+     # Proxy::Dns::Dnscmd::Record.new.create_a_record('host.domain', '192.168.33.33')
+    #end
+  end
+
+  def test_remove_non_existent_omputer_account_raises_exception
+    #Proxy::Dns::Dnscmd::Record.any_instance.expects(:dns_find).with('host.domain').returns(false)
+    #assert_raise Proxy::Dns::NotFound do
+    #  Proxy::Dns::Dnscmd::Record.new.remove_a_record('host.domain')
+    #end
+  end
+end


### PR DESCRIPTION
Adds a proposal for an active directory ream provider using [wirm](https://github.com/WinRb/WinRM)

As discussed on ML with @stbenjam, I mainly refactored FreeIPA as as active directory.
Currently I do not see a way on how to implement the OTP.
Also, it only provides a singe auth method (NTLM) and no https; more methodes will be implemented once we get further.
Same is true for test cases - but I am at it, @witlessbird and might need your help (interestingly it seems FreeIPA does not get tested at all).

Note, because this introduces `winrm`, we can run this provider on any host, just run:
`winrm quickconfig` as admin on a DC as admin.
