### PR TITLE
Fixes #12295 -- Added support for log rotation

### DIFF
--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -27,7 +27,7 @@ module Proxy
         :server => :webrick,
         :Host => SETTINGS.bind_host,
         :Port => SETTINGS.http_port,
-        :Logger => ::Proxy::Log.logger,
+        :Logger => ::Proxy::LogBuffer::Decorator.instance,
         :daemonize => false)
     end
 
@@ -50,7 +50,7 @@ module Proxy
           :server => :webrick,
           :Host => SETTINGS.bind_host,
           :Port => SETTINGS.https_port,
-          :Logger => ::Proxy::Log.logger,
+          :Logger => ::Proxy::LogBuffer::Decorator.instance,
           :SSLEnable => true,
           :SSLVerifyClient => OpenSSL::SSL::VERIFY_PEER,
           :SSLPrivateKey => load_ssl_private_key(SETTINGS.ssl_private_key),

--- a/lib/proxy/log.rb
+++ b/lib/proxy/log.rb
@@ -14,19 +14,13 @@ Logger.class_eval { alias_method :write, :info }
 
 module Proxy
   module Log
-    @@logger = nil
-
     def logger
-      @@logger ||= ::Proxy::Log.logger
+      ::Proxy::LogBuffer::Decorator.instance
     end
+  end
 
-    def self.default_logger(log_file)
-      # We keep the last 6 10MB log files
-      ::Logger.new(log_file, 6, 1024*1024*10)
-    end
-
+  class LoggerFactory
     def self.logger
-      log_file = ::Proxy::SETTINGS.log_file
       if log_file.casecmp('STDOUT').zero?
         if SETTINGS.daemon
           puts "Settings log_file=STDOUT and daemon=true are incompatible, exiting..."
@@ -44,7 +38,16 @@ module Proxy
         logger = default_logger(log_file)
       end
       logger.level = ::Logger.const_get(::Proxy::SETTINGS.log_level.upcase)
-      ::Proxy::LogBuffer::Decorator.new(logger)
+      logger
+    end
+
+    def self.default_logger(log_file)
+      # We keep the last 6 10MB log files
+      ::Logger.new(log_file, 6, 1024*1024*10)
+    end
+
+    def self.log_file
+      ::Proxy::SETTINGS.log_file
     end
   end
 

--- a/lib/proxy/log_buffer/decorator.rb
+++ b/lib/proxy/log_buffer/decorator.rb
@@ -1,32 +1,55 @@
 require 'proxy/log_buffer/decorator'
 require 'proxy/log_buffer/buffer'
+require 'thread'
 
 module Proxy::LogBuffer
   class Decorator
-    def initialize(logger, buffer = Proxy::LogBuffer::Buffer.instance)
+    def self.instance
+      @@instance ||= new(::Proxy::LoggerFactory.logger, ::Proxy::LoggerFactory.log_file)
+    end
+
+    def initialize(logger, log_file, buffer = Proxy::LogBuffer::Buffer.instance)
       @logger = logger
       @buffer = buffer
+      @log_file = log_file
+      @mutex = Mutex.new
+      @roll_log = false
+    end
+
+    # due to synchronization can't re-open the log from the signal trap
+    def roll_log
+      @roll_log = true
+    end
+
+    def handle_log_rolling
+      return if @log_file.casecmp('STDOUT') == 0 || @log_file.casecmp('SYSLOG') == 0
+      @roll_log = false
+      @logger.close rescue nil
+      @logger = ::Proxy::LoggerFactory.logger
     end
 
     def add(severity, message = nil, progname = nil, backtrace = nil)
-      severity ||= UNKNOWN
-      if message.nil?
-        if block_given?
-          message = yield
-        else
-          message = progname
+      @mutex.synchronize do
+        handle_log_rolling if @roll_log
+        severity ||= UNKNOWN
+        if message.nil?
+          if block_given?
+            message = yield
+          else
+            message = progname
+          end
         end
-      end
-      # add to the logger first
-      @logger.add(severity, message)
-      @logger.add(::Logger::Severity::DEBUG, backtrace) if backtrace
-      # add add to the buffer
-      if severity >= @logger.level
-        # we accept backtrace, exception and simple string
-        backtrace = backtrace.is_a?(Exception) ? backtrace.backtrace : backtrace
-        backtrace = backtrace.respond_to?(:join) ? backtrace.join("\n") : backtrace
-        rec = Proxy::LogBuffer::LogRecord.new(nil, severity, message, backtrace)
-        @buffer.push(rec)
+        # add to the logger first
+        @logger.add(severity, message)
+        @logger.add(::Logger::Severity::DEBUG, backtrace) if backtrace
+        # add add to the buffer
+        if severity >= @logger.level
+          # we accept backtrace, exception and simple string
+          backtrace = backtrace.is_a?(Exception) ? backtrace.backtrace : backtrace
+          backtrace = backtrace.respond_to?(:join) ? backtrace.join("\n") : backtrace
+          rec = Proxy::LogBuffer::LogRecord.new(nil, severity, message, backtrace)
+          @buffer.push(rec)
+        end
       end
     end
 

--- a/lib/proxy/signal_handler.rb
+++ b/lib/proxy/signal_handler.rb
@@ -8,6 +8,7 @@ class Proxy::SignalHandler
     handler.install_ttin_trap unless RUBY_PLATFORM =~ /mingw/
     handler.install_int_trap
     handler.install_term_trap
+    handler.install_usr1_trap
   end
 
   def install_ttin_trap
@@ -40,5 +41,11 @@ class Proxy::SignalHandler
 
   def install_term_trap
     trap(:TERM) { exit(0) }
+  end
+
+  def install_usr1_trap
+    trap(:USR1) do
+      ::Proxy::LogBuffer::Decorator.instance.roll_log
+    end
   end
 end

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -47,7 +47,7 @@ module Proxy
   ::Sinatra::Base.set :root, APP_ROOT
   ::Sinatra::Base.set :logging, false # we are not going to use Rack::Logger
   ::Sinatra::Base.use ::Proxy::LoggerMiddleware # instead, we have our own logging middleware
-  ::Sinatra::Base.use ::Rack::CommonLogger, ::Proxy::Log.logger
+  ::Sinatra::Base.use ::Rack::CommonLogger, ::Proxy::LogBuffer::Decorator.instance
   ::Sinatra::Base.set :env, :production
   ::Sinatra::Base.register ::Sinatra::Authorization
 

--- a/modules/templates/template_proxy_request.rb
+++ b/modules/templates/template_proxy_request.rb
@@ -22,7 +22,7 @@ module Proxy::Templates
 
       # You get a 201 from the 'built' URL
       raise "Error retrieving #{kind} for #{opts.inspect} from #{uri.host}: #{res.class}" unless ["200", "201"].include?(res.code)
-      Proxy::Log.logger.info "Template: request for #{kind} using #{opts.inspect} at #{uri.host}"
+      logger.info "Template: request for #{kind} using #{opts.inspect} at #{uri.host}"
       res.body
     end
 


### PR DESCRIPTION
  SIGUSR1 now can be used to re-open log file when file-based logger is used.
