### PR TITLE
Fixes #17045 - hostgroup templates URLs proxied correctly

### DIFF
--- a/modules/templates/template_proxy_request.rb
+++ b/modules/templates/template_proxy_request.rb
@@ -8,15 +8,17 @@ module Proxy::Templates
     include Proxy::Log
 
     def get_template(kind, env, params)
-      url = Proxy::Templates::Plugin.settings.template_url
-      proxy_ip = URI.parse(url).host
-      opts = params.clone.merge(:url => url)
+      template_url = Proxy::Templates::Plugin.settings.template_url
+      proxy_ip = URI.parse(template_url).host
+      opts = params.clone.merge(:url => template_url)
       opts.delete("kind")
+      opts.delete("template")
+      opts.delete("hostgroup")
       opts.delete("splat")
       opts.delete("captures")
       proxy_headers = extract_request_headers(env).merge("X-Forwarded-For" => "#{env['REMOTE_ADDR']}, #{proxy_ip}")
       proxy_req = request_factory.create_get("/unattended/#{kind}", opts, proxy_headers)
-      logger.debug "Retrieving a template from %s/%s" % [url, proxy_req.path]
+      logger.debug "Retrieving a template from %s%s" % [uri, proxy_req.path]
       logger.debug "HTTP headers: #{proxy_headers.inspect}"
       res = send_request(proxy_req)
 

--- a/modules/templates/templates_api.rb
+++ b/modules/templates/templates_api.rb
@@ -14,9 +14,15 @@ class Proxy::TemplatesApi < Sinatra::Base
     end
   end
 
+  get "/:kind/:template/:hostgroup" do |kind, template, hostgroup|
+    log_halt(500, "Failed to retrieve #{kind} hostgroup template for #{params.inspect}: ") do
+      Proxy::Templates::TemplateProxyRequest.new.get_template([kind, template, hostgroup].join('/'), request.env, params)
+    end
+  end
+
   get "/:kind" do |kind|
     log_halt(500, "Failed to retrieve #{kind} template for #{params.inspect}: ") do
-      Proxy::Templates::TemplateProxyRequest.new.get_template(kind, request.env, params)
+      Proxy::Templates::TemplateProxyRequest.new.get_template([kind].join('/'), request.env, params)
     end
   end
 end

--- a/test/templates/template_api_test.rb
+++ b/test/templates/template_api_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 require 'json'
 require 'templates/templates_api'
 require 'templates/templates'
+require 'webmock/test_unit'
 
 class TemplateApiTest < Test::Unit::TestCase
   include Rack::Test::Methods
@@ -11,23 +12,38 @@ class TemplateApiTest < Test::Unit::TestCase
   end
 
   def setup
-    Proxy::Templates::Plugin.settings.stubs(:template_url).returns("someproxy:8443")
-    Proxy::SETTINGS.stubs(:foreman_url).returns("someproxy:8443")
+    @foreman_url = 'https://foreman.example.com'
+    Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+    @template_url = 'http://proxy.lan:8443'
+    Proxy::Templates::Plugin.settings.stubs(:template_url).returns(@template_url)
     @args = { :token => "test-token" }
   end
 
   def test_api_can_return_templateserver
     get "/templateServer"
-    assert last_response.ok?, "Last response was not ok"
+    assert last_response.ok?, "Last response was ok"
     data = JSON.parse(last_response.body)
-    assert_equal("someproxy:8443", data["templateServer"].to_s)
+    assert_equal(@template_url, data["templateServer"].to_s)
   end
 
-  def test_api_can_ask_for_a_template
-    Proxy::Templates::TemplateProxyRequest.any_instance.expects(:get_template).returns("An API template")
+  def test_api_passes_token_and_template_url
+    stub_request(:get, "#{@foreman_url}/unattended/provision").with(query: {"token" => "test-token", "url" => @template_url}).to_return(:body => 'An API template')
     get "/provision", @args
-    assert last_response.ok?, "Last response was not ok"
+    assert last_response.ok?, "Last response was ok"
     assert_match("An API template", last_response.body)
   end
 
+  def test_api_can_ask_for_a_template
+    stub_request(:get, "#{@foreman_url}/unattended/provision").with(query: {"url" => @template_url}).to_return(:body => 'An API template')
+    get "/provision", {}
+    assert last_response.ok?, "Last response was ok"
+    assert_match("An API template", last_response.body)
+  end
+
+  def test_api_can_ask_for_a_hostgroup_template
+    stub_request(:get, "#{@foreman_url}/unattended/kind/temp/hg").with(query: {"url" => @template_url}).to_return(:body => 'An API template')
+    get "/kind/temp/hg", {}
+    assert last_response.ok?, "Last response was ok"
+    assert_match("An API template", last_response.body)
+  end
 end


### PR DESCRIPTION
It was not working as the route did not match it.
