### PR TITLE
Fixes #17037 - Resolver::DNS#getresources is used now.

### DIFF
--- a/modules/dns_nsupdate/dns_nsupdate_main.rb
+++ b/modules/dns_nsupdate/dns_nsupdate_main.rb
@@ -35,7 +35,7 @@ module Proxy::Dns::Nsupdate
     end
 
     def create_ptr_record(fqdn, ptr)
-      case ptr_record_conflicts(fqdn, ptr_to_ip(ptr)) #returns -1, 0, 1
+      case ptr_record_conflicts(fqdn, ptr) #returns -1, 0, 1
       when 1
         raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
       when 0 then

--- a/test/dns_nsupdate/dns_nsupdate_test.rb
+++ b/test/dns_nsupdate/dns_nsupdate_test.rb
@@ -10,19 +10,18 @@ class DnsNsupdateTest < Test::Unit::TestCase
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update add 33.33.168.192.in-addr.arpa. 100 PTR some.host').returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_disconnect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_close)
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:ptr_record_conflicts).with('some.host', '192.168.33.33').returns(-1)
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:ptr_record_conflicts).with('some.host', '33.33.168.192.in-addr.arpa').returns(-1)
 
     assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_ptr_record('some.host', '33.33.168.192.in-addr.arpa')
   end
 
   def test_overwrite_ptr_record
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:ptr_record_conflicts).with('some.host', '192.168.33.33').returns(0)
-
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:ptr_record_conflicts).with('some.host', '33.33.168.192.in-addr.arpa').returns(0)
     assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_ptr_record('some.host', '33.33.168.192.in-addr.arpa')
   end
 
   def test_create_duplicate_ptr_record_fails
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:ptr_record_conflicts).with('some.host', '192.168.33.33').returns(1)
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:ptr_record_conflicts).with('some.host', '33.33.168.192.in-addr.arpa').returns(1)
 
     assert_raise Proxy::Dns::Collision do
       Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_ptr_record('some.host', '33.33.168.192.in-addr.arpa')


### PR DESCRIPTION
It replaces calls to Resolver::DNS#getaddresses and Resolver::DNS#getnames in dns module and its providers.
