### PR TITLE
Fixes #17003 - DNS Plugins now support rewriting of PTR records

### DIFF
--- a/config/settings.d/dns_dnscmd.yml.example
+++ b/config/settings.d/dns_dnscmd.yml.example
@@ -5,3 +5,7 @@
 
 # use this setting if you are managing a dns server which is not localhost though this proxy
 #:dns_server: dns.domain.com
+# use this setting if you have classless reverse delegation as described in rfc2317
+#:dns_ptr_rewritemap:
+#   '2\.0\.192\.in-addr\.arpa$': '2.0.192.in-addr.yourdomain.tld'
+#   '100\.51\.198\.in-addr\.arpa$': '128/25.\1'

--- a/config/settings.d/dns_nsupdate.yml.example
+++ b/config/settings.d/dns_nsupdate.yml.example
@@ -6,3 +6,7 @@
 #:dns_key: /etc/rndc.key
 # use this setting if you are managing a dns server which is not localhost though this proxy
 #:dns_server: dns.domain.com
+# use this setting if you have classless reverse delegation as described in rfc2317
+#:dns_ptr_rewritemap:
+#   '2\.0\.192\.in-addr\.arpa$': '2.0.192.in-addr.yourdomain.tld'
+#   '100\.51\.198\.in-addr\.arpa$': '128/25.\1'

--- a/config/settings.d/dns_nsupdate_gss.yml.example
+++ b/config/settings.d/dns_nsupdate_gss.yml.example
@@ -9,3 +9,7 @@
 # Secure Dynamic Updates, or BIND as used in FreeIPA.  Set dns_provider to nsupdate_gss.
 #:dns_tsig_keytab: /usr/share/foreman-proxy/dns.keytab
 #:dns_tsig_principal: DNS/host.example.com@EXAMPLE.COM
+# use this setting if you have classless reverse delegation as described in rfc2317
+#:dns_ptr_rewritemap:
+#   '2\.0\.192\.in-addr\.arpa$': '2.0.192.in-addr.yourdomain.tld'
+#   '100\.51\.198\.in-addr\.arpa$': '128/25.\1'

--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -5,8 +5,8 @@ module Proxy::Dns::Dnscmd
     include Proxy::Log
     include Proxy::Util
 
-    def initialize(a_server, a_ttl)
-      super(a_server, a_ttl)
+    def initialize(a_server, a_ttl, a_rewritemap)
+      super(a_server, a_ttl, a_rewritemap)
     end
 
     def create_a_record(fqdn, ip)
@@ -61,6 +61,7 @@ module Proxy::Dns::Dnscmd
         when 0
           return nil
         else
+          ptr = rewrite_ptr(ptr)
           zone = match_zone(ptr, enum_zones)
           msg = "Added PTR entry #{ptr} => #{fqdn}"
           cmd = "/RecordAdd #{zone} #{ptr}. PTR #{fqdn}."
@@ -97,7 +98,7 @@ module Proxy::Dns::Dnscmd
     end
 
     def remove_ptr_record(ptr)
-      remove_record(ptr, 'PTR')
+      remove_record(rewrite_ptr(ptr), 'PTR')
     end
 
     def execute cmd, msg=nil, error_only=false

--- a/modules/dns_dnscmd/plugin_configuration.rb
+++ b/modules/dns_dnscmd/plugin_configuration.rb
@@ -6,7 +6,7 @@ module ::Proxy::Dns::Dnscmd
     end
 
     def load_dependency_injection_wirings(container_instance, settings)
-      container_instance.dependency :dns_provider, lambda {::Proxy::Dns::Dnscmd::Record.new(settings[:dns_server], settings[:dns_ttl]) }
+      container_instance.dependency :dns_provider, lambda {::Proxy::Dns::Dnscmd::Record.new(settings[:dns_server], settings[:dns_ttl], settings[:dns_ptr_rewritemap]) }
     end
   end
 end

--- a/modules/dns_nsupdate/dns_nsupdate_gss_main.rb
+++ b/modules/dns_nsupdate/dns_nsupdate_gss_main.rb
@@ -6,10 +6,10 @@ module Proxy::Dns::NsupdateGSS
     include Proxy::Kerberos
     attr_reader :tsig_keytab, :tsig_principal
 
-    def initialize(a_server, a_ttl, tsig_keytab, tsig_principal)
+    def initialize(a_server, a_ttl, a_rewritemap, tsig_keytab, tsig_principal)
       @tsig_keytab = tsig_keytab
       @tsig_principal = tsig_principal
-      super(a_server, a_ttl, nil)
+      super(a_server, a_ttl, a_rewritemap, nil)
     end
 
     def nsupdate_args

--- a/modules/dns_nsupdate/nsupdate_configuration.rb
+++ b/modules/dns_nsupdate/nsupdate_configuration.rb
@@ -6,7 +6,7 @@ module ::Proxy::Dns::Nsupdate
     end
 
     def load_dependency_injection_wirings(container_instance, settings)
-      container_instance.dependency :dns_provider, lambda {::Proxy::Dns::Nsupdate::Record.new(settings[:dns_server], settings[:dns_ttl], settings[:dns_key]) }
+      container_instance.dependency :dns_provider, lambda {::Proxy::Dns::Nsupdate::Record.new(settings[:dns_server], settings[:dns_ttl], settings[:dns_ptr_rewritemap], settings[:dns_key]) }
     end
   end
 end

--- a/modules/dns_nsupdate/nsupdate_gss_configuration.rb
+++ b/modules/dns_nsupdate/nsupdate_gss_configuration.rb
@@ -7,7 +7,7 @@ module ::Proxy::Dns::NsupdateGSS
 
     def load_dependency_injection_wirings(container_instance, settings)
       container_instance.dependency :dns_provider,
-                                    lambda { ::Proxy::Dns::NsupdateGSS::Record.new(settings[:dns_server], settings[:dns_ttl], settings[:dns_tsig_keytab], settings[:dns_tsig_principal]) }
+                                    lambda { ::Proxy::Dns::NsupdateGSS::Record.new(settings[:dns_server], settings[:dns_ttl], settings[:dns_ptr_rewritemap], settings[:dns_tsig_keytab], settings[:dns_tsig_principal]) }
     end
   end
 end

--- a/test/dns_dnscmd/dnscmd_config_test.rb
+++ b/test/dns_dnscmd/dnscmd_config_test.rb
@@ -16,10 +16,11 @@ class DnsCmdWiringTest < Test::Unit::TestCase
   end
 
   def test_dns_provider_wiring
-    @config.load_dependency_injection_wirings(@container, :dns_server => 'dnscmd_test', :dns_ttl => 999)
+    @config.load_dependency_injection_wirings(@container, :dns_server => 'dnscmd_test', :dns_ttl => 999, :dns_ptr_rewritemap => {'a' => 'b'})
     provider = @container.get_dependency(:dns_provider)
 
     assert_equal 'dnscmd_test', provider.server
     assert_equal 999, provider.ttl
+    assert_equal ({'a' => 'b'}), provider.ptr_rewritemap
   end
 end


### PR DESCRIPTION
nsupdate, nsupdate_gss and dnscmd now support a new option called
dns_ptr_rewritemap.
You can provide a hash of regex => replacement that will be used as
a map to rewrite your PTR just before it is sent to the backend.
