### PR TITLE
Fixes #15864 - Pxelinux alias variant for Syslinux

### DIFF
--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -74,6 +74,7 @@ module Proxy::TFTP
       ["#{pxeconfig_dir}/01-"+mac.gsub(/:/,"-").downcase]
     end
   end
+  class Pxelinux < Syslinux; end
 
   class Pxegrub < Server
     def pxeconfig_dir

--- a/modules/tftp/tftp_api.rb
+++ b/modules/tftp/tftp_api.rb
@@ -8,7 +8,7 @@ module Proxy::TFTP
     helpers ::Proxy::Helpers
     authorize_with_trusted_hosts
     authorize_with_ssl_client
-    VARIANTS = ["Syslinux", "Pxegrub", "Pxegrub2", "Ztp", "Poap"].freeze
+    VARIANTS = ["Syslinux", "Pxelinux", "Pxegrub", "Pxegrub2", "Ztp", "Poap"].freeze
 
     helpers do
       def instantiate variant, mac=nil

--- a/test/tftp/tftp_api_test.rb
+++ b/test/tftp/tftp_api_test.rb
@@ -25,6 +25,11 @@ class TftpApiTest < Test::Unit::TestCase
     assert_equal "Proxy::TFTP::Syslinux", obj.class.name
   end
 
+  def test_instantiate_pxelinux
+    obj = app.helpers.instantiate "pxelinux", "AA:BB:CC:DD:EE:FF"
+    assert_equal "Proxy::TFTP::Pxelinux", obj.class.name
+  end
+
   def test_instantiate_pxegrub
     obj = app.helpers.instantiate "pxegrub", "AA:BB:CC:DD:EE:FF"
     assert_equal "Proxy::TFTP::Pxegrub", obj.class.name


### PR DESCRIPTION
We are removing template variant attribute from OS in Foreman Core and template
kind will define what to pass to Proxy. Since Syslinux variant is implemented
as PXELinux kind and PXELinux = SYSLinux (it's the same just different name), I
will submit a patch to accept both.

I will attach a Core PR to this for further details.
