### PR TITLE
Fixes #13536 - working ptr's for dnscmd

### DIFF
--- a/modules/dns_common/dns_common.rb
+++ b/modules/dns_common/dns_common.rb
@@ -1,3 +1,6 @@
+require 'resolv'
+require 'ipaddr'
+
 module Proxy::Dns
   class Error < RuntimeError; end
   class NotFound < RuntimeError; end
@@ -23,6 +26,44 @@ module Proxy::Dns
       end
     rescue Resolv::ResolvError
       false
+    end
+
+    def ptr_to_ip ptr
+     if ptr =~ /\.in-addr\.arpa$/
+       ptr.split('.')[0..-3].reverse.join('.')
+     elsif ptr =~ /\.ip6\.arpa$/
+       ptr.split('.')[0..-3].reverse.each_slice(4).inject([]) {|address, word| address << word.join}.join(":")
+     else
+       raise Proxy::Dns::Error.new("Not a PTR record: '#{ptr}'")
+     end
+    end
+
+    # conflict methods return values:
+    # no conflict: -1; conflict: 1, conflict but record / ip matches: 0
+    def a_record_conflicts(fqdn, ip)
+      if ip_addr = to_ipaddress(ip)
+        addresses = resolver.getaddresses(fqdn)
+        return -1 if addresses.empty?
+        return 0 if addresses.any? {|a| IPAddr.new(a) == ip_addr}
+        1
+      else
+        raise Proxy::Dns::Error.new("Not an IP Address: '#{ip}'")
+      end
+    end
+
+    def ptr_record_conflicts(fqdn, ip)
+      if ip_addr = to_ipaddress(ip)
+        names = resolver.getnames(ip_addr.to_s)
+        return -1 if names.empty?
+        return 0 if names.any? {|n| n.to_s.casecmp(fqdn) == 0}
+        1
+      else
+        raise Proxy::Dns::Error.new("Not an IP Address: '#{ip}'")
+      end
+    end
+
+    def to_ipaddress ip
+      IPAddr.new(ip) rescue false
     end
   end
 end

--- a/test/dns_common/record_test.rb
+++ b/test/dns_common/record_test.rb
@@ -16,4 +16,54 @@ class DnsRecordTest < Test::Unit::TestCase
     Resolv::DNS.any_instance.expects(:getaddress).with('another.host').raises(Resolv::ResolvError.new('DNS result has no information'))
     assert !Proxy::Dns::Record.new.dns_find('another.host')
   end
+
+  def test_ptr_to_ip_ipv4
+    assert_equal('192.168.33.30', Proxy::Dns::Record.new.ptr_to_ip('30.33.168.192.in-addr.arpa'))
+  end
+
+  def test_ptr_to_ip_ipv6
+    assert_equal('2001:0db8:deef:0000:0000:0000:0000:0001', Proxy::Dns::Record.new.ptr_to_ip('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa'))
+  end
+
+  def test_ptr_to_ip_without_record_exception
+    assert_raise Proxy::Dns::Error do
+      Proxy::Dns::Record.new.ptr_to_ip('host.example.com')
+    end
+  end
+
+  def test_a_record_conflicts_no_conflict
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns([])
+    assert_equal -1, Proxy::Dns::Record.new.a_record_conflicts('some.host', '192.168.33.33')
+  end
+
+  def test_a_record_conflicts_has_conflict
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns(['192.168.33.33', '2001:DB8:DEEF::1'])
+    assert_equal 1, Proxy::Dns::Record.new.a_record_conflicts('some.host', '2001:db8:deef:1000::1')
+  end
+
+  def test_a_record_conflicts_but_nothing_todo
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns(['192.168.33.33', '2001:DB8:DEEF::1'])
+    assert_equal 0, Proxy::Dns::Record.new.a_record_conflicts('some.host', '192.168.33.33')
+  end
+
+  def test_ptr_record_conflicts_no_conflict
+    Resolv::DNS.any_instance.expects(:getnames).with('192.168.33.33').returns([])
+    assert_equal -1, Proxy::Dns::Record.new.ptr_record_conflicts('some.host', '192.168.33.33')
+  end
+
+  def test_ptr_record_conflicts_has_conflict
+    Resolv::DNS.any_instance.expects(:getnames).with('2001:db8:deef::1').returns(['some.host'])
+    assert_equal 1, Proxy::Dns::Record.new.ptr_record_conflicts('another.host', '2001:db8:deef::1')
+  end
+
+  def test_ptr_record_conflicts_but_nothing_todo
+    Resolv::DNS.any_instance.expects(:getnames).with('192.168.33.33').returns(['some.host'])
+    assert_equal 0, Proxy::Dns::Record.new.ptr_record_conflicts('some.host', '192.168.33.33')
+  end
+
+  def test_validate_ip
+    assert_equal '192.168.33.33', Proxy::Dns::Record.new.to_ipaddress('192.168.33.33').to_s
+    assert_equal '2001:db8:deef::1', Proxy::Dns::Record.new.to_ipaddress('2001:db8:deef::1').to_s
+    assert_equal false, Proxy::Dns::Record.new.to_ipaddress('some.host')
+  end
 end


### PR DESCRIPTION
Makes PTR's for dnscmd working again.

~~Sadly~~ I had to introduce a ~~rather complicated~~ method `#get_ptr_record` ~~because dnscmd's rather strange implementation of adding pointers~~. It should also handle IPv6 reverse zones, see tests.

It executes dnscmd in the following manner:

Eg for host `host.foo.bar.domain.local.` with `192.168.33.2` and a given /16 reverse zone `168.192.in-addr.arpa`:
#### IPv4

```
dnscmd /RecordAdd 168.192.in-addr.arpa 2.33.168.192.in-addr.arpa. PTR host.foo.bar.domain.local.
```
#### IPv6

```
dnscmd /RecordAdd f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa. PTR host.foo.bar.domain.local.
```

~~**Note:** This further fixes a rubocop offense introduced with overlapping #369 and #373 merges (it seems)~~
