### PR TITLE
fixes #17823 -  MS DHCP record deletion is returning the stdout

### DIFF
--- a/modules/dhcp_native_ms/dhcp_native_ms_main.rb
+++ b/modules/dhcp_native_ms/dhcp_native_ms_main.rb
@@ -20,8 +20,8 @@ module Proxy::DHCP::NativeMS
       mac = record.mac.gsub(/:/,"")
       msg = "Removed DHCP reservation for #{record.name} => #{record.ip} - #{record.mac}"
       cmd = "scope #{subnet.network} delete reservedip #{record.ip} #{mac}"
-
       execute(cmd, msg)
+      nil
     end
 
     def add_record options={}


### PR DESCRIPTION
The stdout which is being returned by the server, is causing to parsing
issues by Foreman and thus the host is not being deleted at the first
attempt while the DHCP record is already gone