### PR TITLE
Fixes #14387 - correctly disable SSLv3 on Ruby 1.8.7

### DIFF
--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -43,8 +43,10 @@ module Proxy
 
         ssl_options = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options]
         ssl_options |= OpenSSL::SSL::OP_CIPHER_SERVER_PREFERENCE if defined?(OpenSSL::SSL::OP_CIPHER_SERVER_PREFERENCE)
+        # This is required to disable SSLv3 on Ruby 1.8.7
+        ssl_options |= OpenSSL::SSL::OP_NO_SSLv2 if defined?(OpenSSL::SSL::OP_NO_SSLv2)
+        ssl_options |= OpenSSL::SSL::OP_NO_SSLv3 if defined?(OpenSSL::SSL::OP_NO_SSLv3)
         ssl_options |= OpenSSL::SSL::OP_NO_TLSv1 if defined?(OpenSSL::SSL::OP_NO_TLSv1)
-        ssl_options |= OpenSSL::SSL::OP_NO_TLSv1_1 if defined?(OpenSSL::SSL::OP_NO_TLSv1_1)
 
         {
           :app => app,


### PR DESCRIPTION
This is a fix for the work done in #351. During testing I noticed different ciphers suits were being presented by EL6 and EL7 smart proxies. This turns out to be because in Ruby 1.8.7 `OpenSSL::SSL::OP_NO_SSLv3` is not part of `DEFAULT_PARAMS` and `OpenSSL::SSL::OP_NO_TLSv1_1` is not defined.

This change has three effects:
- Disables SSLv2 on Ruby 1.8.7 (if `OPENSSL_ENABLE_SSL2` is set)
- Disables SSLv3 on Ruby 1.8.7 (was already disabled on >= 1.9.3)
- Enables TLSv1.1 on Ruby >= 1.9.3 (was already enabled on 1.8.7)

While reenabling TLSv1.1 is slightly less than ideal, I think presenting uniform cipher suites is more important. After Ruby 1.8.7 support is dropped, this change can be reverted.
