### PR TITLE
fixes  #17847 -  MS DHCP: delete the lease upon a host deletion

### DIFF
--- a/modules/dhcp_native_ms/dhcp_native_ms_main.rb
+++ b/modules/dhcp_native_ms/dhcp_native_ms_main.rb
@@ -10,19 +10,31 @@ module Proxy::DHCP::NativeMS
     def initialize(name, subnets, subnet_service)
       super(name, subnets, subnet_service)
     end
+    
+    def del_reservation(record_name, record_ip, record_mac, subnet_network)
+      mac = record_mac.gsub(/:/,"")
+      msg = "Remove DHCP reservation for #{record_name} => #{record_ip} - #{record_mac}"
+      cmd = "scope #{subnet_network} delete reservedip #{record_ip} #{mac}"
+      execute(cmd, msg)
+      nil
+    end
+
+    def del_lease(record_name, record_ip, record_mac, subnet_network)
+      msg = "Removed DHCP lease for #{record_name} => #{record_ip} - #{record_mac}"
+      cmd  = "scope #{subnet_network} delete lease #{record_ip}"
+      execute(cmd, msg)
+      nil
+    end
 
     def del_record subnet, record
       validate_subnet subnet
       validate_record record
       # TODO: Refactor this into the base class
       raise InvalidRecord, "#{record} is static - unable to delete" unless record.deleteable?
-
-      mac = record.mac.gsub(/:/,"")
-      msg = "Removed DHCP reservation for #{record.name} => #{record.ip} - #{record.mac}"
-      cmd = "scope #{subnet.network} delete reservedip #{record.ip} #{mac}"
-
-      execute(cmd, msg)
-    end
+      del_reservation(record.name, record.ip, record.mac, subnet.network)
+      del_lease(record.name, record.ip, record.mac, subnet.network)
+      nil
+     end
 
     def add_record options={}
       record = super(options)
@@ -184,7 +196,6 @@ module Proxy::DHCP::NativeMS
           ret_val << Proxy::DHCP::Subnet.new(match[1], match[2])
         end
       end
-
       ret_val
     end
 
@@ -192,35 +203,37 @@ module Proxy::DHCP::NativeMS
       super
       service.add_subnets(*find_all_subnets)
     end
-
+    
     def execute cmd, msg=nil, error_only=false
       tsecs = 5
-      response = nil
+      exit_code = response = nil
       interpreter = Proxy::SETTINGS.x86_64 ? 'c:\windows\sysnative\cmd.exe' : 'c:\windows\system32\cmd.exe'
       command  = interpreter + ' /c c:\Windows\System32\netsh.exe -c dhcp ' + "server #{name} #{cmd}"
-
-      std_in = std_out = std_err = nil
       begin
         timeout(tsecs) do
           logger.debug "executing: #{command}"
-          std_in, std_out, std_err  = Open3.popen3(command)
-          response  = std_out.readlines
-          response += std_err.readlines
+          Open3.popen3(command) do |stdin, stdout, stderr, wait_thr|
+            exit_value = wait_thr.value
+            exit_code = exit_value.exitstatus
+            response = stdout.readlines
+            response += stderr.readlines
+          end
         end
-      rescue TimeoutError
-        raise Proxy::DHCP::Error.new("Netsh did not respond within #{tsecs} seconds")
-      ensure
-        std_in.close  unless std_in.nil?
-        std_out.close unless std_out.nil?
-        std_err.close unless std_err.nil?
+        rescue TimeoutError
+         raise Proxy::DHCP::Error.new("Netsh did not respond within #{tsecs} seconds")
       end
-      report msg, response, error_only
+      report msg, response, error_only, exit_code
+      logger.debug "response=#{response}"
       response
     end
 
-    def report msg, response, error_only
-      if response.grep(/completed successfully/).empty?
+    def report msg, response, error_only, exit_code
+      # Since we can't make sure that every netsh command will contain specific string
+      # We'll check the exit code of the command, this can assure us whether it succeeded or not
+      if exit_code.to_i != 0
+        is_known_vendor = true
         if !response.grep(/class name being used is unknown/).empty?
+          is_known_vendor = false
           logger.warn "Vendor class not found"
         else
           logger.error "Netsh failed:\n" + response.join()
@@ -230,6 +243,7 @@ module Proxy::DHCP::NativeMS
         msg.sub! /Enumerated/, "enumerate"
         msg.sub! /Queried/,    "query"
         msg  = "Failed to #{msg}"
+        msg += "Vendor class not found" if !is_known_vendor
         msg += "Vendor class not found" if !response.grep(/class name being used is unknown/).empty?
         msg += ": No entry found" if !response.grep(/not a reserved client/).empty?
         match = response.grep(/used by another client/)


### PR DESCRIPTION
1) Added a functionality of a lease deletion
2) Handling better errors in the report generation - Instead of looking
for a hard coded string, replaced it with an exit code of the execution
    (A.K.A ERRORLEVEL in Windows)
3) Some cosmetics in the report function
4) Modified the execute method, so it'll get the exit value of the
process