### PR TITLE
Fixes #14153 - Allow configuration of SSL_CLIENT_CERT header name

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -6,6 +6,7 @@
 #:ssl_certificate: ssl/certs/fqdn.pem
 #:ssl_ca_file: ssl/certs/ca.pem
 #:ssl_private_key: ssl/private_keys/fqdn.key
+#:ssl_client_cert_header: SSL_CLIENT_CERT
 
 # Use this option only if you need to disable certain cipher suites.
 # Note: we use the OpenSSL suite name, take a look at:

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -11,7 +11,8 @@ module ::Proxy::Settings
       :bind_host => "*",
       :log_buffer => 2000,
       :log_buffer_errors => 1000,
-      :ssl_disabled_ciphers => []
+      :ssl_disabled_ciphers => [],
+      :ssl_client_cert_header => 'SSL_CLIENT_CERT',
     }
 
     HOW_TO_NORMALIZE = {

--- a/lib/sinatra/authorization.rb
+++ b/lib/sinatra/authorization.rb
@@ -32,7 +32,7 @@ module Sinatra
 
       before do
         if ['yes', 'on', '1'].include? request.env['HTTPS'].to_s
-          if request.env['SSL_CLIENT_CERT'].to_s.empty?
+          if request.env[Proxy::SETTINGS.ssl_client_cert_header].to_s.empty?
             log_halt 403, "No client SSL certificate supplied"
           end
         else


### PR DESCRIPTION
In passenger 5, `passenger_set_header` nginx option is adding HTTP_ prefix to each header, so we need to be able to set proper header name in order to validate client certificate.
