### PR TITLE
Fixes #10504 - Avoid splitting undefined customrun_args

### DIFF
--- a/modules/puppet_proxy/customrun.rb
+++ b/modules/puppet_proxy/customrun.rb
@@ -8,7 +8,7 @@ class Proxy::Puppet::CustomRun < Proxy::Puppet::Runner
       return false
     end
 
-    customrun_args = (a = Proxy::Puppet::Plugin.settings.customrun_args).is_a?(Array) ? a : a.split(' ')
+    customrun_args = (a = Proxy::Puppet::Plugin.settings.customrun_args).is_a?(Array) ? a : (a || '').split(' ')
     shell_command(([escape_for_shell(cmd), customrun_args] + shell_escaped_nodes).flatten)
   end
 end

--- a/test/puppet/customrun_test.rb
+++ b/test/puppet/customrun_test.rb
@@ -13,6 +13,12 @@ class CustomRunTest < Test::Unit::TestCase
     @customrun.run
   end
 
+  def test_customrun_with_nil_customrun_args
+    ::Proxy::Puppet::Plugin.load_test_settings(:customrun_cmd => "/bin/false", :customrun_args => nil)
+    @customrun.expects(:shell_command).with(["/bin/false", "host1", "host2"]).returns(true)
+    @customrun.run
+  end
+
   def test_customrun_with_array_command_args
     ::Proxy::Puppet::Plugin.load_test_settings(:customrun_cmd => "/bin/false", :customrun_args => ["-ay", "-f", "-s"])
     @customrun.expects(:shell_command).with(["/bin/false", "-ay", "-f", "-s", "host1", "host2"]).returns(true)


### PR DESCRIPTION
Fixes #10504.
