### PR TITLE
Fixes #13942: Backport {a,ptr}_record_conflicts functions

### DIFF
--- a/modules/dns_common/dns_common.rb
+++ b/modules/dns_common/dns_common.rb
@@ -1,3 +1,6 @@
+require 'resolv'
+require 'ipaddr'
+
 module Proxy::Dns
   class Error < RuntimeError; end
   class NotFound < RuntimeError; end
@@ -23,6 +26,55 @@ module Proxy::Dns
       end
     rescue Resolv::ResolvError
       false
+    end
+
+    def ptr_to_ip ptr
+     if ptr =~ /\.in-addr\.arpa$/
+       ptr.split('.')[0..-3].reverse.join('.')
+     elsif ptr =~ /\.ip6\.arpa$/
+       ptr.split('.')[0..-3].reverse.each_slice(4).inject([]) {|address, word| address << word.join}.join(":")
+     else
+       raise Proxy::Dns::Error.new("Not a PTR record: '#{ptr}'")
+     end
+    end
+
+    # conflict methods return values:
+    # no conflict: -1; conflict: 1, conflict but record / ip matches: 0
+    def a_record_conflicts(fqdn, ip)
+      if ip_addr = to_ipaddress(ip)
+        addresses = resolver.getaddresses(fqdn).select { |a| a =~ Resolv::IPv4::Regex }
+        return -1 if addresses.empty?
+        return 0 if addresses.any? {|a| IPAddr.new(a.to_s) == ip_addr}
+        1
+      else
+        raise Proxy::Dns::Error.new("Not an IP Address: '#{ip}'")
+      end
+    end
+
+    def aaaa_record_conflicts(fqdn, ip)
+      if ip_addr = to_ipaddress(ip)
+        addresses = resolver.getaddresses(fqdn).select { |a| a =~ Resolv::IPv6::Regex }
+        return -1 if addresses.empty?
+        return 0 if addresses.any? {|a| IPAddr.new(a.to_s) == ip_addr}
+        1
+      else
+        raise Proxy::Dns::Error.new("Not an IP Address: '#{ip}'")
+      end
+    end
+
+    def ptr_record_conflicts(fqdn, ip)
+      if ip_addr = to_ipaddress(ip)
+        names = resolver.getnames(ip_addr.to_s)
+        return -1 if names.empty?
+        return 0 if names.any? {|n| n.to_s.casecmp(fqdn) == 0}
+        1
+      else
+        raise Proxy::Dns::Error.new("Not an IP Address: '#{ip}'")
+      end
+    end
+
+    def to_ipaddress ip
+      IPAddr.new(ip) rescue false
     end
   end
 end

--- a/test/dns_common/record_test.rb
+++ b/test/dns_common/record_test.rb
@@ -16,4 +16,84 @@ class DnsRecordTest < Test::Unit::TestCase
     Resolv::DNS.any_instance.expects(:getaddress).with('another.host').raises(Resolv::ResolvError.new('DNS result has no information'))
     assert !Proxy::Dns::Record.new.dns_find('another.host')
   end
+
+  def test_ptr_to_ip_ipv4
+    assert_equal('192.168.33.30', Proxy::Dns::Record.new.ptr_to_ip('30.33.168.192.in-addr.arpa'))
+  end
+
+  def test_ptr_to_ip_ipv6
+    assert_equal('2001:0db8:deef:0000:0000:0000:0000:0001', Proxy::Dns::Record.new.ptr_to_ip('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa'))
+  end
+
+  def test_ptr_to_ip_without_record_exception
+    assert_raise Proxy::Dns::Error do
+      Proxy::Dns::Record.new.ptr_to_ip('host.example.com')
+    end
+  end
+
+  def test_a_record_conflicts_no_conflict
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns([])
+    assert_equal -1, Proxy::Dns::Record.new.a_record_conflicts('some.host', '192.168.33.33')
+  end
+
+  def test_a_record_conflicts_no_conflict_with_ipv6
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns(['2001:DB8:DEEF::1'])
+    assert_equal -1, Proxy::Dns::Record.new.a_record_conflicts('some.host', '192.168.33.33')
+  end
+
+  def test_a_record_conflicts_has_conflict
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns(['192.168.33.33', '2001:DB8:DEEF::1'])
+    assert_equal 1, Proxy::Dns::Record.new.a_record_conflicts('some.host', '192.168.11.11')
+  end
+
+  def test_a_record_conflicts_but_nothing_todo
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns(['192.168.33.33', '2001:DB8:DEEF::1'])
+    assert_equal 0, Proxy::Dns::Record.new.a_record_conflicts('some.host', '192.168.33.33')
+  end
+
+  def test_aaaa_record_conflicts_no_conflict
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns([])
+    assert_equal -1, Proxy::Dns::Record.new.aaaa_record_conflicts('some.host', '2001:DB8:DEEF::1')
+  end
+
+  def test_aaaa_record_conflicts_no_conflict_with_ipv4
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns(['192.168.33.33'])
+    assert_equal -1, Proxy::Dns::Record.new.aaaa_record_conflicts('some.host', '2001:DB8:DEEF::1')
+  end
+
+  def test_aaaa_record_conflicts_has_conflict
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns(['192.168.33.33', '2001:DB8:DEEF::1'])
+    assert_equal 1, Proxy::Dns::Record.new.aaaa_record_conflicts('some.host', '2001:DB8:ABCD::1')
+  end
+
+  def test_aaaa_record_conflicts_but_nothing_todo
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns(['192.168.33.33', '2001:DB8:DEEF::1'])
+    assert_equal 0, Proxy::Dns::Record.new.aaaa_record_conflicts('some.host', '2001:DB8:DEEF::1')
+  end
+
+  def test_aaaa_record_conflicts_but_nothing_todo_case_check
+    Resolv::DNS.any_instance.expects(:getaddresses).with('some.host').returns(['192.168.33.33', '2001:DB8:DEEF::1'])
+    assert_equal 0, Proxy::Dns::Record.new.aaaa_record_conflicts('some.host', '2001:dB8:deef::1')
+  end
+
+  def test_ptr_record_conflicts_no_conflict
+    Resolv::DNS.any_instance.expects(:getnames).with('192.168.33.33').returns([])
+    assert_equal -1, Proxy::Dns::Record.new.ptr_record_conflicts('some.host', '192.168.33.33')
+  end
+
+  def test_ptr_record_conflicts_has_conflict
+    Resolv::DNS.any_instance.expects(:getnames).with('2001:db8:deef::1').returns(['some.host'])
+    assert_equal 1, Proxy::Dns::Record.new.ptr_record_conflicts('another.host', '2001:db8:deef::1')
+  end
+
+  def test_ptr_record_conflicts_but_nothing_todo
+    Resolv::DNS.any_instance.expects(:getnames).with('192.168.33.33').returns(['some.host'])
+    assert_equal 0, Proxy::Dns::Record.new.ptr_record_conflicts('some.host', '192.168.33.33')
+  end
+
+  def test_to_ipaddress
+    assert_equal '192.168.33.33', Proxy::Dns::Record.new.to_ipaddress('192.168.33.33').to_s
+    assert_equal '2001:db8:deef::1', Proxy::Dns::Record.new.to_ipaddress('2001:db8:deef::1').to_s
+    assert_equal false, Proxy::Dns::Record.new.to_ipaddress('some.host')
+  end
 end


### PR DESCRIPTION
This backports from 450e0b694ead84961db9c1ffd4256919423484f6 but leaves out all the dnscmd changes. It also correctly ignores IPv6 addresses in a_record_conflicts. That's taken from 05d87379a132968d045258249c5e765e6aa8824a which hasn't made it to develop yet.
