### PR TITLE
Fixes #15944 - Make it obvious that messages come from DHCP

### DIFF
--- a/modules/dhcp/dhcp_api.rb
+++ b/modules/dhcp/dhcp_api.rb
@@ -70,7 +70,7 @@ class Proxy::DhcpApi < ::Sinatra::Base
       load_subnet_data
 
       record = server.find_record(@subnet.network, params[:record])
-      log_halt 404, "Record #{params[:network]}/#{params[:record]} not found" unless record
+      log_halt 404, "DHCP record #{params[:network]}/#{params[:record]} not found" unless record
       record.options.to_json
     rescue => e
       log_halt 400, e
@@ -102,10 +102,10 @@ class Proxy::DhcpApi < ::Sinatra::Base
       load_subnet_data
 
       record = server.find_record(@subnet.network, params[:record])
-      log_halt 404, "Record #{params[:network]}/#{params[:record]} not found" unless record
+      log_halt 404, "DHCP record #{params[:network]}/#{params[:record]} not found" unless record
       server.del_record @subnet, record
     rescue Proxy::DHCP::InvalidRecord
-      log_halt 404, "Record #{params[:network]}/#{params[:record]} not found"
+      log_halt 404, "DHCP record #{params[:network]}/#{params[:record]} not found"
     rescue Exception => e
       log_halt 400, e
     end

--- a/modules/dhcp_common/server.rb
+++ b/modules/dhcp_common/server.rb
@@ -80,7 +80,7 @@ module Proxy::DHCP
           service.find_lease_by_mac(subnet.network, mac_address)
 
       if r && subnet.valid_range(:from => from_address, :to => to_address).include?(r.ip)
-        logger.debug "Found an existing dhcp record #{r}, reusing..."
+        logger.debug "Found an existing DHCP record #{r}, reusing..."
         return r.ip
       end
     end
@@ -121,10 +121,10 @@ module Proxy::DHCP
           logger.debug "We already got the same DHCP record - skipping"
           raise Proxy::DHCP::AlreadyExists
         else
-          logger.warn "Request to create a conflicting record"
+          logger.warn "Request to create a conflicting DHCP record"
           logger.debug "request: #{options.inspect}"
           logger.debug "local:   #{record.options.inspect}"
-          raise Proxy::DHCP::Collision, "Record #{net}/#{ip} already exists"
+          raise Proxy::DHCP::Collision, "DHCP record #{net}/#{ip} already exists"
         end
       end
 


### PR DESCRIPTION
The occasional log reader might not know if this referts to a DNS or
DHCP 'record'.
