### PR TITLE
Fixes #17880 - Follow same pattern for DNS CNAME methods signature

### DIFF
--- a/modules/dns_common/dns_common.rb
+++ b/modules/dns_common/dns_common.rb
@@ -42,14 +42,14 @@ module Proxy::Dns
       end
     end
 
-    def create_cname_record(fqdn, target)
-      case cname_record_conflicts(fqdn, target) #returns -1, 0, 1
+    def create_cname_record(fqdn, host_alias)
+      case cname_record_conflicts(fqdn, host_alias) #returns -1, 0, 1
         when 1 then
-          raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
+          raise(Proxy::Dns::Collision, "'#{host_alias} 'is already in use")
         when 0 then
           return nil
         else
-          do_create(fqdn, target, "CNAME")
+          do_create(host_alias, fqdn, "CNAME")
       end
     end
 
@@ -76,8 +76,8 @@ module Proxy::Dns
       do_remove(fqdn, "AAAA")
     end
 
-    def remove_cname_record(fqdn)
-      do_remove(fqdn, "CNAME")
+    def remove_cname_record(host_alias)
+      do_remove(host_alias, "CNAME")
     end
 
     def remove_ptr_record(name)
@@ -170,10 +170,10 @@ module Proxy::Dns
       end
     end
 
-    def cname_record_conflicts(fqdn, target)
-      current = resolver.getresources(fqdn, Resolv::DNS::Resource::IN::CNAME)
+    def cname_record_conflicts(fqdn, host_alias)
+      current = resolver.getresources(host_alias, Resolv::DNS::Resource::IN::CNAME)
       return -1 if current.empty?
-      return 0 if current[0].name.to_s == target #There can only be one CNAME
+      return 0 if current[0].name.to_s == fqdn #There can only be one CNAME
       1
     end
 

--- a/test/dns/dns_api_test.rb
+++ b/test/dns/dns_api_test.rb
@@ -13,8 +13,8 @@ class DnsApiTestProvider
   def create_ptr_record(fqdn, ip)
     @fqdn = fqdn; @ip = ip; @type = 'PTR'
   end
-  def create_cname_record(fqdn, target)
-    @fqdn = fqdn; @target = target; @type = 'CNAME'
+  def create_cname_record(fqdn, host_alias)
+    @fqdn = fqdn; @host_alias = host_alias; @type = 'CNAME'
   end
   def remove_a_record(fqdn)
     @fqdn = fqdn; @type = 'A'
@@ -25,8 +25,8 @@ class DnsApiTestProvider
   def remove_ptr_record(ip)
     @ip = ip; @type = 'PTR'
   end
-  def remove_cname_record(fqdn)
-    @fqdn = fqdn; @type = 'CNAME'
+  def remove_cname_record(host_alias)
+    @host_alias = host_alias; @type = 'CNAME'
   end
 end
 
@@ -149,10 +149,10 @@ class DnsApiTest < Test::Unit::TestCase
   end
 
   def test_create_cname_record
-    post '/', :fqdn => 'test.com', :value => 'test1.com', :type => 'CNAME'
+    post '/', :fqdn => 'test.com', :value => 'alias.com', :type => 'CNAME'
     assert_equal 200, last_response.status
     assert_equal 'test.com', @server.fqdn
-    assert_equal 'test1.com', @server.target
+    assert_equal 'alias.com', @server.host_alias
     assert_equal 'CNAME', @server.type
   end
 
@@ -192,9 +192,9 @@ class DnsApiTest < Test::Unit::TestCase
   end
 
   def test_delete_explicit_cname_record
-    delete "/test.com/CNAME"
+    delete "/alias.com/CNAME"
     assert_equal 200, last_response.status
-    assert_equal 'test.com', @server.fqdn
+    assert_equal 'alias.com', @server.host_alias
     assert_equal 'CNAME', @server.type
   end
 


### PR DESCRIPTION
All DNS methods uses fqdn parameters as the target of the action and the    second argument as the attribute that will be set to that target

Since CNAME methods does the opposite, this commit aim to fix that