### PR TITLE
fixes #15244 - provide a CNAME api to the DNSCMD provider

### DIFF
--- a/modules/dns/dns_api.rb
+++ b/modules/dns/dns_api.rb
@@ -27,6 +27,8 @@ module Proxy::Dns
         when 'AAAA'
           ip = IPAddr.new(value, Socket::AF_INET6).to_s
           server.create_aaaa_record(fqdn, ip)
+        when 'CNAME'
+          server.create_cname_record(fqdn, value)
         when 'PTR'
           validate_reverse_dns_name!(value)
           server.create_ptr_record(fqdn, value)
@@ -56,6 +58,8 @@ module Proxy::Dns
           server.remove_a_record(name)
         when 'AAAA'
           server.remove_aaaa_record(name)
+        when 'CNAME'
+          server.remove_cname_record(name)
         when 'PTR'
           validate_reverse_dns_name!(name)
           server.remove_ptr_record(name)

--- a/modules/dns_common/dns_common.rb
+++ b/modules/dns_common/dns_common.rb
@@ -62,6 +62,13 @@ module Proxy::Dns
       end
     end
 
+    def cname_record_conflicts(fqdn, target)
+      current = resolver.getresources(fqdn, Resolv::DNS::Resource::IN::CNAME)
+      return -1 if current.empty?
+      return 0 if current[0].name.to_s == target #There can only be one CNAME
+      1
+    end
+
     def ptr_record_conflicts(fqdn, ip)
       if ip_addr = to_ipaddress(ip)
         names = resolver.getnames(ip_addr.to_s)
@@ -75,6 +82,14 @@ module Proxy::Dns
 
     def to_ipaddress ip
       IPAddr.new(ip) rescue false
+    end
+
+    def create_cname_record(fqdn, target)
+      raise Proxy::Dns::Error.new("This DNS provider does not support CNAME management")
+    end
+
+    def remove_cname_record(fqdn)
+      raise Proxy::Dns::Error.new("This DNS provider does not support CNAME management")
     end
   end
 end

--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -41,6 +41,21 @@ module Proxy::Dns::Dnscmd
       end
     end
 
+    def create_cname_record(fqdn, target)
+      case cname_record_conflicts(fqdn, target) #returns -1, 0, 1
+        when 1 then
+          raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
+        when 0 then
+          return nil
+        else
+          zone = match_zone(fqdn, enum_zones)
+          msg = "Added CNAME entry #{fqdn} => #{target}"
+          cmd = "/RecordAdd #{zone} #{fqdn}. CNAME #{target}"
+          execute(cmd, msg)
+          nil
+      end
+    end
+
     def create_ptr_record(fqdn, ptr)
       case ptr_record_conflicts(fqdn, ptr_to_ip(ptr)) #returns -1, 0, 1
         when 1 then
@@ -68,6 +83,14 @@ module Proxy::Dns::Dnscmd
       zone = match_zone(fqdn, enum_zones)
       msg = "Removed DNS entry #{fqdn}"
       cmd = "/RecordDelete #{zone} #{fqdn}. AAAA /f"
+      execute(cmd, msg)
+      nil
+    end
+
+    def remove_cname_record(fqdn)
+      zone = match_zone(fqdn, enum_zones)
+      msg = "Removed CNAME entry #{fqdn}"
+      cmd = "/RecordDelete #{zone} #{fqdn}. CNAME /f"
       execute(cmd, msg)
       nil
     end

--- a/test/dns/dns_api_test.rb
+++ b/test/dns/dns_api_test.rb
@@ -7,7 +7,7 @@ ENV['RACK_ENV'] = 'test'
 
 class DnsApiTest < Test::Unit::TestCase
   class DnsApiTestProvider
-    attr_reader :fqdn, :ip, :type
+    attr_reader :fqdn, :ip, :type, :target
     def create_a_record(fqdn, ip)
       @fqdn = fqdn; @ip = ip; @type = 'A'
     end
@@ -17,6 +17,9 @@ class DnsApiTest < Test::Unit::TestCase
     def create_ptr_record(fqdn, ip)
       @fqdn = fqdn; @ip = ip; @type = 'PTR'
     end
+    def create_cname_record(fqdn, target)
+      @fqdn = fqdn; @target = target; @type = 'CNAME'
+    end
     def remove_a_record(fqdn)
       @fqdn = fqdn; @type = 'A'
     end
@@ -25,6 +28,9 @@ class DnsApiTest < Test::Unit::TestCase
     end
     def remove_ptr_record(ip)
       @ip = ip; @type = 'PTR'
+    end
+    def remove_cname_record(fqdn)
+      @fqdn = fqdn; @type = 'CNAME'
     end
   end
 
@@ -132,6 +138,14 @@ class DnsApiTest < Test::Unit::TestCase
     assert_equal 'AAAA', @server.type
   end
 
+  def test_create_cname_record
+    post '/', :fqdn => 'test.com', :value => 'test1.com', :type => 'CNAME'
+    assert_equal 200, last_response.status
+    assert_equal 'test.com', @server.fqdn
+    assert_equal 'test1.com', @server.target
+    assert_equal 'CNAME', @server.type
+  end
+
   def test_delete_a_record
     delete '/test.com'
     assert_equal 200, last_response.status
@@ -165,6 +179,13 @@ class DnsApiTest < Test::Unit::TestCase
     assert_equal 200, last_response.status
     assert_equal 'test.com', @server.fqdn
     assert_equal 'AAAA', @server.type
+  end
+
+  def test_delete_explicit_cname_record
+    delete "/test.com/CNAME"
+    assert_equal 200, last_response.status
+    assert_equal 'test.com', @server.fqdn
+    assert_equal 'CNAME', @server.type
   end
 
   def test_delete_returns_error_if_value_is_missing

--- a/test/dns_nsupdate/dns_nsupdate_test.rb
+++ b/test/dns_nsupdate/dns_nsupdate_test.rb
@@ -72,6 +72,12 @@ class DnsNsupdateTest < Test::Unit::TestCase
     end
   end
 
+  def test_remove_cname_record_fails
+    assert_raise Proxy::Dns::Error do
+      Proxy::Dns::Nsupdate::Record.new(nil, 100).remove_cname_record('some.host')
+    end
+  end
+
   def test_create_aaaa_record
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_connect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update add some.host. 100 AAAA 2001:db8::1').returns(true)


### PR DESCRIPTION
This is similar to a part of a solution that is used in my organization. There is a rake task that scans all hosts for a cnames host parameter and pushes out these aliases into the Microsoft DHCP servers scattered across the world.

This implementation is not optimal as the collision checks for A, AAAA and CNAME entries should all check for the other types as an A and CNAME entry can collide. I would argue that cname management is an ancillary function so does not need so much attention. In addition the names given to aliases tend to be specialized so will generally not be given to an ordinary machine. The rake task also does additional collision detection to ensure that A and CNAME entries are not already present.
