### PR TITLE
refs #13638 - fix .empty? check in pkg:generate_source task

### DIFF
--- a/tasks/pkg.rake
+++ b/tasks/pkg.rake
@@ -6,7 +6,7 @@ namespace :pkg do
     File.exist?('pkg') || FileUtils.mkdir('pkg')
     ref = ENV['ref'] || 'HEAD'
     version = `git show #{ref}:VERSION`.chomp.chomp('-develop')
-    raise "can't find VERSION from #{ref}" if !version.empty?
+    raise "can't find VERSION from #{ref}" if version.empty?
     `git archive --prefix=foreman-proxy-#{version}/ #{ref} | bzip2 -9 > pkg/foreman-proxy-#{version}.tar.bz2`
   end
 end


### PR DESCRIPTION
Caught pretty quickly by Jenkins when building the smart proxy packages.
