### PR TITLE
Fixes #15095 - introduced support for puppet environment classes api

### DIFF
--- a/bundler.d/puppet.rb
+++ b/bundler.d/puppet.rb
@@ -3,3 +3,7 @@ group :puppet_proxy_legacy do
   gem 'puppet', '< 5.0.0'
   gem 'ruby-augeas', :require => 'augeas'
 end
+
+group :puppet_proxy_puppet_api do
+  gem 'concurrent-ruby', '~> 1.0'
+end

--- a/modules/puppet_proxy/puppet_api.rb
+++ b/modules/puppet_proxy/puppet_api.rb
@@ -45,6 +45,23 @@ class Proxy::Puppet::Api < ::Sinatra::Base
       class_retriever.classes_in_environment(params[:environment]).map{|k| {k.to_s => { :name => k.name, :module => k.module, :params => k.params} } }.to_json
     rescue Proxy::Puppet::EnvironmentNotFound
       log_halt 404, "Could not find environment '#{params[:environment]}'"
+    rescue Proxy::Puppet::TimeoutError => e
+      log_halt 503, e.message
+    rescue Exception => e
+      log_halt 406, "Failed to show puppet classes: #{e}"
+    end
+  end
+
+  get "/environments/:environment/classes_and_errors" do
+    content_type :json
+    begin
+      class_retriever.classes_and_errors_in_environment(params[:environment]).to_json
+    rescue NoMethodError
+      log_halt 501, "classes_and_errors api end-point is not available for '#{class_retriever.class}' provider"
+    rescue Proxy::Puppet::EnvironmentNotFound
+      log_halt 404, "Could not find environment '#{params[:environment]}'"
+    rescue Proxy::Puppet::TimeoutError => e
+      log_halt 503, e.message
     rescue Exception => e
       log_halt 406, "Failed to show puppet classes: #{e}"
     end

--- a/modules/puppet_proxy_common/api_request.rb
+++ b/modules/puppet_proxy_common/api_request.rb
@@ -13,11 +13,12 @@ module Proxy::Puppet
       @ssl_key = ssl_key
     end
 
-    def send_request(path)
-      uri              = URI.parse(url)
-      http             = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl     = uri.scheme == 'https'
+    def send_request(path, timeout = 60, additional_headers = {})
+      uri = URI.parse(url)
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = uri.scheme == 'https'
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.read_timeout = timeout
 
       if http.use_ssl?
         if ssl_ca && !ssl_ca.to_s.empty?
@@ -34,6 +35,7 @@ module Proxy::Puppet
       path = [uri.path.chomp("/"), path.start_with?("/") ? path.slice(1..-1) : path].join('/')
       req = Net::HTTP::Get.new(path)
       req.add_field('Accept', 'application/json')
+      additional_headers.each_key {|k| req[k] = additional_headers[k]}
       http.request(req)
     end
 

--- a/modules/puppet_proxy_common/errors.rb
+++ b/modules/puppet_proxy_common/errors.rb
@@ -1,4 +1,5 @@
 module Proxy::Puppet
   class EnvironmentNotFound < StandardError; end
   class DataError < StandardError; end
+  class TimeoutError < StandardError; end
 end

--- a/modules/puppet_proxy_puppet_api/plugin_configuration.rb
+++ b/modules/puppet_proxy_puppet_api/plugin_configuration.rb
@@ -16,15 +16,33 @@ module ::Proxy::PuppetApi
       require 'puppet_proxy_puppet_api/v3_api_request'
       require 'puppet_proxy_puppet_api/v3_environments_retriever'
       require 'puppet_proxy_puppet_api/v3_classes_retriever'
+      require 'puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever'
     end
 
     def load_dependency_injection_wirings(container_instance, settings)
       container_instance.dependency :environment_retriever_impl,
                                     lambda {::Proxy::PuppetApi::V3EnvironmentsRetriever.new(settings[:puppet_url], settings[:puppet_ssl_ca], settings[:puppet_ssl_cert], settings[:puppet_ssl_key])}
 
-      container_instance.dependency :class_retriever_impl,
-                                    lambda {::Proxy::PuppetApi::V3ClassesRetriever.new(settings[:puppet_url], settings[:puppet_ssl_ca], settings[:puppet_ssl_cert], settings[:puppet_ssl_key])}
-
+      if settings[:puppet_version].to_s < "4.4"
+        container_instance.dependency :class_retriever_impl,
+                                      lambda {::Proxy::PuppetApi::V3ClassesRetriever.new(settings[:puppet_url], settings[:puppet_ssl_ca], settings[:puppet_ssl_cert], settings[:puppet_ssl_key])}
+        container_instance.dependency :class_cache_initializer, lambda {Proxy::PuppetApi::NoopClassesCacheInitializer.new}
+      else
+        container_instance.singleton_dependency :class_retriever_impl,
+                                                (lambda do
+                                                  ::Proxy::PuppetApi::V3EnvironmentClassesApiClassesRetriever.new(
+                                                    settings[:puppet_url],
+                                                    settings[:puppet_ssl_ca],
+                                                    settings[:puppet_ssl_cert],
+                                                    settings[:puppet_ssl_key])
+                                                end)
+        container_instance.dependency :class_cache_initializer,
+                                      (lambda do
+                                        Proxy::PuppetApi::EnvironmentClassesCacheInitializer.new(
+                                          container_instance.get_dependency(:class_retriever_impl),
+                                          container_instance.get_dependency(:environment_retriever_impl))
+                                      end)
+      end
     end
   end
 end

--- a/modules/puppet_proxy_puppet_api/puppet_proxy_puppet_api_plugin.rb
+++ b/modules/puppet_proxy_puppet_api/puppet_proxy_puppet_api_plugin.rb
@@ -11,5 +11,7 @@ module Proxy::PuppetApi
 
     validate :puppet_url, :url => true
     validate_readable :puppet_ssl_ca, :puppet_ssl_cert, :puppet_ssl_key
+
+    start_services :class_cache_initializer
   end
 end

--- a/modules/puppet_proxy_puppet_api/v3_api_request.rb
+++ b/modules/puppet_proxy_puppet_api/v3_api_request.rb
@@ -13,4 +13,17 @@ module Proxy::PuppetApi
       response.code == '404' ? [] : handle_response(response) # resource api responds with a 404 if filter returns no results
     end
   end
+
+  class EnvironmentClassesApiv3 < ::Proxy::Puppet::ApiRequest
+    NOT_MODIFIED = Object.new
+
+    def list_classes(environment, etag, timeout)
+      response = send_request("puppet/v3/environment_classes?environment=#{environment}", timeout, "If-None-Match" => etag)
+
+      return [NOT_MODIFIED, response['Etag']] if response.code == '304'
+      return [JSON.load(response.body), response['Etag']] if response.is_a? Net::HTTPOK
+      raise ::Proxy::Puppet::EnvironmentNotFound, "Could not find environment '#{environment}'" if response.code == '404'
+      raise ::Proxy::Error::HttpError.new(response.code, response.body)
+    end
+  end
 end

--- a/modules/puppet_proxy_puppet_api/v3_classes_retriever.rb
+++ b/modules/puppet_proxy_puppet_api/v3_classes_retriever.rb
@@ -26,3 +26,10 @@ class Proxy::PuppetApi::V3ClassesRetriever
     raise e
   end
 end
+
+# A dummy noop service
+class Proxy::PuppetApi::NoopClassesCacheInitializer
+  def start_service
+    # nothing to do, we don't cache classes in this implementation
+  end
+end

--- a/modules/puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever.rb
+++ b/modules/puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever.rb
@@ -1,0 +1,122 @@
+require 'concurrent'
+
+class Proxy::PuppetApi::V3EnvironmentClassesApiClassesRetriever
+  include ::Proxy::Log
+
+  MAX_CLIENT_TIMEOUT = 15
+  MAX_PUPPETAPI_TIMEOUT = 300
+
+  attr_reader :puppet_url, :ssl_ca, :ssl_cert, :ssl_key
+
+  def initialize(puppet_url, puppet_ssl_ca, puppet_ssl_cert, puppet_ssl_key, api = nil)
+    @etag_cache = {}
+    @classes_cache = {}
+    @futures_cache = {}
+    @ssl_ca = puppet_ssl_ca
+    @ssl_cert = puppet_ssl_cert
+    @ssl_key = puppet_ssl_key
+    @puppet_url = puppet_url
+    @m = Monitor.new
+    @puppet_api = api || Proxy::PuppetApi::EnvironmentClassesApiv3
+  end
+
+  def classes_in_environment(environment)
+    legacy_classes_format(get_classes(environment))
+  end
+
+  def classes_and_errors_in_environment(environment)
+    classes_and_errors(get_classes(environment))
+  end
+
+  def classes_and_errors(response)
+    response['files'].map do |current|
+      classes = (current['classes'] || []).map do |clazz|
+        parameters = clazz['params'].map do |parameter|
+          if parameter['default_source'].is_a?(String) && parameter['default_source'].start_with?('$')
+            to_return = parameter.dup
+            to_return['default_source'] = "${#{parameter['default_source'].slice(1..-1)}}"
+            to_return
+          else
+            parameter
+          end
+        end
+        {'name' => clazz['name'], 'params' => parameters}
+      end
+      current.has_key?('error') ? current : {'path' => current['path'], 'classes' => classes}
+    end
+  end
+
+  def legacy_classes_format(response)
+    response['files'].map do |current|
+      (current['classes'] || []).map do |manifest| # current['classes'] is nil for 'error' entities
+        parameters = manifest['params'].inject({}) do |all, parameter|
+          parameter_value = parameter['default_literal'] || parameter['default_source']
+          all[parameter['name']] = (parameter_value.is_a?(String) && parameter_value.start_with?('$')) ? "${#{parameter_value.slice(1..-1)}}" : parameter_value
+          all
+        end
+        ::Proxy::Puppet::PuppetClass.new(manifest['name'], parameters)
+      end
+    end.flatten
+  end
+
+  def get_classes(environment)
+    future = async_get_classes(environment)
+    future.value!(MAX_CLIENT_TIMEOUT)
+
+    raise ::Proxy::Puppet::TimeoutError, "Puppet is taking too long to respond, please try again later." if future.pending?
+    future.value
+  end
+
+  def async_get_classes(environment)
+    etag, classes, existing_future = @m.synchronize { [@etag_cache[environment], @classes_cache[environment], @futures_cache[environment]] }
+    return existing_future unless existing_future.nil?
+
+    future = Concurrent::Promise.new do
+      begin
+        response, etag = @puppet_api.new(puppet_url, ssl_ca, ssl_cert, ssl_key).list_classes(environment, etag, MAX_PUPPETAPI_TIMEOUT)
+      rescue Exception => e
+        @m.synchronize { @futures_cache[environment] = nil }
+        logger.error("Error while retrieving puppet classes for '%s' environment" % [environment], e)
+        raise e
+      end
+
+      if response == Proxy::PuppetApi::EnvironmentClassesApiv3::NOT_MODIFIED
+        @m.synchronize { @futures_cache[environment] = nil }
+        classes
+      else
+        @m.synchronize do
+          @futures_cache[environment] = nil
+          @etag_cache[environment] = etag
+          @classes_cache[environment] = response
+        end
+      end
+    end
+    @m.synchronize { @futures_cache[environment] = future }
+
+    future.execute
+  end
+end
+
+class Proxy::PuppetApi::EnvironmentClassesCacheInitializer
+  include ::Proxy::Log
+
+  def initialize(classes_retriever, environments_retriever)
+    @environments = environments_retriever
+    @classes = classes_retriever
+  end
+
+  def start
+    logger.info("Started puppet class cache initialization")
+    Concurrent::Promise.new { @environments.all }
+                       .then do |environments|
+                         environments.map(&:name).map do |environment|
+                           logger.debug("Initializing puppet class cache for '#{environment}' environment")
+                           @classes.async_get_classes(environment)
+                         end
+                       end
+                       .flat_map { |futures| Concurrent::Promise.all?(*futures) }
+                       .then { logger.info("Finished puppet class cache initialization") }
+                       .on_error { logger.error("Failed to initialize puppet class cache, will use lazy initialization instead") }
+                       .execute
+  end
+end

--- a/test/puppet/puppet_api_configuration_test.rb
+++ b/test/puppet/puppet_api_configuration_test.rb
@@ -51,9 +51,25 @@ class PuppetApiDIWiringsTest < Test::Unit::TestCase
                                                      :puppet_url => "http://puppet.url",
                                                      :puppet_ssl_ca => "path_to_ca_cert",
                                                      :puppet_ssl_cert => "path_to_ssl_cert",
-                                                     :puppet_ssl_key => "path_to_ssl_key")
+                                                     :puppet_ssl_key => "path_to_ssl_key",
+                                                     :puppet_version => "4.2")
 
     assert @container.get_dependency(:class_retriever_impl).instance_of?(::Proxy::PuppetApi::V3ClassesRetriever)
+    assert_equal "http://puppet.url", @container.get_dependency(:class_retriever_impl).puppet_url
+    assert_equal "path_to_ca_cert", @container.get_dependency(:class_retriever_impl).ssl_ca
+    assert_equal "path_to_ssl_cert", @container.get_dependency(:class_retriever_impl).ssl_cert
+    assert_equal "path_to_ssl_key", @container.get_dependency(:class_retriever_impl).ssl_key
+  end
+
+  def test_environment_classes_retriever_wiring_parameters
+    @configuration.load_dependency_injection_wirings(@container,
+                                                     :puppet_url => "http://puppet.url",
+                                                     :puppet_ssl_ca => "path_to_ca_cert",
+                                                     :puppet_ssl_cert => "path_to_ssl_cert",
+                                                     :puppet_ssl_key => "path_to_ssl_key",
+                                                     :puppet_version => "4.4")
+
+    assert @container.get_dependency(:class_retriever_impl).instance_of?(::Proxy::PuppetApi::V3EnvironmentClassesApiClassesRetriever)
     assert_equal "http://puppet.url", @container.get_dependency(:class_retriever_impl).puppet_url
     assert_equal "path_to_ca_cert", @container.get_dependency(:class_retriever_impl).ssl_ca
     assert_equal "path_to_ssl_cert", @container.get_dependency(:class_retriever_impl).ssl_cert

--- a/test/puppet/puppet_api_v3_environment_classes_retriever_test.rb
+++ b/test/puppet/puppet_api_v3_environment_classes_retriever_test.rb
@@ -1,0 +1,202 @@
+require 'test_helper'
+require 'puppet_proxy_common/api_request'
+require 'puppet_proxy_puppet_api/v3_api_request'
+require 'puppet_proxy_common/errors'
+require 'puppet_proxy_common/puppet_class'
+
+module PuppetApiv3EnvironmentClassesApiRetrieverTests
+  def setup
+    @api = Proxy::PuppetApi::EnvironmentClassesApiv3
+    @retriever = Proxy::PuppetApi::V3EnvironmentClassesApiClassesRetriever.new(nil, nil, nil, nil, @api)
+  end
+
+  def test_uses_puppet_environment_classes_api
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).
+      with('test_environment', nil, EnvironmentClassesApiRetrieverForTesting::MAX_PUPPETAPI_TIMEOUT).
+      returns('files' => [])
+    EnvironmentClassesApiRetrieverForTesting.new(nil, nil, nil, nil).get_classes('test_environment')
+  end
+
+  def test_passes_cached_etag_value_to_puppetapi
+    etag_value = 42
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).
+      with('test_environment', etag_value, EnvironmentClassesApiRetrieverForTesting::MAX_PUPPETAPI_TIMEOUT).
+      returns([{'files' => []}, etag_value + 1])
+    retriever = EnvironmentClassesApiRetrieverForTesting.new(nil, nil, nil, nil)
+    retriever.etag_cache['test_environment'] = etag_value
+    retriever.get_classes('test_environment')
+  end
+
+  def test_returns_cached_classes_if_puppet_responds_with_not_modified
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).returns([Proxy::PuppetApi::EnvironmentClassesApiv3::NOT_MODIFIED, 42])
+    expected_classes =<<EOL
+{
+  "files": [
+    {
+      "classes": [{"name": "dns::config", "params": []}],
+      "path": "/etc/puppetlabs/code/environments/home/modules/dns/manifests/config.pp"
+    }],
+  "name": "test_environment"
+}
+EOL
+    retriever = EnvironmentClassesApiRetrieverForTesting.new(nil, nil, nil, nil)
+    retriever.classes_cache['test_environment'] = JSON.parse(expected_classes)
+    assert_equal JSON.parse(expected_classes), retriever.get_classes('test_environment')
+  end
+
+  def test_reuses_future_for_concurrent_environment_classes_retrievals
+    fake_future = Object.new
+    retriever = EnvironmentClassesApiRetrieverForTesting.new(nil, nil, nil, nil)
+    retriever.futures_cache['test_environment'] = fake_future
+    assert_equal fake_future, retriever.async_get_classes('test_environment')
+  end
+
+  def test_clears_futures_cache
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).returns([{'files' => []}, 42])
+    retriever = EnvironmentClassesApiRetrieverForTesting.new(nil, nil, nil, nil)
+    retriever.get_classes('test_environment')
+    assert_nil retriever.futures_cache['test_environment']
+  end
+
+  def test_clears_futures_cache_if_puppet_responds_with_not_modified
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).returns([Proxy::PuppetApi::EnvironmentClassesApiv3::NOT_MODIFIED, 42])
+    retriever = EnvironmentClassesApiRetrieverForTesting.new(nil, nil, nil, nil)
+    retriever.get_classes('test_environment')
+    assert_nil retriever.futures_cache['test_environment']
+  end
+
+  def test_clears_futures_cache_if_call_to_puppet_raises_an_exception
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).raises(StandardError)
+    retriever = EnvironmentClassesApiRetrieverForTesting.new(nil, nil, nil, nil)
+    assert retriever.async_get_classes('test_environment').wait(1).rejected?
+    assert_nil retriever.futures_cache['test_environment']
+  end
+
+  def test_raises_timeouterror_if_puppet_takes_too_long_to_respond
+    fake_future = Object.new
+    fake_future.expects(:value!).returns(nil)
+    fake_future.expects(:pending?).returns(true)
+
+    @retriever.stubs(:async_get_classes).returns(fake_future)
+
+    assert_raises(::Proxy::Puppet::TimeoutError) { @retriever.get_classes('test_environment') }
+  end
+end
+
+module PuppetApiv3EnvironmentClassesApiParsingTests
+  def setup
+    @retriever = Proxy::PuppetApi::V3EnvironmentClassesApiClassesRetriever.new(nil, nil, nil, nil)
+  end
+
+  ENVIRONMENT_CLASSES_RESPONSE =<<EOL
+{
+  "files": [
+    {
+      "classes": [{"name": "dns::config", "params": []}],
+      "path": "/manifests/config.pp"
+    },
+    {
+      "classes": [{"name": "dns::install", "params": []}],
+      "path": "/manifests/install.pp"
+    },
+    {
+      "error": "Syntax error at '=>' at /manifests/witherror.pp:20:19",
+      "path": "/manifests/witherror.pp"
+    }],
+  "name": "test_environment"
+}
+EOL
+  def test_legacy_parser_with_environment_classes_response
+    expected_classes = [Proxy::Puppet::PuppetClass.new("dns::config", {}), Proxy::Puppet::PuppetClass.new("dns::install", {})]
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).returns([JSON.load(ENVIRONMENT_CLASSES_RESPONSE), 42])
+    assert_equal expected_classes, @retriever.classes_in_environment('test_environment')
+  end
+
+  def test_parser_with_environment_classes_response
+    expected_reponse = [
+      {"classes" => [{"name" => "dns::config", "params" => []}], "path" => "/manifests/config.pp"},
+      { "classes" => [{"name" => "dns::install", "params" => []}], "path" => "/manifests/install.pp"},
+      {"error" => "Syntax error at '=>' at /manifests/witherror.pp:20:19", "path" => "/manifests/witherror.pp"}]
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).returns([JSON.load(ENVIRONMENT_CLASSES_RESPONSE), 42])
+    assert_equal expected_reponse, @retriever.classes_and_errors_in_environment('test_environment')
+  end
+
+  ENVIRONMENT_CLASSES_RESPONSE_WITH_EXPRESSION_PARAMETERS =<<EOL
+{
+  "files": [{"classes": [{"name": "dns",
+                          "params": [
+                                      {"default_source": "$::dns::params::namedconf_path", "name": "namedconf_path"},
+                                      {"default_source": "$::dns::params::dnsdir", "name": "dnsdir"}
+                                    ]}],
+             "path": "/manifests/init.pp"
+           }],
+  "name": "test_environment"
+}
+EOL
+  def test_legacy_parser_with_environment_classes_response_with_variable_expression_parameteres
+    expected_classes = [Proxy::Puppet::PuppetClass.new("dns", 'namedconf_path' => '${::dns::params::namedconf_path}', 'dnsdir' => '${::dns::params::dnsdir}')]
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).returns([JSON.load(ENVIRONMENT_CLASSES_RESPONSE_WITH_EXPRESSION_PARAMETERS), 42])
+    assert_equal expected_classes, @retriever.classes_in_environment('test_environment')
+  end
+
+  def test_parser_with_environment_classes_response_with_variable_expression_parameteres
+    expected_response = [
+      {"classes" => [{"name" => "dns", "params" => [
+        {"default_source" => "${::dns::params::namedconf_path}", "name" => "namedconf_path"},
+        {"default_source" => "${::dns::params::dnsdir}", "name" => "dnsdir"}]}], "path" => "/manifests/init.pp"}]
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).returns([JSON.load(ENVIRONMENT_CLASSES_RESPONSE_WITH_EXPRESSION_PARAMETERS), 42])
+    assert_equal expected_response, @retriever.classes_and_errors_in_environment('test_environment')
+  end
+
+  ENVIRONMENT_CLASSES_RESPONSE_WITH_DEFAULT_LITERALS =<<EOL
+{
+  "files": [{"classes": [{"name": "testing",
+                          "params": [
+                                      {"default_literal": "literal default", "default_source": "literal default", "name": "string_with_literal_default", "type": "String"},
+                                      {
+                                        "default_literal": {
+                                          "one": "foo",
+                                          "two": "hello"
+                                        },
+                                       "default_source": "{'one' => 'foo', 'two' => 'hello'}",
+                                        "name": "a_hash",
+                                        "type": "Hash"
+                                      }
+                          ]}],
+             "path": "init.pp"
+           }],
+  "name": "test_environment"
+}
+EOL
+  def test_legacy_parser_with_puppet_environment_classes_response_with_default_literals
+    expected_classes = [Proxy::Puppet::PuppetClass.new("testing", 'string_with_literal_default' => 'literal default', 'a_hash' => {'one' => 'foo', 'two' => 'hello'})]
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).returns([JSON.load(ENVIRONMENT_CLASSES_RESPONSE_WITH_DEFAULT_LITERALS), 42])
+    assert_equal expected_classes, @retriever.classes_in_environment('test_environment')
+  end
+
+  def test_parser_with_puppet_environment_classes_response_with_default_literals
+    expected_response = [
+      {"classes" => [{"name" => "testing", "params" => [
+        {"default_literal" => "literal default", "default_source" => "literal default", "name" => "string_with_literal_default", "type" => "String"},
+        {
+          "default_literal" => {"one" => "foo", "two" => "hello"},
+          "default_source" => "{'one' => 'foo', 'two' => 'hello'}",
+          "name" => "a_hash",
+          "type" => "Hash"}]}], "path" => "init.pp"}]
+
+    Proxy::PuppetApi::EnvironmentClassesApiv3.any_instance.expects(:list_classes).returns([JSON.load(ENVIRONMENT_CLASSES_RESPONSE_WITH_DEFAULT_LITERALS), 42])
+    assert_equal expected_response, @retriever.classes_and_errors_in_environment('test_environment')
+  end
+end
+
+if RUBY_VERSION > "1.8.7"
+  require 'puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever'
+  class EnvironmentClassesApiRetrieverForTesting < Proxy::PuppetApi::V3EnvironmentClassesApiClassesRetriever
+    attr_accessor :etag_cache, :classes_cache, :futures_cache
+  end
+
+  class PuppetApiv3EnvironmentClassesApiRetrieverTest < Test::Unit::TestCase
+    include PuppetApiv3EnvironmentClassesApiRetrieverTests
+    include PuppetApiv3EnvironmentClassesApiParsingTests
+  end
+end


### PR DESCRIPTION
- Ruby 1.8.7 is NOT supported.
  - This will attempt to cache puppet classes and rely on etag for cache validation. Enable puppet's environment class cache for this feature to have effect.
  - It will return a timeout error to the client if puppet doesn't respond within 15 seconds. The module will wait for 5 minutes to update the classes cache before timing out however.
