### PR TITLE
Fixes #14862 - pin webmock version for Ruby <1.9.3

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -6,12 +6,13 @@ group :test do
   gem 'rdoc'
   gem 'test-unit' if RUBY_VERSION > "1.8.7"
   gem 'addressable', '~> 2.3.8' if RUBY_VERSION == '1.8.7' # 2.4.0 drops support for ruby 1.8.7
-  gem 'webmock'
 
   if RUBY_VERSION < '1.9.3'
     gem 'rake', '< 11'
+    gem 'webmock', '< 2.0.0'
   else
     gem 'rake'
     gem 'rubocop-checkstyle_formatter', '~> 0.2'
+    gem 'webmock'
   end
 end


### PR DESCRIPTION
this is also needed in 1.11 and 1.10
