### PR TITLE
RFC: Add new :mcollective_target_puppet_server option

### DIFF
--- a/config/settings.d/puppet.yml.example
+++ b/config/settings.d/puppet.yml.example
@@ -41,6 +41,10 @@
 # If you want to override the puppet_user above just for mco commands
 #:mcollective_user: peadmin
 
+# If you want to override the puppet server an agent will connect to when triggered with mco.
+# By default the agent will connect to the server defined in its local agent configuration file.
+#:mcollective_target_puppet_server: puppet.example.net:1234
+
 # URL of the puppet master itself for API requests
 #:puppet_url: https://puppet.example.com:8140
 # SSL certificates used to access the puppet master API

--- a/modules/puppet_proxy/mcollective.rb
+++ b/modules/puppet_proxy/mcollective.rb
@@ -23,6 +23,13 @@ class Proxy::Puppet::MCollective < Proxy::Puppet::Runner
       return false
     end
 
-    shell_command(cmd + ["puppet", "runonce", "-I"] + shell_escaped_nodes)
+    cmd.push("puppet", "runonce")
+
+    server = Proxy::Puppet::Plugin.settings.mcollective_target_puppet_server
+    if server
+      cmd.push("--server", server)
+    end
+
+    shell_command(cmd + ["-I"] + shell_escaped_nodes)
   end
 end

--- a/test/puppet/mcollective_test.rb
+++ b/test/puppet/mcollective_test.rb
@@ -42,6 +42,14 @@ class MCollectiveTest < Test::Unit::TestCase
     assert @mcollective.run
   end
 
+  def test_run_command_with_mcollective_target_puppet_server_defined
+    @mcollective.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
+    @mcollective.stubs(:which).with("mco", anything).returns("/usr/bin/mco")
+    Proxy::Puppet::Plugin.settings.stubs(:mcollective_target_puppet_server).returns("puppet.example.net:1234")
+    @mcollective.expects(:shell_command).with(["/usr/bin/sudo", "/usr/bin/mco", "puppet", "runonce", "--server", "puppet.example.net:1234", "-I", "host1", "host2"]).returns(true)
+    assert @mcollective.run
+  end
+
   def test_run_command_with_missing_sudo
     @mcollective.stubs(:which).with("sudo", anything).returns(false)
     @mcollective.stubs(:which).with("mco", anything).returns("/usr/bin/mco")


### PR DESCRIPTION
RFC: - DO NOT MERGE (NOT TESTED !!)

Hi.  I'm looking for any early feedback for this idea I had.  The code _probably_ hasn't got any bugs in it (famous last words), but I haven't actually tried it yet, so I'm not looking to have this merged at the moment.

The new setting allows the puppet smart-proxy to override the puppet
agents' puppet servers during an mco triggered puppet run.

Typically, I'd expect users to set :mcollective_target_puppet_server to
match the fqdn of the host running the smart-proxy.  After changing the
puppet master of a host in foreman, the 'run puppet' button would then
cause the agent to run puppet against its new master.  This might be more
convenient than using the old puppet server to update the agent's
'puppet server' setting.

Sound reasonable??

Thanks,
Alex
