### PR TITLE
Fixes #14394 - set :ServerSoftware to nil

### DIFF
--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -28,6 +28,7 @@ module Proxy
         :BindAddress => SETTINGS.bind_host,
         :Port => SETTINGS.http_port,
         :Logger => ::Proxy::LogBuffer::Decorator.instance,
+        :ServerSoftware => 'WEBrick',
         :daemonize => false
       }
     end
@@ -52,6 +53,7 @@ module Proxy
           :BindAddress => SETTINGS.bind_host,
           :Port => SETTINGS.https_port,
           :Logger => ::Proxy::LogBuffer::Decorator.instance,
+          :ServerSoftware => 'WEBrick',
           :SSLEnable => true,
           :SSLVerifyClient => OpenSSL::SSL::VERIFY_PEER,
           :SSLPrivateKey => load_ssl_private_key(SETTINGS.ssl_private_key),


### PR DESCRIPTION
Initial attempt at reducing the information disclosed by WEBrick in the HTTP server header.

Options I can think of:
- Set :ServerSoftware to "WEBrick." This is a best practice across many major sites, e.g. only returning "Apache" as the header. However given WEBrick's tiny install base, this would effectively uniquely identify Smart Proxy servers exposed to the internet.
- Set the :ServerSoftware to nil, causing WEBrick to return an empty server header.
- Monkey patch WEBrick::HTTPResponse#setup_header to not set the server header. This is the most ideal result, however I don't know how to accomplish it without copying the entire method into the Smart Proxy codebase. https://github.com/ruby/ruby/blob/trunk/lib/webrick/httpresponse.rb#L222 Is there a clean way to do this?

This is just a rough draft, I'd appreciate input on the best way to accomplish this.
