### PR TITLE
fixes #14142 - launch WEBrick directly, avoiding Rack::Server

### DIFF
--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -22,13 +22,14 @@ module Proxy
         end
       end
 
-      Rack::Server.new(
+      {
         :app => app,
         :server => :webrick,
-        :Host => SETTINGS.bind_host,
+        :BindAddress => SETTINGS.bind_host,
         :Port => SETTINGS.http_port,
         :Logger => ::Proxy::LogBuffer::Decorator.instance,
-        :daemonize => false)
+        :daemonize => false
+      }
     end
 
     def https_app
@@ -45,10 +46,10 @@ module Proxy
         ssl_options |= OpenSSL::SSL::OP_NO_TLSv1 if defined?(OpenSSL::SSL::OP_NO_TLSv1)
         ssl_options |= OpenSSL::SSL::OP_NO_TLSv1_1 if defined?(OpenSSL::SSL::OP_NO_TLSv1_1)
 
-        Rack::Server.new(
+        {
           :app => app,
           :server => :webrick,
-          :Host => SETTINGS.bind_host,
+          :BindAddress => SETTINGS.bind_host,
           :Port => SETTINGS.https_port,
           :Logger => ::Proxy::LogBuffer::Decorator.instance,
           :SSLEnable => true,
@@ -57,7 +58,8 @@ module Proxy
           :SSLCertificate => load_ssl_certificate(SETTINGS.ssl_certificate),
           :SSLCACertificateFile => SETTINGS.ssl_ca_file,
           :SSLOptions => ssl_options,
-          :daemonize => false)
+          :daemonize => false
+        }
       end
     end
 
@@ -110,6 +112,12 @@ module Proxy
       ::Proxy::Plugins.update(::Proxy::PluginInitializer.new.initialize_plugins(::Proxy::Plugins.loaded))
     end
 
+    def webrick_server(app)
+      server = ::WEBrick::HTTPServer.new(app)
+      server.mount "/", Rack::Handler::WEBrick, app[:app]
+      server
+    end
+
     def launch
       configure_plugins
 
@@ -123,8 +131,8 @@ module Proxy
         write_pid
       end
 
-      t1 = Thread.new { https_app.start } unless https_app.nil?
-      t2 = Thread.new { http_app.start } unless http_app.nil?
+      t1 = Thread.new { webrick_server(https_app).start } unless https_app.nil?
+      t2 = Thread.new { webrick_server(http_app).start } unless http_app.nil?
 
       Proxy::SignalHandler.install_traps
 

--- a/lib/proxy/signal_handler.rb
+++ b/lib/proxy/signal_handler.rb
@@ -26,17 +26,7 @@ class Proxy::SignalHandler
   end
 
   def install_int_trap
-    if Rack.release < '1.6.4'
-      # Rack installs its own trap; Sleeping for 5 secs insures we overwrite it with our own
-      Thread.new do
-        sleep 5
-        begin
-          trap(:INT) { exit(0) }
-        rescue Exception => e
-          logger.warn "Unable to overwrite interrupt trap: #{e}"
-        end
-      end
-    end
+    trap(:INT) { exit(0) }
   end
 
   def install_term_trap


### PR DESCRIPTION
Rack::Server calls server-specific handlers such as
Rack::Handler::WEBrick which relies on a class-level variable that
causes race conditions when launching two WEBrick instances via
Rack::Server within the same process.

Launching WEBrick with the Rack::Builder-prepared app prevents the race
between the two instances, ensuring both start up correctly.  The Rack
WEBrick handler is still used to interface between WEBrick and the app
built with Rack.
