### PR TITLE
Fixes #13761 - added leases support to virsh provider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ bundler.d/*.local.rb
 .bundle
 pkg/
 test/tmp/*
+/tmp

--- a/config/settings.d/dhcp_virsh.yml.example
+++ b/config/settings.d/dhcp_virsh.yml.example
@@ -2,7 +2,9 @@
 #
 # Configuration file for libvirtd-specific 'virsh' dhcp provider
 #
-# There's currently no configuration options for this provider.
-# Virsh network name is a global parameter that can be set
-# in the main settings.yml file in 'virsh_network' parameter.
-#
+
+# Libvirt network to use
+#:network: default
+
+# Leases file (managed via /usr/libexec/libvirt_leaseshelper)
+#:leases: /var/lib/libvirt/dnsmasq/virbr0.status

--- a/config/settings.d/dns_virsh.yml.example
+++ b/config/settings.d/dns_virsh.yml.example
@@ -2,7 +2,6 @@
 #
 # Configuration file for libvirtd-specific 'virsh' dns provider
 #
-# There's currently no configuration options for this provider.
-# Virsh network name is a global parameter that can be set
-# in the main settings.yml file in 'virsh_network' parameter.
-#
+
+# Libvirt network to use
+#:network: default

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -47,9 +47,6 @@
 # default values for https_port is 8443
 #:https_port: 8443
 
-# Shared options for virsh DNS/DHCP provider
-:virsh_network: default
-
 # Log configuration
 # Uncomment and modify if you want to change the location of the log file or use STDOUT or SYSLOG values
 #:log_file: /var/log/foreman-proxy/proxy.log

--- a/extra/migrations/20160224000000_migrate_virsh_settings.rb
+++ b/extra/migrations/20160224000000_migrate_virsh_settings.rb
@@ -1,0 +1,33 @@
+require 'fileutils'
+require 'yaml'
+
+class MigrateVirshSettingsConfig < ::Proxy::Migration
+  def migrate
+    input_yaml = YAML.load_file(File.join(src_dir, 'settings.yml'))
+    write_yaml("dhcp_virsh.yml", transform_dhcp_yaml(input_yaml))
+    write_yaml("dns_virsh.yml", transform_dns_yaml(input_yaml))
+  end
+
+  def transform_dns_yaml(yaml)
+    network = yaml.delete(:virsh_network) || 'default'
+    {
+      :network => network
+    }
+  end
+
+  def transform_dhcp_yaml(yaml)
+    network = yaml.delete(:virsh_network) || 'default'
+    {
+      :network => network,
+      :leases => "/var/lib/libvirt/dnsmasq/virbr0.status",
+    }
+  end
+
+  def write_yaml(filepath, yaml)
+    dst = path(dst_dir, "settings.d", filepath)
+    puts "Writing result to #{dst}"
+    File.open(dst, 'w') do |f|
+      f.write(yaml.to_yaml)
+    end
+  end
+end

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -9,7 +9,6 @@ module ::Proxy::Settings
       :daemon_pid => "/var/run/foreman-proxy/foreman-proxy.pid",
       :forward_verify => true,
       :bind_host => "*",
-      :virsh_network => 'default',
       :log_buffer => 2000,
       :log_buffer_errors => 1000,
     }

--- a/modules/dhcp_virsh/dhcp_virsh_main.rb
+++ b/modules/dhcp_virsh/dhcp_virsh_main.rb
@@ -7,9 +7,12 @@ module Proxy::DHCP::Virsh
   class Provider < ::Proxy::DHCP::Server
     include Proxy::Virsh
 
+    attr_reader :name, :network, :leases
+
     def initialize
       super("127.0.0.1")
-      @network = Proxy::SETTINGS.virsh_network
+      @network = Proxy::DHCP::Virsh::Plugin.settings.network
+      @leases = Proxy::DHCP::Virsh::Plugin.settings.leases
     end
 
     def initialize_for_testing(params)
@@ -53,27 +56,46 @@ module Proxy::DHCP::Virsh
       ret_val
     end
 
-    def parse_config_for_dhcp_records(subnet)
-      to_ret = []
-      begin
-        doc = REXML::Document.new xml = dump_xml
-        REXML::XPath.each(doc, "//network/ip[not(@family) or @family='ipv4']/dhcp/host") do |e|
-          to_ret << Proxy::DHCP::Reservation.new(:subnet => subnet, :ip => e.attributes["ip"],
-                                                 :mac => e.attributes["mac"], :hostname => e.attributes["name"])
-        end
-      rescue Exception => e
-        msg = "DHCP virsh provider error: unable to retrive virsh info: #{e}"
-        logger.error msg
-        logger.debug xml if defined?(xml)
-        raise Proxy::DHCP::Error, msg
+    def parse_config_for_dhcp_reservations(subnet)
+    to_ret = []
+      doc = REXML::Document.new xml = dump_xml
+      REXML::XPath.each(doc, "//network/ip[not(@family) or @family='ipv4']/dhcp/host") do |e|
+        to_ret << Proxy::DHCP::Reservation.new(:subnet => subnet, :ip => e.attributes["ip"],
+                                               :mac => e.attributes["mac"], :hostname => e.attributes["name"])
       end
       to_ret
+    rescue Exception => e
+      msg = "DHCP virsh provider error: unable to retrive virsh info: #{e}"
+      logger.error msg
+      logger.debug xml if defined?(xml)
+      raise Proxy::DHCP::Error, msg
+    end
+
+    def parse_json_for_dhcp_leases
+      JSON.parse(File.read(@leases))
+    rescue Exception => e
+      msg = "DHCP virsh provider error: unable to retrive leases from #{@leases}: #{e}"
+      logger.error msg
+      logger.debug xml if defined?(xml)
+      raise Proxy::DHCP::Error, msg
     end
 
     def load_subnet_data subnet
       super(subnet)
-      records = parse_config_for_dhcp_records(subnet)
-      records.each { |record| service.add_host(record.subnet_address, record) }
+      reservations = parse_config_for_dhcp_reservations(subnet)
+      reservations.each { |record| service.add_host(record.subnet_address, record) }
+      leases = parse_json_for_dhcp_leases
+      leases.each do |element|
+        lease = Proxy::DHCP::Lease.new(
+          :subnet => subnet,
+          :ip => element['ip-address'],
+          :mac => element['mac-address'],
+          :starts => Time.now.utc,
+          :ends => Time.at(element['expiry-time']).utc,
+          :state => 'active'
+        )
+        service.add_lease(lease.subnet_address, lease)
+      end
     end
 
     def add_record options={}

--- a/modules/dhcp_virsh/dhcp_virsh_plugin.rb
+++ b/modules/dhcp_virsh/dhcp_virsh_plugin.rb
@@ -4,6 +4,8 @@ module ::Proxy::DHCP::Virsh
 
     requires :dhcp, ::Proxy::VERSION
 
+    default_settings :network => 'default', :leases => '/var/lib/libvirt/dnsmasq/virbr0.status'
+
     after_activation do
       require 'dhcp_virsh/dhcp_virsh_main'
       require 'dhcp_virsh/dependencies'

--- a/modules/dns_virsh/dns_virsh_main.rb
+++ b/modules/dns_virsh/dns_virsh_main.rb
@@ -8,8 +8,10 @@ module Proxy::Dns::Virsh
     include Proxy::Util
     include Proxy::Virsh
 
+    attr_reader :network
+
     def initialize(a_network = nil)
-      @network = a_network || ::Proxy::SETTINGS.virsh_network
+      @network = a_network || Proxy::Dns::Virsh::Plugin.settings.network
       raise "DNS virsh provider needs 'virsh_network' option" unless @network
       super(nil, nil)
     end

--- a/modules/dns_virsh/dns_virsh_plugin.rb
+++ b/modules/dns_virsh/dns_virsh_plugin.rb
@@ -4,6 +4,8 @@ module ::Proxy::Dns::Virsh
 
     requires :dns, ::Proxy::VERSION
 
+    default_settings :network => 'default'
+
     after_activation do
       require 'dns_virsh/dns_virsh_main'
       require 'dns_virsh/dependencies'

--- a/test/dns_virsh/dns_virsh_test.rb
+++ b/test/dns_virsh/dns_virsh_test.rb
@@ -3,10 +3,13 @@ require 'dns_virsh/dns_virsh_plugin'
 require 'dns_virsh/dns_virsh_main'
 
 class DnsVirshTest < Test::Unit::TestCase
+  def test_default_settings
+    assert_equal 'default', Proxy::DHCP::Virsh::Provider.new.network
+  end
+
   def test_virsh_provider_initialization
-    ::Proxy::SETTINGS.stubs(:virsh_network).returns('some_network')
-    server = Proxy::Dns::Virsh::Record.new
-    assert_equal "some_network", server.network
+    ::Proxy::Dns::Virsh::Plugin.load_test_settings(:network => 'some_network')
+    assert_equal "some_network", Proxy::Dns::Virsh::Record.new.network
   end
 
   def test_virsh_entry_not_exists_returns_proxy_dns_notfound


### PR DESCRIPTION
This patch also splits configuration into two individual module configuration
files. This allows to use two different libvirt network for DHCP and DNS.

Note this needs most recent libvirt that stores leases now in JSON format
rather than plaintext:

```
cat /var/lib/libvirt/dnsmasq/virbr0.status
[
    {
        "ip-address": "192.168.122.68",
        "mac-address": "52:54:00:13:05:13",
        "client-id": "01:52:54:00:13:05:13",
        "expiry-time": 1455723598
    }
]
```

This takes advantage of that and directly parses the JSON. The filename is
configurable. Example:

```
curl -sk http://localhost:8448/dhcp/192.168.122.0 | json_reformat
{
    "reservations": [
        {
            "hostname": "test01.local.lan",
            "ip": "192.168.122.14",
            "mac": "52:54:00:01:4a:01"
        }
    ],
    "leases": [
        {
            "ip": "192.168.122.68",
            "mac": "52:54:00:13:05:13",
            "starts": "2016-02-17 14:41:51 UTC",
            "ends": "2016-02-17 15:39:58 UTC",
            "state": "active"
        }
    ]
}
```

There is no lease start stored in the JSON data, therefore the module puts
current time there.
