### PR TITLE
Fixes #17879 Add DNS CNAME support for nsupdate

### DIFF
--- a/modules/dns_nsupdate/dns_nsupdate_main.rb
+++ b/modules/dns_nsupdate/dns_nsupdate_main.rb
@@ -45,6 +45,17 @@ module Proxy::Dns::Nsupdate
       end
     end
 
+    def create_cname_record(fqdn, target)
+      case cname_record_conflicts(fqdn, target) #return -1, 0, 1
+        when 1
+          raise(Proxy::Dns::Collision, "'#{fqdn}' is already in use by #{target}")
+        when 0
+          return nil
+        else
+          do_create(fqdn, target, "CNAME")
+      end
+    end
+
     def do_create(id, value, type)
       nsupdate_connect
       nsupdate "update add #{id}. #{@ttl} #{type} #{value}"
@@ -67,6 +78,10 @@ module Proxy::Dns::Nsupdate
     def remove_ptr_record(ip)
       get_name!(ip)
       do_remove(ip, "PTR")
+    end
+
+    def remove_cname_record(fqdn_alias)
+      do_remove(fqdn_alias, "CNAME")
     end
 
     def do_remove(id, type)


### PR DESCRIPTION
Smart-proxy API currently only supports DNS CNAME entries for DNSCMD

This commit creates and remove CNAME entries for nsupdate, making it
possible to assign alias to a host using nsupdate providers