### PR TITLE
fixes #17262 - verify the JSON request body contains a hash

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,9 @@
 inherit_from: .rubocop_todo.yml
 
+Metrics/ClassLength:
+  Exclude:
+    - 'test/**/*'
+
 # Offense count: 11
 Lint/AmbiguousRegexpLiteral:
   Enabled: false

--- a/lib/proxy/helpers.rb
+++ b/lib/proxy/helpers.rb
@@ -41,7 +41,7 @@ module Proxy::Helpers
   end
 
   # parses the body as json and returns a hash of the body
-  # returns empty hash if there is a json parse error or body is empty
+  # returns empty hash if there is a json parse error, the body is empty or is not a hash
   # request.env["CONTENT_TYPE"] must contain application/json in order for the json to be parsed
   def parse_json_body
     json_data = {}
@@ -57,6 +57,8 @@ module Proxy::Helpers
       rescue => e
         log_halt 415, "Invalid JSON content in body of request: \n#{e.message}"
       end
+
+      log_halt 415, "Invalid JSON content in body of request: data must be a hash, not #{json_data.class.name}" unless json_data.is_a?(Hash)
     end
     json_data
   end

--- a/test/bmc/bmc_api_test.rb
+++ b/test/bmc/bmc_api_test.rb
@@ -366,8 +366,25 @@ class BmcApiTest < Test::Unit::TestCase
   def test_api_can_pass_empty_body_and_get_415_error
     Proxy::BMC::Plugin.load_test_settings(:bmc_default_provider => 'freeipmi')
     Proxy::BMC::IPMI.any_instance.stubs(:bootbios).returns(true)
+    put "/#{@host}/chassis/config/bootdevice/bios", "", "CONTENT_TYPE" => "application/json"
+    assert_equal 415, last_response.status
+    assert_match /Invalid JSON content in body of request:/, last_response.body
+  end
+
+  def test_api_can_pass_invalid_json_and_get_415_error
+    Proxy::BMC::Plugin.load_test_settings(:bmc_default_provider => 'freeipmi')
+    Proxy::BMC::IPMI.any_instance.stubs(:bootbios).returns(true)
+    put "/#{@host}/chassis/config/bootdevice/bios", "{", "CONTENT_TYPE" => "application/json"
+    assert_equal 415, last_response.status
+    assert_match /Invalid JSON content in body of request:/, last_response.body
+  end
+
+  def test_api_can_pass_wrong_data_type_and_get_415_error
+    Proxy::BMC::Plugin.load_test_settings(:bmc_default_provider => 'freeipmi')
+    Proxy::BMC::IPMI.any_instance.stubs(:bootbios).returns(true)
     put "/#{@host}/chassis/config/bootdevice/bios", "".to_json, "CONTENT_TYPE" => "application/json"
-    assert_equal last_response.status, 415
+    assert_equal 415, last_response.status
+    assert_equal 'Invalid JSON content in body of request: data must be a hash, not String', last_response.body
   end
 
   def test_api_returns_actions_for_power_get


### PR DESCRIPTION
The json 2.x gem now parses strings and other non-hash root nodes, so
the data type need to be checked when parsing JSON bodies.