### PR TITLE
fixes #13841 Smart Proxy DNS nsupdate GSS fails

### DIFF
--- a/modules/dns_nsupdate/dns_nsupdate_gss_main.rb
+++ b/modules/dns_nsupdate/dns_nsupdate_gss_main.rb
@@ -17,7 +17,7 @@ module Proxy::Dns::NsupdateGSS
       " -g "
     end
 
-    def nsupdate_connect cmd
+    def nsupdate_connect
       init_krb5_ccache(tsig_keytab, tsig_principal)
       super
     end


### PR DESCRIPTION
Definition signature change to nsupdate_connect in dns_nsupdate_gss_main.rb.
