### PR TITLE
refs #16021 - monitor modifications on entire directory

### DIFF
--- a/modules/dhcp_isc/inotify_leases_file_observer.rb
+++ b/modules/dhcp_isc/inotify_leases_file_observer.rb
@@ -13,14 +13,18 @@ module ::Proxy::DHCP::ISC
 
     def monitor_leases
       @notifier = INotify::Notifier.new
-      @notifier.watch(leases_filename, :modify) do |event|
-        logger.debug "caught :modify event on #{event.absolute_name}"
-        observer.leases_modified
-      end
-      @notifier.watch(File.dirname(leases_filename), :moved_to) do |event|
+      @notifier.watch(File.dirname(leases_filename), :modify, :moved_to) do |event|
         if event.absolute_name == leases_filename
-          logger.debug "caught :moved_to event on #{event.absolute_name}"
-          observer.leases_recreated
+          event.flags.each do |flag|
+            case flag
+            when :modify
+              logger.debug "caught :modify event on #{event.absolute_name}."
+              observer.leases_modified
+            when :moved_to
+              logger.debug "caught :moved_to event on #{event.absolute_name}."
+              observer.leases_recreated
+            end
+          end
         end
       end
 


### PR DESCRIPTION
inotify file watches are based on the inode, so after the leases file
is recreated the watch no longer fires. Later versions of rb-inotify
will properly allow for the watch to be re-registered after the file is
recreated (issue #16140).
