### PR TITLE
fixes #17856 - support multiple dhcp records for same ip

### DIFF
--- a/modules/dhcp_common/record/deleted_reservation.rb
+++ b/modules/dhcp_common/record/deleted_reservation.rb
@@ -3,8 +3,6 @@ require 'dhcp_common/record/reservation'
 module Proxy::DHCP
   # represent a deleted DHCP Record
   class DeletedReservation < Reservation
-    attr_reader :name
-
     def initialize options = {}
       @name = options[:name] || options[:hostname] || raise("Must define a name: #{options.inspect}")
       @options = options

--- a/modules/dhcp_isc/dhcp_isc_main.rb
+++ b/modules/dhcp_isc/dhcp_isc_main.rb
@@ -43,9 +43,9 @@ module Proxy::DHCP::ISC
       options = record.options
       # TODO: Extract this block into a generic dhcp options helper
       statements = []
-      statements << "filename = \\\"#{options[:filename]}\\\";"  if options[:filename]
-      statements << bootServer(options[:nextServer])             if options[:nextServer]
-      statements << "option host-name = \\\"#{record.name}\\\";" if record.name
+      statements << "filename = \\\"#{options[:filename]}\\\";" if options[:filename]
+      statements << bootServer(options[:nextServer])            if options[:nextServer]
+      statements << "option host-name = \\\"#{options[:hostname] || record.name}\\\";"
 
       statements += solaris_options_statements(options)
       statements += ztp_options_statements(options)

--- a/modules/dhcp_isc/isc_file_parser.rb
+++ b/modules/dhcp_isc/isc_file_parser.rb
@@ -23,9 +23,9 @@ module Proxy::DHCP::ISC
       # scan for host statements
       conf.scan(/host\s+(\S+\s*\{[^}]+\})/) do |host|
         if match = host[0].match(/^(\S+)\s*\{([^\}]+)/)
-          hostname = match[1]
+          name = match[1]
           body  = match[2]
-          opts = {:hostname => hostname}
+          opts = {:name => name, :hostname => name}
           body.split(";").each do |data|
             opts.merge!(parse_record_options(data))
           end
@@ -152,6 +152,10 @@ module Proxy::DHCP::ISC
           options[:nextServer] = ns
         when /^supersede server.filename\s+=\s+"(\S+)"/
           options[:filename] = $1
+        when /^option\s+host-name\s+"(\S+)"/
+          options[:hostname] = $1
+        when /^supersede host-name\s+=\s+"(\S+)"/
+          options[:hostname] = $1
         when "dynamic"
           options[:deleteable] = true
         #TODO: check if adding a new reservation with omshell for a free lease still

--- a/modules/dhcp_isc/isc_state_changes_observer.rb
+++ b/modules/dhcp_isc/isc_state_changes_observer.rb
@@ -166,9 +166,6 @@ module Proxy::DHCP
               if dupe = service.find_host_by_mac(record.subnet_address, record.mac)
                 service.delete_host(dupe)
               end
-              if dupe = service.find_host_by_ip(record.subnet_address, record.ip)
-                service.delete_host(dupe)
-              end
 
               service.add_host(record.subnet_address, record)
             when Proxy::DHCP::Lease

--- a/test/dhcp/subnet_service_test.rb
+++ b/test/dhcp/subnet_service_test.rb
@@ -114,7 +114,7 @@ class SubnetServiceTest < Test::Unit::TestCase
                                      :mac => "00:11:22:33:44:55", :ip => "192.168.0.1", :name => "test")
     @service.add_host("192.168.0.0", reservation)
 
-    assert_equal reservation, @reservations_ip_store["192.168.0.0", "192.168.0.1"]
+    assert_equal [reservation], @reservations_ip_store["192.168.0.0", "192.168.0.1"]
     assert_equal reservation, @reservations_mac_store["192.168.0.0", "00:11:22:33:44:55"]
     assert_equal reservation, @reservations_name_store["test"]
   end
@@ -196,16 +196,16 @@ class SubnetServiceTest < Test::Unit::TestCase
     assert_nil @service.find_lease_by_ip("192.168.0.0", "00:11:22:33:44:55")
   end
 
-  def test_find_host_by_ip
+  def test_find_hosts_by_ip
     reservation = ::Proxy::DHCP::Reservation.new(:subnet =>  Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0"),
                                                  :mac => "00:11:22:33:44:55", :ip => "192.168.0.1", :name => "test")
     @service.add_host("192.168.0.0", reservation)
 
-    assert_equal reservation, @service.find_host_by_ip("192.168.0.0", "192.168.0.1")
+    assert_equal [reservation], @service.find_hosts_by_ip("192.168.0.0", "192.168.0.1")
   end
 
-  def test_find_reservation_by_ip_returns_nil_for_nonexistent_record
-    assert_nil @service.find_host_by_ip("192.168.0.0", "192.168.0.1")
+  def test_find_hosts_by_ip_returns_nil_for_nonexistent_record
+    assert_nil @service.find_hosts_by_ip("192.168.0.0", "192.168.0.1")
   end
 
   def test_find_host_by_mac

--- a/test/dhcp_isc/dhcp_isc_parser_test.rb
+++ b/test/dhcp_isc/dhcp_isc_parser_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'dhcp_common/dhcp_common'
 require 'dhcp_common/subnet'
 require 'dhcp_common/subnet_service'
 require 'dhcp_isc/isc_file_parser'
@@ -148,14 +149,26 @@ END
     @subnet_service.add_subnet(subnet)
     parsed = @parser.parse_config_and_leases_for_records(File.read("./test/fixtures/dhcp/dhcp.leases"))
 
-    assert_equal 20, parsed.size
+    assert_equal 24, parsed.size
 
     deleted = parsed.select {|record| record.is_a?(::Proxy::DHCP::Reservation) && record.name == "deleted.example.com" }
     assert_equal [::Proxy::DHCP::Reservation, ::Proxy::DHCP::DeletedReservation], deleted.map(&:class)
 
+    bonds = parsed.select {|record| record.is_a?(::Proxy::DHCP::Reservation) && record.name =~ /^bond\.example\.com/ }
+    assert_equal ['bond.example.com', 'bond.example.com'], bonds.map(&:hostname)
+
+    minimal = parsed.find {|record| record.is_a?(::Proxy::DHCP::Reservation) && record.name == "alpha.example.com" }
+    assert_equal 'alpha.example.com', minimal.hostname
+
+    hostname = parsed.find {|record| record.is_a?(::Proxy::DHCP::Reservation) && record.name == "bravo2.example.com" }
+    assert_equal 'bravo.example.com', hostname.hostname
+
     assert_nil parsed.find {|record| record.ip == "192.168.122.0" }
     assert_not_nil parsed.find {|record| record.respond_to?(:name) && record.name == "undeleted.example.com" }
     assert_not_nil parsed.find {|record| record.ip == "192.168.122.35"}
+    assert_not_nil parsed.find {|record| record.name == "bond.example.com-01"}
+    assert_not_nil parsed.find {|record| record.name == "bond.example.com-02"}
+    assert_equal 2, parsed.count {|record| record.ip == "192.168.122.43"}
   end
 
   def test_get_ip_list_from_config_line

--- a/test/dhcp_isc/server_isc_test.rb
+++ b/test/dhcp_isc/server_isc_test.rb
@@ -1,4 +1,6 @@
 require 'test_helper'
+require 'dhcp/dhcp'
+require 'dhcp/dhcp_plugin'
 require 'dhcp/sparc_attrs'
 require 'dhcp_common/server'
 require 'dhcp_isc/dhcp_isc_main'
@@ -51,7 +53,8 @@ class ServerIscTest < Test::Unit::TestCase
     @dhcp.expects(:ztp_options_statements).returns([])
     @dhcp.expects(:poap_options_statements).returns([])
 
-    record_to_add = Proxy::DHCP::Reservation.new(:name => 'a-test',
+    record_to_add = Proxy::DHCP::Reservation.new(:name => 'a-test-01',
+                                 :hostname => 'a-test',
                                  :ip => '192.168.42.100',
                                  :subnet => Proxy::DHCP::Subnet.new('192.168.42.0', '255.255.255.0'),
                                  :mac => '01:02:03:04:05:06',
@@ -65,7 +68,7 @@ class ServerIscTest < Test::Unit::TestCase
       "set ip-address = #{record_to_add.ip}",
       "set hardware-address = #{record_to_add.mac}",
       "set hardware-type = 1",
-      "set statements = \"filename = \\\"#{record_to_add.options[:filename]}\\\"; next-server = c0:a8:2a:0a; option host-name = \\\"#{record_to_add.name}\\\";\"",
+      "set statements = \"filename = \\\"#{record_to_add.options[:filename]}\\\"; next-server = c0:a8:2a:0a; option host-name = \\\"#{record_to_add.hostname}\\\";\"",
       "create"
     ]
     assert_equal expected_om_output, omio.input_commands

--- a/test/dhcp_isc/state_changes_observer_test.rb
+++ b/test/dhcp_isc/state_changes_observer_test.rb
@@ -114,7 +114,7 @@ class StateChangesObserverTest < Test::Unit::TestCase
     reservation_details = {:subnet =>  @subnet, :mac => "00:11:22:33:44:55", :ip => "192.168.0.1", :name => "test"}
     @observer.update_subnet_service_with_dhcp_records([::Proxy::DHCP::Reservation.new(reservation_details)])
 
-    assert @service.find_host_by_ip("192.168.0.0", "192.168.0.1")
+    assert @service.find_hosts_by_ip("192.168.0.0", "192.168.0.1")
   end
 
   def test_update_subnet_service_with_dhcp_records_should_delete_hosts_with_duplicate_macs_when_adding_reservations
@@ -123,7 +123,7 @@ class StateChangesObserverTest < Test::Unit::TestCase
 
     @observer.update_subnet_service_with_dhcp_records([::Proxy::DHCP::Reservation.new(reservation_details.merge(:ip => "192.168.0.1"))])
 
-    assert @service.find_host_by_ip("192.168.0.0", "192.168.0.1")
+    assert @service.find_hosts_by_ip("192.168.0.0", "192.168.0.1")
   end
 
   def test_update_subnet_service_with_dhcp_records_should_delete_hosts_with_duplicate_ips_when_adding_reservations

--- a/test/dhcp_libvirt/dhcp_libvirt_provider_test.rb
+++ b/test/dhcp_libvirt/dhcp_libvirt_provider_test.rb
@@ -1,4 +1,6 @@
 require 'test_helper'
+require 'dhcp_common/server'
+require 'dhcp_common/subnet_service'
 require 'dhcp_libvirt/dhcp_libvirt'
 require 'dhcp_libvirt/dhcp_libvirt_main'
 
@@ -49,8 +51,8 @@ XMLFIXTURE
   def test_should_load_subnet_data
     @subject.load_subnet_data(@subnet)
 
-    assert @service.find_host_by_ip("192.168.122.0", "192.168.122.10")
-    assert @service.find_host_by_ip("192.168.122.0", "192.168.122.11")
+    assert @service.find_hosts_by_ip("192.168.122.0", "192.168.122.10")
+    assert @service.find_hosts_by_ip("192.168.122.0", "192.168.122.11")
     assert @service.find_lease_by_ip("192.168.122.0", "192.168.122.22")
     assert @service.find_lease_by_mac("192.168.122.0", "52:54:00:13:05:12")
     assert_equal 2, @service.all_hosts.size

--- a/test/fixtures/dhcp/dhcp.leases
+++ b/test/fixtures/dhcp/dhcp.leases
@@ -164,6 +164,40 @@ host mac441ea173366b.example.com {
         supersede host-name = "mac441ea173366b.example.com";
 }
 
+# Reservations for a bonded interface
+host bond.example.com-01 {
+  dynamic;
+  hardware ethernet 44:1e:a1:73:36:10;
+  fixed-address 192.168.122.43;
+        supersede server.filename = "pxelinux.0";
+        supersede server.next-server = c0:a8:00:01;
+        supersede host-name = "bond.example.com";
+}
+
+host bond.example.com-02 {
+  dynamic;
+  hardware ethernet 44:1e:a1:73:36:11;
+  fixed-address 192.168.122.43;
+        supersede server.filename = "pxelinux.0";
+        supersede server.next-server = c0:a8:00:01;
+        supersede host-name = "bond.example.com";
+}
+
+# hostname set without supersede
+host bravo2.example.com {
+  dynamic;
+  hardware ethernet 44:1e:a1:73:36:15;
+  fixed-address 192.168.122.42;
+  option host-name "bravo.example.com";
+}
+
+# No hostname set
+host alpha.example.com {
+  dynamic;
+  hardware ethernet 44:1e:a1:73:36:15;
+  fixed-address 192.168.122.42;
+}
+
 # Prevent deletion of a reserved record via expired lease
 host quux.example.org {
   dynamic;

--- a/test/provider_interface_validation/dhcp_provider.rb
+++ b/test/provider_interface_validation/dhcp_provider.rb
@@ -7,7 +7,11 @@ module DhcpProviderInterfaceValidation
     assert dhcp_provider.respond_to?(:all_hosts)
     assert dhcp_provider.respond_to?(:unused_ip)
     assert dhcp_provider.respond_to?(:find_record)
+    assert dhcp_provider.respond_to?(:find_records_by_ip)
+    assert dhcp_provider.respond_to?(:find_record_by_mac)
     assert dhcp_provider.respond_to?(:add_record)
+    assert dhcp_provider.respond_to?(:del_records_by_ip)
+    assert dhcp_provider.respond_to?(:del_record_by_mac)
     assert dhcp_provider.respond_to?(:del_record)
   end
 end


### PR DESCRIPTION
This is the smart-proxy implementation for https://github.com/theforeman/foreman/pull/4129.

The code works fine so far in my tests.

Comments very welcome.