### PR TITLE
Fixes #9169 - Add option to ignore supersede next-server statement

### DIFF
--- a/config/settings.d/tftp.yml.example
+++ b/config/settings.d/tftp.yml.example
@@ -5,3 +5,6 @@
 #:tftproot: /var/lib/tftpboot
 # Defines the TFTP Servername to use, overrides the name in the subnet declaration
 #:tftp_servername: tftp.domain.com
+# By enabling this option, all new reservations for this subnets will not include
+#   "supersede server.next-server" option
+#:dont_pass_nextserver: true

--- a/modules/tftp/tftp_api.rb
+++ b/modules/tftp/tftp_api.rb
@@ -66,9 +66,12 @@ module Proxy::TFTP
       delete "syslinux", mac
     end
 
-    # Get the value for next_server
+    # Get the value for next_server and suppress flag
     get "/serverName" do
-       {"serverName" => (Proxy::TFTP::Plugin.settings.tftp_servername || "")}.to_json
+      {
+        "serverName" => (Proxy::TFTP::Plugin.settings.tftp_servername || ""),
+        "dont_pass_nextserver" => (Proxy::TFTP::Plugin.settings.dont_pass_nextserver || "")
+      }.to_json
     end
   end
 end


### PR DESCRIPTION
This patch introduces a new option "dont_pass_nextserver" into tftp.yml.

To set this option true, all new reservations for the subnet does not include "supersede server.next-server" statement into dhcpd.leases.
So, "next-server" value in each subnet specified in dhcpd.conf becomes valid.

It is necessary to modify both foreman and smart-proxy, I send the same titled PR to each.
