### PR TITLE
Fixes #14775 - virsh provider is now being renamed

### DIFF
--- a/extra/migrations/20160411000000_migrate_libvirt_settings.rb
+++ b/extra/migrations/20160411000000_migrate_libvirt_settings.rb
@@ -4,9 +4,19 @@ require 'yaml'
 class MigrateVirshToLibvirtConfig < ::Proxy::Migration
   def migrate
     input_yaml = YAML.load_file(path(src_dir, "settings.yml"))
-    copy_original_configuration_except("settings.yml", path("settings.d", "dhcp_virsh.yml"), path("settings.d", "dns_virsh.yml"))
-    write_yaml(path(dst_dir, "settings.d", "dhcp_libvirt.yml"), transform_dhcp_yaml(input_yaml))
-    write_yaml(path(dst_dir, "settings.d", "dns_libvirt.yml"), transform_dns_yaml(input_yaml))
+    copy_original_configuration_except("settings.yml",
+                                       path("settings.d", "dhcp.yml"), path("settings.d", "dhcp_virsh.yml"),
+                                       path("settings.d", "dns.yml"), path("settings.d", "dns_virsh.yml"))
+
+    dhcp_path = path(src_dir, "settings.d", "dhcp.yml")
+    write_yaml(path(dst_dir, "settings.d", "dhcp.yml"), transform_dhcp_yaml(YAML.load_file(dhcp_path))) if File.exist?(dhcp_path)
+
+    write_yaml(path(dst_dir, "settings.d", "dhcp_libvirt.yml"), transform_dhcp_libvirt_yaml(input_yaml))
+
+    dns_path = path(src_dir, "settings.d", "dns.yml")
+    write_yaml(path(dst_dir, "settings.d", "dns.yml"), transform_dns_yaml(YAML.load_file(dns_path))) if File.exist?(dns_path)
+    write_yaml(path(dst_dir, "settings.d", "dns_libvirt.yml"), transform_dns_libvirt_yaml(input_yaml))
+
     write_yaml(path(dst_dir, "settings.yml"), transform_settings_yaml(input_yaml))
   end
 
@@ -15,12 +25,22 @@ class MigrateVirshToLibvirtConfig < ::Proxy::Migration
     yaml
   end
 
-  def transform_dns_yaml(yaml)
+  def transform_dns_libvirt_yaml(yaml)
     network = yaml[:virsh_network] || 'default'
     { :network => network }
   end
 
+  def transform_dns_yaml(yaml)
+    yaml[:use_provider] = "dns_libvirt" if yaml[:use_provider] == "dns_virsh"
+    yaml
+  end
+
   def transform_dhcp_yaml(yaml)
+    yaml[:use_provider] = "dhcp_libvirt" if yaml[:use_provider] == "dhcp_virsh"
+    yaml
+  end
+
+  def transform_dhcp_libvirt_yaml(yaml)
     network = yaml[:virsh_network] || 'default'
     { :network => network }
   end

--- a/test/migrations/libvirt_migration_test.rb
+++ b/test/migrations/libvirt_migration_test.rb
@@ -8,23 +8,37 @@ class ProxyLibvirtMigrationTest < Test::Unit::TestCase
   def setup
     @old_config = YAML.load_file(File.join(File.dirname(__FILE__),'./migration_settings.yml'))
     @migration = MigrateVirshToLibvirtConfig.new("/tmp")
-    @dhcp_data = @migration.transform_dhcp_yaml(@old_config.dup)
-    @dns_data = @migration.transform_dns_yaml(@old_config.dup)
+  end
+
+  def test_transform_main_dhcp_configuration
+    assert_equal({:use_provider => 'dhcp_libvirt'}, @migration.transform_dhcp_yaml(:use_provider => 'dhcp_virsh'))
+  end
+
+  def test_transform_main_dhcp_configuration_when_another_provider_is_used
+    assert_equal({:use_provider => 'dhcp_isc'}, @migration.transform_dhcp_yaml(:use_provider => 'dhcp_isc'))
   end
 
   def test_transform_dhcp_yaml_empty
-    assert_equal 'default', @migration.transform_dhcp_yaml({})[:network]
+    assert_equal 'default', @migration.transform_dhcp_libvirt_yaml({})[:network]
   end
 
   def test_output_has_correct_dhcp_network
-    assert_equal 'mynetwork', @dhcp_data[:network]
+    assert_equal 'mynetwork', @migration.transform_dhcp_libvirt_yaml(@old_config.dup)[:network]
   end
 
   def test_transform_dns_yaml_empty
-    assert_equal 'default', @migration.transform_dns_yaml({})[:network]
+    assert_equal 'default', @migration.transform_dns_libvirt_yaml({})[:network]
+  end
+
+  def test_transform_main_dns_configuration
+    assert_equal({:use_provider => 'dns_libvirt'}, @migration.transform_dns_yaml(:use_provider => 'dns_virsh'))
+  end
+
+  def test_transform_main_dns_configuration_when_another_provider_is_used
+    assert_equal({:use_provider => 'dns_nsupdate'}, @migration.transform_dns_yaml(:use_provider => 'dns_nsupdate'))
   end
 
   def test_output_has_correct_dns_network
-    assert_equal 'mynetwork', @dns_data[:network]
+    assert_equal 'mynetwork', @migration.transform_dns_libvirt_yaml(@old_config.dup)[:network]
   end
 end


### PR DESCRIPTION
  When migrating during dns and dhcp configuration files.
