### PR TITLE
Fixes #15240 - empty arrays no longer trigger validation failures

### DIFF
--- a/lib/proxy/plugin_validators.rb
+++ b/lib/proxy/plugin_validators.rb
@@ -34,7 +34,11 @@ module ::Proxy::PluginValidators
   class Presence < Base
     def validate!(settings)
       setting_value = settings[@setting_name]
-      raise ::Proxy::Error::ConfigurationError, "Parameter '#{@setting_name}' is expected to have a non-empty value" if setting_value.to_s.empty?
+
+      empty_value = setting_value.nil?
+      empty_value ||= setting_value.empty? if setting_value.is_a?(String)
+
+      raise ::Proxy::Error::ConfigurationError, "Parameter '#{@setting_name}' is expected to have a non-empty value" if empty_value
       true
     end
   end

--- a/test/plugins/validator_test.rb
+++ b/test/plugins/validator_test.rb
@@ -73,6 +73,12 @@ class PresenceValidatorTest < Test::Unit::TestCase
     assert ::Proxy::PluginValidators::Presence.new(PresenceValidatorTestPlugin, 'a_setting', nil, nil).validate!(:a_setting => 'some_file')
   end
 
+  def test_empty_string_treated_as_missing_value
+    assert_raises ::Proxy::Error::ConfigurationError do
+      ::Proxy::PluginValidators::Presence.new(PresenceValidatorTestPlugin, 'a_setting', nil, nil).validate!(:a_setting => '')
+    end
+  end
+
   def test_required_parameter_without_a_value_fails_validation
     assert_raises ::Proxy::Error::ConfigurationError do
       ::Proxy::PluginValidators::Presence.new(PresenceValidatorTestPlugin, 'a_setting', nil, nil).validate!(:a_setting => nil)


### PR DESCRIPTION
```
On 1.8.7 (only there) [].to_s == '', which lead to presence validator failures.
```
