### PR TITLE
fixes #16395 - add api that returns puppet version

### DIFF
--- a/modules/puppet_proxy/puppet_api.rb
+++ b/modules/puppet_proxy/puppet_api.rb
@@ -9,6 +9,11 @@ class Proxy::Puppet::Api < ::Sinatra::Base
   inject_attr :environment_retriever_impl, :environment_retriever
   inject_attr :puppet_runner_impl, :puppet_runner
 
+  get "/" do
+    content_type :json
+    {:version => Proxy::Puppet::Plugin.settings.puppet_version}.to_json
+  end
+
   post "/run" do
     begin
       log_halt 400, "Failed puppet run: No nodes defined" unless params[:nodes]

--- a/test/puppet/puppet_api_test.rb
+++ b/test/puppet/puppet_api_test.rb
@@ -84,6 +84,12 @@ class PuppetApiTest < Test::Unit::TestCase
     app
   end
 
+  def test_gets_puppet_index
+    get "/"
+    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
+    assert_equal '4.6.1', JSON.parse(last_response.body)['version']
+  end
+
   def test_gets_puppet_environments
     get "/environments"
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"


### PR DESCRIPTION
Katello needs to know which version of puppet's installed so we can put things in the right places when pulp publishes a puppet module. This adds an api call on / that returns as a hash with some info, at the moment that's just the version. 

This could also be used in just plain foreman by showing it on the foreman proxy puppet tab.
