### PR TITLE
Fixes #15043 - Fix puppet 4 mco search path

### DIFF
--- a/modules/puppet_proxy/mcollective.rb
+++ b/modules/puppet_proxy/mcollective.rb
@@ -15,7 +15,7 @@ class Proxy::Puppet::MCollective < Proxy::Puppet::Runner
       cmd.push("-u", user)
     end
 
-    cmd.push(which("mco", "/opt/puppet/bin"))
+    cmd.push(which("mco", ["/opt/puppet/bin", "/opt/puppetlabs/bin"]))
 
     if cmd.include?(false)
       logger.warn "sudo or the mco binary is missing."


### PR DESCRIPTION
In puppet 4, (AIO packaging), binaries can be found in `/opt/puppetlabs/bin`.

(`/opt/puppetlabs/bin/mco` is actually a symlink to
`/opt/puppetlabs/puppet/bin/mco`, but `/opt/puppetlabs/bin` is what's
added to PATH in `/etc/profile.d/puppet-agent.sh` so is probably the
path that should be searched.)
