### PR TITLE
Fixes #14931 - TFTP class instantiating fixed

### DIFF
--- a/modules/tftp/tftp_api.rb
+++ b/modules/tftp/tftp_api.rb
@@ -8,13 +8,14 @@ module Proxy::TFTP
     helpers ::Proxy::Helpers
     authorize_with_trusted_hosts
     authorize_with_ssl_client
+    VARIANTS = ["Syslinux", "Pxegrub", "Pxegrub2", "Ztp", "Poap"].freeze
 
     helpers do
       def instantiate variant, mac=nil
         # Filenames must end in a hex representation of a mac address but only if mac is not empty
         log_halt 403, "Invalid MAC address: #{mac}"                  unless valid_mac?(mac) || mac.nil?
-        log_halt 403, "Unrecognized pxeboot config type: #{variant}" unless defined? variant.capitalize
-        eval "Proxy::TFTP::#{variant.capitalize}.new"
+        log_halt 403, "Unrecognized pxeboot config type: #{variant}" unless VARIANTS.include?(variant.capitalize)
+        Object.const_get("Proxy").const_get('TFTP').const_get(variant.capitalize).new
       end
 
       def create variant, mac

--- a/test/tftp/tftp_api_test.rb
+++ b/test/tftp/tftp_api_test.rb
@@ -17,6 +17,17 @@ class TftpApiTest < Test::Unit::TestCase
     @args = { :pxeconfig => "foo" }
   end
 
+  def test_instantiate_syslinux
+    obj = app.helpers.instantiate "syslinux", "AA:BB:CC:DD:EE:FF"
+    assert_equal "Proxy::TFTP::Syslinux", obj.class.name
+  end
+
+  def test_instantiate_nonexisting
+    subject = app
+    subject.helpers.expects(:log_halt).with(403, "Unrecognized pxeboot config type: Server").at_least(1)
+    subject.helpers.instantiate "Server", "AA:BB:CC:DD:EE:FF"
+  end
+
   def test_api_can_fetch_boot_file
     Proxy::Util::CommandTask.stubs(:new).returns(true)
     FileUtils.stubs(:mkdir_p).returns(true)


### PR DESCRIPTION
I prefer hardcoded list of classes to something like

```
ObjectSpace.each_object(::Class).select {|klass| klass < ::Proxy::TFTP }.collect(&:name).freeze
```

which can slow down startups.
