### PR TITLE
WIP #15613 - Add DHCPv6 support to proxy

### DIFF
--- a/modules/dhcp/dhcp_api.rb
+++ b/modules/dhcp/dhcp_api.rb
@@ -31,7 +31,7 @@ class Proxy::DhcpApi < ::Sinatra::Base
   get "/?" do
     begin
       content_type :json
-      server.subnets.map{|s| {:network => s.network, :netmask => s.netmask, :options => s.options}}.to_json
+      server.subnets.map{|s| {:network => s.network, :netmask => s.netmask, :options => s.options, :prefix => s.prefix}}.to_json
     rescue => e
       log_halt 400, e
     end

--- a/modules/dhcp_common/record.rb
+++ b/modules/dhcp_common/record.rb
@@ -5,7 +5,7 @@ module Proxy::DHCP
   # represent a DHCP Record
   class Record
 
-    attr_reader :ip, :mac, :subnet, :options
+    attr_reader :ip, :mac, :uid, :subnet, :options
     include Proxy::DHCP
     include Proxy::Log
     include Proxy::Validations
@@ -13,7 +13,7 @@ module Proxy::DHCP
     def initialize options = {}
       @subnet  = validate_subnet options[:subnet]
       @ip      = validate_ip options[:ip]
-      @mac     = validate_mac options[:mac]
+      set_mac_or_uid(validate_mac_or_uid options[:mac], options[:uid])
       @deleteable = options.delete(:deleteable) if options[:deleteable]
       @options = options
     end
@@ -22,8 +22,12 @@ module Proxy::DHCP
       @subnet.network
     end
 
+    def v6?
+      subnet.v6?
+    end
+
     def to_s
-      "#{ip} / #{mac}"
+      "#{ip} / #{prefix}"
     end
 
     def inspect
@@ -54,5 +58,11 @@ module Proxy::DHCP
       true
     end
 
+    private
+
+    def set_mac_or_uid(hash)
+      var = hash.keys.first
+      instance_variable_set "@#{var}", hash[var]
+    end
   end
 end

--- a/modules/dhcp_common/record/reservation.rb
+++ b/modules/dhcp_common/record/reservation.rb
@@ -11,7 +11,7 @@ module Proxy::DHCP
     end
 
     def to_s
-      "#{name} (#{ip} / #{mac})"
+      "#{name} (#{ip} / #{mac}#{uid})"
     end
 
     def method_missing arg
@@ -19,7 +19,7 @@ module Proxy::DHCP
     end
 
     def to_json(*options)
-      Hash[[:hostname, :ip, :mac].map{|s| [s, send(s)]}].to_json(*options)
+      Hash[[:hostname, :ip, :mac, :uid].map{|s| [s, send(s)]}].to_json(*options)
     end
   end
 end

--- a/modules/dhcp_common/subnet/ipv4.rb
+++ b/modules/dhcp_common/subnet/ipv4.rb
@@ -1,0 +1,71 @@
+require 'dhcp_common/subnet'
+
+module Proxy::DHCP
+  class Ipv4 < Subnet
+    attr_reader :netmask
+
+    def initialize network, netmask, options = {}
+      @netmask = validate_ip netmask
+      super network, options
+    end
+
+    def to_s
+      "#{network}/#{netmask}"
+    end
+
+    # NOTE: stored index is indepndent of call parameters:
+    # Whether range is passed or not, the lookup starts with the address at the indexed position,
+    # Is the assumption that unused_ip is always called with the same parameters for a given subnet?
+    #
+    # returns the next unused IP Address in a subnet
+    # Pings the IP address as well (just in case its not in Proxy::DHCP)
+    def unused_ip records, args = {}
+      free_ips = valid_range(args) - records.collect{|record| record.ip}
+      if free_ips.empty?
+        logger.warn "No free IPs at #{self}"
+        return nil
+      else
+        @index = 0
+        begin
+          # Read and lock the storage file
+          stored_index = get_index_and_lock("foreman-proxy_#{network}_#{prefix}.tmp")
+          free_ips.rotate(stored_index).each do |ip|
+            logger.debug "Searching for free IP - pinging #{ip}"
+            if tcp_pingable?(ip) || icmp_pingable?(ip)
+              logger.debug "Found a pingable IP(#{ip}) address which does not have a Proxy::DHCP record"
+            else
+              logger.debug "Found free IP #{ip} out of a total of #{free_ips.size} free IPs"
+              @index = free_ips.index(ip) + 1
+              return ip
+            end
+          end
+          logger.warn "No free IPs at #{self}"
+        rescue Exception => e
+          logger.debug e.message
+        ensure
+          # ensure we unlock the storage file
+          write_index_and_unlock @index
+        end
+        nil
+      end
+    end
+
+    def prefix
+      IPAddr.new(netmask).to_i.to_s(2).count("1")
+    end
+
+    def valid_range args = {}
+      total_range(args).map(&:to_s) - [network, broadcast]
+    end
+
+    def broadcast
+      IPAddr.new(to_s).to_range.last.to_s
+    end
+
+    private
+
+    def index_from_file file
+      file.readlines.first.to_i rescue 0
+    end
+  end
+end

--- a/modules/dhcp_common/subnet/ipv6.rb
+++ b/modules/dhcp_common/subnet/ipv6.rb
@@ -1,0 +1,70 @@
+require 'dhcp_common/subnet'
+require 'dhcp_common/monkey_patches' unless IPAddr.new.respond_to?('to_mask')
+
+module Proxy::DHCP
+  class Ipv6 < Subnet
+    attr_reader :prefix
+
+    def initialize network, prefix, options = {}
+      @prefix = validate_v6_prefix prefix
+      super network, options
+    end
+
+    def to_s
+      "#{network}/#{prefix}"
+    end
+
+    def netmask
+      IPAddr.new(network).mask(prefix).to_mask
+    end
+
+    def next_ipaddr(range, ip)
+      if ip == 0
+        range.first
+      else
+        IPAddr.new(ip).mask(range.first.to_mask)
+      end
+    end
+
+    def valid_range args = {}
+      # TODO - handle reserved addresses
+      # and change the first line in unused_ip
+      true
+    end
+
+    def unused_ip records, args = {}
+      current_range = total_range(args)
+
+      begin
+        stored_ip = get_index_and_lock("foreman-proxy_#{network}_#{prefix}.tmp")
+        candidate_ipaddr = next_ipaddr(current_range, stored_ip)
+        first_ipaddr = candidate_ipaddr
+        while true
+          candidate_ipaddr = current_range.first if candidate_ipaddr.to_i > current_range.last.to_i
+          ip = candidate_ipaddr.to_s
+          if tcp_pingable?(ip) || icmp_pingable?(ip)
+            logger.debug "Found a pingable IP(#{ip}) address which does not have a Proxy::DHCP record"
+          else
+            logger.debug "Found free IP #{ip}"
+            @index = candidate_ipaddr.succ.to_s
+            return ip
+          end
+          candidate_ipaddr = candidate_ipaddr.succ
+          break if candidate_ipaddr == first_ipaddr
+        end
+        logger.warn "No free IPs at #{self}"
+      rescue Exception => e
+        logger.debug e.message
+      ensure
+        write_index_and_unlock @index
+      end
+      nil
+    end
+
+    private
+
+    def index_from_file file
+      file.readline rescue 0
+    end
+  end
+end

--- a/modules/dhcp_isc/configuration_loader.rb
+++ b/modules/dhcp_isc/configuration_loader.rb
@@ -19,24 +19,8 @@ module Proxy::DHCP::ISC
                                          container.get_dependency(:memory_store), container.get_dependency(:memory_store),
                                          container.get_dependency(:memory_store), container.get_dependency(:memory_store))
       end)
-      container.dependency :parser, lambda {::Proxy::DHCP::ISC::FileParser.new(container.get_dependency(:subnet_service))}
-      container.dependency :config_file, lambda {::Proxy::DHCP::ISC::ConfigurationFile.new(settings[:config], container.get_dependency(:parser))}
-      container.dependency :leases_file, lambda {::Proxy::DHCP::ISC::LeasesFile.new(settings[:leases], container.get_dependency(:parser))}
-      container.dependency :state_changes_observer, (lambda do
-        ::Proxy::DHCP::ISC::IscStateChangesObserver.new(container.get_dependency(:config_file), container.get_dependency(:leases_file), container.get_dependency(:subnet_service))
-      end)
 
-      if settings[:leases_file_observer] == :inotify_leases_file_observer
-        require 'dhcp_isc/inotify_leases_file_observer'
-        container.singleton_dependency :leases_observer, (lambda do
-          ::Proxy::DHCP::ISC::InotifyLeasesFileObserver.new(container.get_dependency(:state_changes_observer), settings[:leases])
-        end)
-      elsif settings[:leases_file_observer] == :kqueue_leases_file_observer
-        require 'dhcp_isc/kqueue_leases_file_observer'
-        container.singleton_dependency :leases_observer, (lambda do
-          ::Proxy::DHCP::ISC::KqueueLeasesFileObserver.new(container.get_dependency(:state_changes_observer), settings[:leases])
-        end)
-      end
+      load_wirings_for_files container, settings
 
       container.dependency :dhcp_provider, (lambda do
         Proxy::DHCP::ISC::Provider.new(
@@ -48,11 +32,55 @@ module Proxy::DHCP::ISC
     def load_classes
       require 'dhcp_common/subnet_service'
       require 'dhcp_common/server'
-      require 'dhcp_isc/isc_file_parser'
+      require 'dhcp_isc/isc_file_parser4'
+      require 'dhcp_isc/isc_file_parser6'
       require 'dhcp_isc/configuration_file'
       require 'dhcp_isc/leases_file'
       require 'dhcp_isc/isc_state_changes_observer'
       require 'dhcp_isc/dhcp_isc_main'
+      require 'dhcp_common/subnet/ipv4'
+      require 'dhcp_common/subnet/ipv6'
+    end
+
+    private
+
+    def versions
+      %w(4 6)
+    end
+
+    def dep_name(name, ver)
+      "#{name}#{ver}".to_sym
+    end
+
+    def load_wirings_for_files(container, settings)
+      versions.each do |ver|
+        parser_class = Kernel.const_get "::Proxy::DHCP::ISC::FileParser#{ver}"
+        container.dependency dep_name(:parser, ver), lambda { parser_class.new(container.get_dependency(:subnet_service)) }
+        container.dependency dep_name(:config_file, ver), lambda {
+          ::Proxy::DHCP::ISC::ConfigurationFile.new(settings[dep_name(:config, ver)], container.get_dependency(dep_name(:parser, ver))) }
+        container.dependency dep_name(:leases_file, ver), lambda {
+          ::Proxy::DHCP::ISC::LeasesFile.new(settings[dep_name(:leases, ver)], container.get_dependency(dep_name(:parser, ver))) }
+        container.dependency dep_name(:state_changes_observer, ver), (lambda do
+          ::Proxy::DHCP::ISC::IscStateChangesObserver.new(container.get_dependency(dep_name(:config_file, ver)),
+                                                          container.get_dependency(dep_name(:leases_file, ver)),
+                                                          container.get_dependency(:subnet_service))
+        end)
+        load_wirings_for_observers container, settings, ver
+      end
+    end
+
+    def load_wirings_for_observers(container, settings, ipv)
+      if settings[:leases_file_observer] == :inotify_leases_file_observer
+        require 'dhcp_isc/inotify_leases_file_observer'
+        container.singleton_dependency dep_name(:leases_observer, ipv), (lambda do
+          ::Proxy::DHCP::ISC::InotifyLeasesFileObserver.new(container.get_dependency(dep_name(:state_changes_observer, ipv)), settings[dep_name(:leases, ipv)])
+        end)
+      elsif settings[:leases_file_observer] == :kqueue_leases_file_observer
+        require 'dhcp_isc/kqueue_leases_file_observer'
+        container.singleton_dependency dep_name(:leases_observer, ipv), (lambda do
+          ::Proxy::DHCP::ISC::KqueueLeasesFileObserver.new(container.get_dependency(dep_name(:state_changes_observer, ipv)), settings[dep_name(:leases, ipv)])
+        end)
+      end
     end
   end
 end

--- a/modules/dhcp_isc/dhcp_isc_plugin.rb
+++ b/modules/dhcp_isc/dhcp_isc_plugin.rb
@@ -2,16 +2,19 @@ module ::Proxy::DHCP::ISC
   class Plugin < ::Proxy::Provider
     plugin :dhcp_isc, ::Proxy::VERSION
 
-    default_settings :config => '/etc/dhcp/dhcpd.conf', :leases => '/var/lib/dhcpd/dhcpd.leases',
-                     :omapi_port => '7911'
+    default_settings :config4 => '/etc/dhcp/dhcpd.conf',
+                     :leases4 => '/var/lib/dhcpd/dhcpd.leases',
+                     :omapi_port => '7911',
+                     :config6 => '/etc/dhcp/dhcpd6.conf',
+                     :leases6 => '/var/lib/dhcpd/dhcpd6.leases'
 
     requires :dhcp, ::Proxy::VERSION
-    validate_readable :config, :leases
+    validate_readable :config4, :leases4, :config6, :leases6
 
     load_classes ::Proxy::DHCP::ISC::PluginConfiguration
     load_programmable_settings ::Proxy::DHCP::ISC::PluginConfiguration
     load_dependency_injection_wirings ::Proxy::DHCP::ISC::PluginConfiguration
 
-    start_services :leases_observer
+    start_services :leases_observer4, :leases_observer6
   end
 end

--- a/modules/dhcp_isc/isc_file_parser4.rb
+++ b/modules/dhcp_isc/isc_file_parser4.rb
@@ -1,0 +1,69 @@
+require 'dhcp_isc/isc_file_parser'
+
+module Proxy::DHCP::ISC
+  class FileParser4 < FileParser
+    attr_reader :subnet_block_regex
+
+    def initialize(subnet_service)
+      super subnet_service
+      @subnet_block_regex = /subnet\s+([\d\.]+)\s+netmask\s+([\d\.]+)#{subnet_block_body_regex}/
+    end
+
+    def parse_record_options text
+      options = super text
+      case text
+      when /^fixed-address\s+(\S+)/
+          options[:ip] = $1
+      when /^supersede server.next-server\s+=\s+(\S+)/
+        begin
+          ns = validate_ip hex2ip($1)
+        rescue
+          ns = $1.gsub("\"","")
+        end
+        options[:nextServer] = ns
+      when /^supersede server.filename\s+=\s+"(\S+)"/
+        options[:filename] = $1
+      when "dynamic"
+        options[:deleteable] = true
+      #TODO: check if adding a new reservation with omshell for a free lease still
+      #generates a conflict
+      end
+      options
+    end
+
+    def parse_config_for_subnets(read_config)
+      read_config_for_subnets(read_config).map do |match|
+        network, mask, subnet_config_lines = match
+        Proxy::DHCP::Ipv4.new(network, mask, get_subnet_options(subnet_config_lines))
+      end
+    end
+
+    def get_subnet_options(subnet_config_lines)
+      parse_subnet_options(subnet_config_lines) do |option, options|
+        case option
+        when /^option\s+routers\s+[\d\.]+/
+          options[:routers] = get_ip_list_from_config_line(option)
+        when /^option\s+domain\-name\-servers\s+[\d\.]+/
+          options[:domain_name_servers] = get_ip_list_from_config_line(option)
+        when /^range\s+[\d\.]+\s+[\d\.]+/
+          # get IP addr range used for this subnet
+          options[:range] = get_range_from_config_line(option)
+        end
+      end
+    end
+
+    # Get all IPv4 addresses provided by the ISC DHCP config line following the pattern "my-config-option-or-directive IPv4_ADDR[, IPv4_ADDR] [...];" and return an array.
+    def get_ip_list_from_config_line(option_line)
+      option_line.scan(/\s*((?:(?:\d{1,3}\.){3}\d{1,3})\s*(?:,\s*(?:(?:\d{1,3}\.){3}\d{1,3})\s*)*)/).first.first.gsub(/\s/,'').split(",").reject{|value| value.nil? || value.empty? }
+    end
+
+    # Get IPv4 range provided by the ISC DHCP config line following the pattern "range IPv4_ADDR IPv4_ADDR;" and return an array.
+    def get_range_from_config_line(range_line)
+      range_line.scan(/\s*((?:\d{1,3}\.){3}\d{1,3})\s*((?:\d{1,3}\.){3}\d{1,3})\s*/).first
+    end
+
+    def hex2ip hex
+      hex.split(":").map{|h| h.to_i(16).to_s}.join(".")
+    end
+  end
+end

--- a/modules/dhcp_isc/isc_file_parser6.rb
+++ b/modules/dhcp_isc/isc_file_parser6.rb
@@ -1,0 +1,63 @@
+require 'dhcp_isc/isc_file_parser'
+require 'proxy/validations'
+
+module Proxy::DHCP::ISC
+  class FileParser6 < FileParser
+    include Proxy::Validations
+
+    attr_reader :subnet_block_regex
+
+    def initialize(subnet_service)
+      super subnet_service
+      @subnet_block_regex = /subnet6\s+([\da-f:]+)\/(\d{1,3})#{subnet_block_body_regex}/
+    end
+
+    def parse_record_options text
+      options = super text
+      case text
+      when /^fixed-address6\s+(\S+)/
+        options[:ip] = $1
+      when /^fixed-prefix6\s+(\S+)/
+        options[:prefix] = $1
+      # this comes from dhcpd6.conf
+      when /dhcp6\.client-id\s+(\S+)/
+        options[:uid] = $1
+      # and this from dhcpd6.leases
+      when /^client-identifier\s+(\S+)/
+        options[:uid] ||= $1
+      end
+      options
+    end
+
+    def parse_config_for_subnets(read_config)
+      res = read_config_for_subnets(read_config).map do |match|
+        network, prefix, subnet_config_lines = match
+        Proxy::DHCP::Ipv6.new(network, prefix, get_subnet_options(subnet_config_lines))
+      end
+      res || []
+    end
+
+    def get_subnet_options(subnet_config_lines)
+      parse_subnet_options(subnet_config_lines) do |option, options|
+        case option
+        when /^option\s+dhcp6\.name-servers\s+([\da-f:]+.*)/
+          options[:domain_name_servers] = get_ip_list_from_config_line($1)
+        when /^range6\s+.*temporary$/
+          # do nothing, we do not care about temporary range
+        when /^range6\s+([\dabcdef:]+)\s+([\da-f:]+)/
+          options[:range] = get_range_from_config_file([$1, $2])
+        end
+      end
+    end
+
+    def get_ip_list_from_config_line(match)
+      line.split(',').reject { |item| item.nil? || item.empty? }.select do |item|
+        soft_validate_ip item
+      end
+    end
+
+    def get_range_from_config_file(ip_range)
+      ip_range.all? { |item| soft_validate_ip item } ? ip_range : []
+    end
+  end
+end

--- a/modules/dhcp_libvirt/dhcp_libvirt_main.rb
+++ b/modules/dhcp_libvirt/dhcp_libvirt_main.rb
@@ -1,79 +1,23 @@
-require 'rexml/document'
-require 'ipaddr'
-
 module Proxy::DHCP::Libvirt
   class Provider < ::Proxy::DHCP::Server
-    attr_reader :libvirt_network, :network
+    attr_reader :network, :parser
+    attr_accessor :libvirt_network
 
-    def initialize(network, libvirt_network_impl, subnet_service)
+    def initialize(network, libvirt_network_impl, subnet_service, parser)
       @network = network
       @libvirt_network = libvirt_network_impl
+      @parser = parser
       super(@network, nil, subnet_service)
     end
 
     def load_subnets
       super
-      service.add_subnets(*parse_config_for_subnets)
-    end
-
-    def parse_config_for_subnets
-      ret_val = []
-      doc = REXML::Document.new xml = libvirt_network.dump_xml
-      doc.elements.each("network/ip") do |e|
-        next if e.attributes["family"] == "ipv6"
-        gateway = e.attributes["address"]
-
-        if e.attributes["netmask"].nil? then
-          # converts a prefix/cidr notation to octets
-          netmask = IPAddr.new(gateway).mask(e.attributes["prefix"]).to_mask
-        else
-          netmask = e.attributes["netmask"]
-        end
-
-        a_network = IPAddr.new(gateway).mask(netmask).to_s
-        ret_val << Proxy::DHCP::Subnet.new(a_network, netmask)
-      end
-      raise Proxy::DHCP::Error("Only one subnet is supported") if ret_val.size > 1
-      ret_val
-    rescue Exception => e
-      logger.error msg = "Unable to parse subnets XML: #{e}"
-      logger.debug xml if defined?(xml)
-      raise Proxy::DHCP::Error, msg
-    end
-
-    def parse_config_for_dhcp_reservations(subnet)
-      to_ret = []
-      doc = REXML::Document.new xml = libvirt_network.dump_xml
-      REXML::XPath.each(doc, "//network/ip[not(@family) or @family='ipv4']/dhcp/host") do |e|
-        to_ret << Proxy::DHCP::Reservation.new(
-          :subnet => subnet,
-          :ip => e.attributes["ip"],
-          :mac => e.attributes["mac"],
-          :hostname => e.attributes["name"])
-      end
-      to_ret
-    rescue Exception => e
-      logger.error msg = "Unable to parse reservations XML: #{e}"
-      logger.debug xml if defined?(xml)
-      raise Proxy::DHCP::Error, msg
+      parser.load_subnets
     end
 
     def load_subnet_data(subnet)
       super(subnet)
-      reservations = parse_config_for_dhcp_reservations(subnet)
-      reservations.each { |record| service.add_host(record.subnet_address, record) }
-      leases = libvirt_network.dhcp_leases
-      leases.each do |element|
-        lease = Proxy::DHCP::Lease.new(
-          :subnet => subnet,
-          :ip => element['ipaddr'],
-          :mac => element['mac'],
-          :starts => Time.now.utc,
-          :ends => Time.at(element['expirytime'] || 0).utc,
-          :state => 'active'
-        )
-        service.add_lease(lease.subnet_address, lease)
-      end
+      parser.load_subnet_data(subnet)
     end
 
     def add_record(options={})

--- a/modules/dhcp_libvirt/dhcp_libvirt_parser.rb
+++ b/modules/dhcp_libvirt/dhcp_libvirt_parser.rb
@@ -1,0 +1,111 @@
+require 'rexml/document'
+require 'ipaddr'
+
+module Proxy::DHCP::Libvirt
+  class Parser
+    include Proxy::Log
+
+    attr_reader :service
+    attr_accessor :libvirt_network
+
+    def initialize(subnet_service, libvirt_network)
+      @service = subnet_service
+      @libvirt_network = libvirt_network
+    end
+
+    def load_subnets
+      service.add_subnets(*parse_config_for_subnets)
+    end
+
+    def parse_config_for_subnets
+      ret_val = []
+      doc = REXML::Document.new xml = libvirt_network.dump_xml
+      doc.elements.each_with_index("network/ip") do |elem, index|
+        if elem.attributes["family"] == "ipv6"
+          ret_val << parse_ipv6_subnet(elem)
+          libvirt_network.index_v6 = index
+        else
+          ret_val << parse_ipv4_subnet(elem)
+          libvirt_network.index_v4 = index
+        end
+      end
+      raise Proxy::DHCP::Error("Only one subnet is supported") if ret_val.partition { |net| net.v6? }.any? { |ary| ary.count > 1 }
+      ret_val
+    rescue Exception => e
+      logger.error msg = "Unable to parse subnets XML: #{e}"
+      logger.debug xml if defined?(xml)
+      raise Proxy::DHCP::Error, msg
+    end
+
+    def parse_ipv4_subnet(elem)
+      gateway = elem.attributes["address"]
+      if elem.attributes["netmask"].nil? then
+        # converts a prefix/cidr notation to octets
+        netmask = IPAddr.new(gateway).mask(elem.attributes["prefix"]).to_mask
+      else
+        netmask = elem.attributes["netmask"]
+      end
+      Proxy::DHCP::Ipv4.new(gateway, netmask)
+    end
+
+    def parse_ipv6_subnet(elem)
+      gateway = elem.attributes["address"]
+      prefix = elem.attributes["prefix"]
+      Proxy::DHCP::Ipv6.new(gateway, prefix)
+    end
+
+    def parse_config_for_dhcp_reservations(subnet)
+      doc = REXML::Document.new xml = libvirt_network.dump_xml
+      if subnet.v6?
+        parse_v6_reservations(doc, subnet)
+      else
+        parse_v4_reservations(doc, subnet)
+      end
+    rescue Exception => e
+      logger.error msg = "Unable to parse reservations XML: #{e}"
+      logger.debug xml if defined?(xml)
+      raise Proxy::DHCP::Error, msg
+    end
+
+    def parse_v4_reservations(doc, subnet)
+      to_ret = []
+      REXML::XPath.each(doc, "//network/ip[not(@family) or @family='ipv4']/dhcp/host") do |e|
+        to_ret << Proxy::DHCP::Reservation.new(
+          :subnet => subnet,
+          :ip => e.attributes["ip"],
+          :mac => e.attributes["mac"],
+          :hostname => e.attributes["name"])
+      end
+      to_ret
+    end
+
+    def parse_v6_reservations(doc, subnet)
+      to_ret = []
+      REXML::XPath.each(doc, "//network/ip[@family='ipv6']/dhcp/host") do |e|
+        to_ret << Proxy::DHCP::Reservation.new(
+          :subnet => subnet,
+          :ip => e.attributes["ip"],
+          :id => e.attributes["id"],
+          :hostname => e.attributes["name"])
+      end
+      to_ret
+    end
+
+    def load_subnet_data(subnet)
+      reservations = parse_config_for_dhcp_reservations(subnet)
+      reservations.each { |record| service.add_host(record.subnet_address, record) }
+      leases = libvirt_network.dhcp_leases
+      leases.each do |element|
+        lease = Proxy::DHCP::Lease.new(
+          :subnet => subnet,
+          :ip => element['ipaddr'],
+          :mac => element['mac'],
+          :starts => Time.now.utc,
+          :ends => Time.at(element['expirytime'] || 0).utc,
+          :state => 'active'
+        )
+        service.add_lease(lease.subnet_address, lease)
+      end
+    end
+  end
+end

--- a/modules/libvirt_common/libvirt_network.rb
+++ b/modules/libvirt_common/libvirt_network.rb
@@ -14,7 +14,6 @@ module Proxy
 
     def connection
       @connection ||= ::Libvirt::open(@url)
-      @connection
     end
 
     def dump_xml
@@ -25,10 +24,10 @@ module Proxy
       connection.lookup_network_by_name(@network)
     end
 
-    def network_update command, section, xml
+    def network_update(command, section, xml, index = -1)
       flags = ::Libvirt::Network::NETWORK_UPDATE_AFFECT_LIVE | ::Libvirt::Network::NETWORK_UPDATE_AFFECT_CONFIG
       logger.debug "Libvirt update: #{xml}"
-      find_network.update command, section, -1, xml, flags
+      find_network.update command, section, index, xml, flags
     rescue ::Libvirt::Error => e
       logger.error "Error calling libvirt update: #{e}"
       logger.debug xml


### PR DESCRIPTION
Initial attempt for DHCPv6 on proxy.

TODO:
- [x] Only one Libvirt network supported - check if it is v4 or v6 before suggesting ip
- [ ] Ad file observers for libvirt
- [ ] Check for reserved v6 ips (multicast)
- [ ] ISC
- [ ] native MS
- [ ] tests
