### PR TITLE
Fixes #14461 - removed :method_missing from Proxy::Settings::Plugin class

### DIFF
--- a/lib/proxy/settings/plugin.rb
+++ b/lib/proxy/settings/plugin.rb
@@ -9,7 +9,5 @@ module ::Proxy::Settings
       @used_defaults = @defaults.keys - settings.keys
       super(@defaults.merge(settings))
     end
-
-    def method_missing(symbol, *args); nil; end
   end
 end


### PR DESCRIPTION
  OpenStruct always returned 'nil' when calling methods for non-existing keys. Before ruby 2.3 methods for keys were defined during OpenStruct instantiation.
  Starting with ruby 2.3 methods for members of the OpenStruct are defined lazily, via method_missing. Our override of the method was breaking OpenStruct (and
  as a consequence Proxy::Settings::Plugin).
