### PR TITLE
Fixes #14995 - proxy default log is INFO

### DIFF
--- a/bin/smart-proxy-win-service
+++ b/bin/smart-proxy-win-service
@@ -18,21 +18,21 @@ end
 begin
   class SmartDaemon < Daemon
     def service_init
-      logger.info("Service is initializing")
+      logger.debug("Service is initializing")
     end
 
     def service_main
-      logger.info("Service is running")
+      logger.debug("Service is running")
       # Start the foreman daemon
       Proxy::Launcher.new.launch
 
       # the daemon is about to exit.
-      logger.info("Service is terminating")
+      logger.debug("Service is terminating")
     end
 
     def service_stop
-      logger.info("Service is stopping.")
-    end    
+      logger.debug("Service is stopping.")
+    end
   end
 
   SmartDaemon.mainloop

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -58,7 +58,7 @@
 #:log_file: /var/log/foreman-proxy/proxy.log
 # Uncomment and modify if you want to change the log level
 # WARN, DEBUG, ERROR, FATAL, INFO, UNKNOWN
-#:log_level: ERROR
+#:log_level: INFO
 
 # Log buffer size and extra buffer size (for errors). Defaults to 3000 messages in total,
 # which is about 500 kB request.

--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -136,7 +136,7 @@ module Proxy
 
       (t1 || t2).join
     rescue SignalException => e
-      logger.info("Caught #{e}. Exiting")
+      logger.debug("Caught #{e}. Exiting")
       raise
     rescue SystemExit
       # do nothing. This is to prevent the exception handler below from catching SystemExit exceptions.

--- a/lib/proxy/kerberos.rb
+++ b/lib/proxy/kerberos.rb
@@ -5,7 +5,7 @@ module Proxy::Kerberos
     krb5 = Kerberos::Krb5.new
     ccache = Kerberos::Krb5::CredentialsCache.new
 
-    logger.info "Requesting credentials for Kerberos principal #{principal} using keytab #{keytab}"
+    logger.debug "Requesting credentials for Kerberos principal #{principal} using keytab #{keytab}"
     begin
       krb5.get_init_creds_keytab principal, keytab, nil, ccache
     rescue => e

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -4,7 +4,7 @@ module ::Proxy::Settings
       :settings_directory => Pathname.new(__FILE__).join("..","..","..","..","config","settings.d").expand_path.to_s,
       :https_port => 8443,
       :log_file => "/var/log/foreman-proxy/proxy.log",
-      :log_level => "ERROR",
+      :log_level => "INFO",
       :daemon => false,
       :daemon_pid => "/var/run/foreman-proxy/foreman-proxy.pid",
       :forward_verify => true,

--- a/modules/dhcp_common/subnet.rb
+++ b/modules/dhcp_common/subnet.rb
@@ -100,7 +100,7 @@ module Proxy::DHCP
           free_ips.rotate(stored_index).each do |ip|
             logger.debug "Searching for free IP - pinging #{ip}"
             if tcp_pingable?(ip) || icmp_pingable?(ip)
-              logger.info "Found a pingable IP(#{ip}) address which does not have a Proxy::DHCP record"
+              logger.debug "Found a pingable IP(#{ip}) address which does not have a Proxy::DHCP record"
             else
               logger.debug "Found free IP #{ip} out of a total of #{free_ips.size} free IPs"
               @index = free_ips.index(ip)+1

--- a/modules/dhcp_isc/dhcp_isc_main.rb
+++ b/modules/dhcp_isc/dhcp_isc_main.rb
@@ -273,7 +273,7 @@ module Proxy::DHCP::ISC
         raise Proxy::DHCP::InvalidRecord if response && !response.grep(/can\'t open object: not found/).empty?
         raise Proxy::DHCP::Error.new(msg)
       else
-        logger.info msg
+        logger.debug msg
       end
     end
 

--- a/modules/dhcp_native_ms/dhcp_native_ms_main.rb
+++ b/modules/dhcp_native_ms/dhcp_native_ms_main.rb
@@ -222,7 +222,7 @@ module Proxy::DHCP::NativeMS
     def report msg, response, error_only
       if response.grep(/completed successfully/).empty?
         if response.grep /class name being used is unknown/
-          logger.info "Vendor class not found"
+          logger.warn "Vendor class not found"
         else
           logger.error "Netsh failed:\n" + response.join("\n")
         end
@@ -237,7 +237,7 @@ module Proxy::DHCP::NativeMS
         msg += ": #{match}" if !match.size.empty?
         raise Proxy::DHCP::Error.new(msg)
       else
-        logger.info msg unless error_only
+        logger.debug msg unless error_only
       end
     rescue Proxy::DHCP::Error
       raise

--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -113,7 +113,7 @@ module Proxy::Dns::Dnscmd
         msg  = "Failed to #{msg}"
         raise Proxy::Dns::Error.new(msg)
       else
-        logger.info msg unless error_only
+        logger.debug msg unless error_only
       end
     rescue Proxy::Dns::Error
       raise

--- a/modules/puppet_proxy/initializer.rb
+++ b/modules/puppet_proxy/initializer.rb
@@ -14,7 +14,7 @@ module Proxy::Puppet
       end
 
       Puppet[:config] = Proxy::Puppet::Plugin.settings.puppet_conf
-      logger.info "Initializing from Puppet config file: #{Proxy::Puppet::Plugin.settings.puppet_conf}"
+      logger.debug "Initializing from Puppet config file: #{Proxy::Puppet::Plugin.settings.puppet_conf}"
 
       if Puppet::PUPPETVERSION.to_i >= 3
         Puppet.initialize_settings

--- a/modules/puppetca/puppetca_main.rb
+++ b/modules/puppetca/puppetca_main.rb
@@ -36,9 +36,9 @@ module Proxy::PuppetCa
         autosign.write entries.join("\n")
         autosign.write "\n"
         autosign.close
-        logger.info "Removed #{certname} from autosign"
+        logger.debug "Removed #{certname} from autosign"
       else
-        logger.info "Attempt to remove nonexistent client autosign for #{certname}"
+        logger.debug "Attempt to remove nonexistent client autosign for #{certname}"
         raise NotPresent, "Attempt to remove nonexistent client autosign for #{certname}"
       end
     end
@@ -53,7 +53,7 @@ module Proxy::PuppetCa
       found = autosign.readlines.find { |line| line.chomp == certname }
       autosign.puts certname unless found
       autosign.close
-      logger.info "Added #{certname} to autosign"
+      logger.debug "Added #{certname} to autosign"
     end
 
     # list of hosts which are now allowed to be installed via autosign
@@ -194,9 +194,9 @@ module Proxy::PuppetCa
       logger.debug "Executing #{command}"
       response = `#{command} 2>&1`
       if $?.success?
-        logger.info "#{mode}ed puppet certificate for #{certname}"
+        logger.debug "#{mode}ed puppet certificate for #{certname}"
       elsif response =~ /Could not find client certificate/ || $?.exitstatus == 24
-        logger.info "Attempt to remove nonexistent client certificate for #{certname}"
+        logger.debug "Attempt to remove nonexistent client certificate for #{certname}"
         raise NotPresent, "Attempt to remove nonexistent client certificate for #{certname}"
       else
         logger.warn "Failed to run puppetca: #{response}"

--- a/modules/realm/freeipa.rb
+++ b/modules/realm/freeipa.rb
@@ -18,17 +18,17 @@ module Proxy::Realm
       errors << "keytab not found: #{Proxy::Realm::Plugin.settings.realm_keytab}" unless Proxy::Realm::Plugin.settings.realm_keytab && File.exist?(Proxy::Realm::Plugin.settings.realm_keytab)
       errors << "principal not configured"                   unless Proxy::Realm::Plugin.settings.realm_principal
 
-      logger.info "freeipa: realm keytab is '#{Proxy::Realm::Plugin.settings.realm_keytab}' and using principal '#{Proxy::Realm::Plugin.settings.realm_principal}'"
+      logger.debug "freeipa: realm keytab is '#{Proxy::Realm::Plugin.settings.realm_keytab}' and using principal '#{Proxy::Realm::Plugin.settings.realm_principal}'"
 
       # Get FreeIPA Configuration
       if File.exist?(IPA_CONFIG)
         File.readlines(IPA_CONFIG).each do |line|
           if line =~ /xmlrpc_uri/
             @ipa_server = URI.parse line.split("=")[1].strip
-            logger.info "freeipa: server is #{@ipa_server}"
+            logger.debug "freeipa: server is #{@ipa_server}"
           elsif line =~ /realm/
             @realm_name = line.split("=")[1].strip
-            logger.info "freeipa: realm #{@realm_name}"
+            logger.debug "freeipa: realm #{@realm_name}"
           end
         end
       else
@@ -98,7 +98,7 @@ module Proxy::Realm
           # If the host is being rebuilt and is already enrolled, then
           # disable it in order to revoke existing certs, keytabs, etc.
           if host["result"]["has_keytab"]
-            logger.info "Attempting to disable host #{params[:hostname]} in FreeIPA"
+            logger.debug "Attempting to disable host #{params[:hostname]} in FreeIPA"
             @ipa.call("host_disable", [params[:hostname]])
           end
         end

--- a/modules/templates/template_proxy_request.rb
+++ b/modules/templates/template_proxy_request.rb
@@ -22,7 +22,7 @@ module Proxy::Templates
 
       # You get a 201 from the 'built' URL
       raise "Error retrieving #{kind} for #{opts.inspect} from #{uri.host}: #{res.class}" unless ["200", "201"].include?(res.code)
-      logger.info "Template: request for #{kind} using #{opts.inspect} at #{uri.host}"
+      logger.debug "Template: request for #{kind} using #{opts.inspect} at #{uri.host}"
       res.body
     end
 

--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -11,7 +11,7 @@ module Proxy::TFTP
       FileUtils.mkdir_p pxeconfig_dir
 
       File.open(pxeconfig_file(mac), 'w') {|f| f.write(config) }
-      logger.info "TFTP: entry for #{mac} created successfully"
+      logger.debug "TFTP: entry for #{mac} created successfully"
     end
 
     # Removes pxeconfig files
@@ -21,7 +21,7 @@ module Proxy::TFTP
         FileUtils.rm_f file
         logger.debug "TFTP: entry for #{mac} removed successfully"
       else
-        logger.info "TFTP: Skipping a request to delete a file which doesn't exists"
+        logger.debug "TFTP: Skipping a request to delete a file which doesn't exists"
       end
     end
 
@@ -32,7 +32,7 @@ module Proxy::TFTP
         config = File.open(pxeconfig_file(mac), 'r') {|f| f.readlines }
         logger.debug "TFTP: entry for #{mac} read successfully"
       else
-        logger.info "TFTP: Skipping a request to read a file which doesn't exists"
+        logger.debug "TFTP: Skipping a request to read a file which doesn't exists"
         raise "File #{file} not found"
       end
       config
@@ -44,12 +44,12 @@ module Proxy::TFTP
 
       FileUtils.mkdir_p File.dirname pxe_default
       File.open(pxe_default, 'w') {|f| f.write(config) }
-      logger.info "TFTP: #{pxe_default} entry created successfully"
+      logger.debug "TFTP: #{pxe_default} entry created successfully"
     end
 
     protected
     # returns the absolute path
-    # TODO: 
+    # TODO:
     def path(p = nil)
       p ||= Proxy::TFTP::Plugin.settings.tftproot
       return (p =~ /^\//) ? p : Pathname.new(File.expand_path(File.dirname(__FILE__))).join(p).to_s

--- a/test/global_settings_test.rb
+++ b/test/global_settings_test.rb
@@ -6,7 +6,7 @@ class GlobalSettingsTest < Test::Unit::TestCase
     assert_equal Pathname.new(__FILE__).join("..","..","config","settings.d").expand_path.to_s, settings.settings_directory
     assert_equal 8443, settings.https_port
     assert_equal "/var/log/foreman-proxy/proxy.log", settings.log_file
-    assert_equal "ERROR", settings.log_level
+    assert_equal "INFO", settings.log_level
     assert_equal false, settings.daemon
     assert_equal "/var/run/foreman-proxy/foreman-proxy.pid", settings.daemon_pid
   end


### PR DESCRIPTION
This is a proposal to set the default logging level to `INFO` instead of
`ERROR`. By default for most installation the log is zero-sized which does not
really help investigating issues. Our logging is clean, we currently send
request logs into it (which is what I would like to see with the default
settings) plus several other messages:

```
modules/realm/freeipa.rb
21:      logger.info "freeipa: realm keytab is '#{Proxy::Realm::Plugin.settings.realm_keytab}' and using principal '#{Proxy::Re
28:            logger.info "freeipa: server is #{@ipa_server}"
31:            logger.info "freeipa: realm #{@realm_name}"
101:            logger.info "Attempting to disable host #{params[:hostname]} in FreeIPA"

modules/tftp/server.rb
14:      logger.info "TFTP: entry for #{mac} created successfully"
24:        logger.info "TFTP: Skipping a request to delete a file which doesn't exists"
35:        logger.info "TFTP: Skipping a request to read a file which doesn't exists"
47:      logger.info "TFTP: #{pxe_default} entry created successfully"

modules/dhcp_common/subnet.rb
103:              logger.info "Found a pingable IP(#{ip}) address which does not have a Proxy::DHCP record"

modules/dns_dnscmd/dns_dnscmd_main.rb
116:        logger.info msg unless error_only

modules/templates/template_proxy_request.rb
25:      logger.info "Template: request for #{kind} using #{opts.inspect} at #{uri.host}"

modules/dhcp_native_ms/dhcp_native_ms_main.rb
225:          logger.info "Vendor class not found"
240:        logger.info msg unless error_only

modules/puppet_proxy/initializer.rb
17:      logger.info "Initializing from Puppet config file: #{Proxy::Puppet::Plugin.settings.puppet_conf}"

modules/dhcp_isc/dhcp_isc_main.rb
276:        logger.info msg

modules/puppetca/puppetca_main.rb
39:        logger.info "Removed #{certname} from autosign"
41:        logger.info "Attempt to remove nonexistent client autosign for #{certname}"
56:      logger.info "Added #{certname} to autosign"
197:        logger.info "#{mode}ed puppet certificate for #{certname}"
199:        logger.info "Attempt to remove nonexistent client certificate for #{certname}"

lib/launcher.rb
139:      logger.info("Caught #{e}. Exiting")

lib/proxy/plugin_initializer.rb
162:    logger.info("Successfully initialized '#{plugin.plugin_name}'")
173:    logger.info("Successfully initialized '#{plugin.plugin_name}'")

lib/proxy/kerberos.rb
8:    logger.info "Requesting credentials for Kerberos principal #{principal} using keytab #{keytab}"

bin/smart-proxy-win-service
21:      logger.info("Service is initializing")
25:      logger.info("Service is running")
30:      logger.info("Service is terminating")
34:      logger.info("Service is stopping.")

```

I can turn them into debug logs if required.
