### PR TITLE
Fixes #14719 - Add setting to allow TLSv1.

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -13,6 +13,11 @@
 # for more information.
 #:ssl_disabled_ciphers: [CIPHER-SUITE-1, CIPHER-SUITE-2]
 
+# Use this option only if you need to enable TLSv1, the default value is false.
+# Note: setting this option will lower security as there are known vulnerabilities
+# with TLSv1, only set this if absolutely necessary.
+#:enable_tls_v1: false
+
 # Hosts which the proxy accepts connections from
 # commenting the following lines would mean every verified SSL connection allowed
 # HTTPS: test the certificate CN

--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -53,7 +53,7 @@ module Proxy
       # This is required to disable SSLv3 on Ruby 1.8.7
       ssl_options |= OpenSSL::SSL::OP_NO_SSLv2 if defined?(OpenSSL::SSL::OP_NO_SSLv2)
       ssl_options |= OpenSSL::SSL::OP_NO_SSLv3 if defined?(OpenSSL::SSL::OP_NO_SSLv3)
-      ssl_options |= OpenSSL::SSL::OP_NO_TLSv1 if defined?(OpenSSL::SSL::OP_NO_TLSv1)
+      ssl_options |= OpenSSL::SSL::OP_NO_TLSv1 if !SETTINGS.enable_tls_v1 && defined?(OpenSSL::SSL::OP_NO_TLSv1)
 
       {
         :app => app,

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -11,7 +11,8 @@ module ::Proxy::Settings
       :bind_host => "*",
       :log_buffer => 2000,
       :log_buffer_errors => 1000,
-      :ssl_disabled_ciphers => []
+      :ssl_disabled_ciphers => [],
+      :enable_tls_v1 => false
     }
 
     HOW_TO_NORMALIZE = {


### PR DESCRIPTION
Php in both RHEL 6 & 7 cannot connect to the Foreman smart-proxy if TLSv1 is not allowed. Setting php to use TLSv1 or above will only work if you have curl 7.34 or newer. RHEL6 comes with curl 7.19 and RHEL7 comes with curl 7.29. See:

http://php.net/manual/en/function.curl-setopt.php#115993
