### PR TITLE
Refs #17037 - Fix deprecation warning in dnscmd

### DIFF
--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -55,7 +55,7 @@ module Proxy::Dns::Dnscmd
     end
 
     def create_ptr_record(fqdn, ptr)
-      case ptr_record_conflicts(fqdn, ptr_to_ip(ptr)) #returns -1, 0, 1
+      case ptr_record_conflicts(fqdn, ptr) #returns -1, 0, 1
         when 1 then
           raise(Proxy::Dns::Collision, "'#{ptr}' is already in use")
         when 0

--- a/test/dns_dnscmd/dnscmd_test.rb
+++ b/test/dns_dnscmd/dnscmd_test.rb
@@ -45,18 +45,18 @@ class DnsCmdTest < Test::Unit::TestCase
   end
 
   def test_create_ptr_record
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:ptr_record_conflicts).with('host.foo.bar.domain.local', '192.168.33.33').returns(-1)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:ptr_record_conflicts).with('host.foo.bar.domain.local', '33.33.168.192.in-addr.arpa').returns(-1)
     Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/RecordAdd 33.168.192.in-addr.arpa 33.33.168.192.in-addr.arpa. PTR host.foo.bar.domain.local.', anything).returns(true)
     assert_nil @server.create_ptr_record('host.foo.bar.domain.local', '33.33.168.192.in-addr.arpa')
   end
 
   def test_overwrite_ptr_record
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:ptr_record_conflicts).with('host.foo.bar.domain.local', '192.168.33.33').returns(0)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:ptr_record_conflicts).with('host.foo.bar.domain.local', '33.33.168.192.in-addr.arpa').returns(0)
     assert_nil @server.create_ptr_record('host.foo.bar.domain.local', '33.33.168.192.in-addr.arpa')
   end
 
   def test_create_duplicate_ptr_record_fails
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:ptr_record_conflicts).with('host.foo.bar.domain.local', '192.168.33.33').returns(1)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:ptr_record_conflicts).with('host.foo.bar.domain.local', '33.33.168.192.in-addr.arpa').returns(1)
     assert_raise Proxy::Dns::Collision do
       @server.create_ptr_record('host.foo.bar.domain.local', '33.33.168.192.in-addr.arpa')
     end


### PR DESCRIPTION
522231bf3e4c918ee821a73acb3f70459ca57791 deprecated the use of ptr_record_conflicts with IPs, but didn't update this implementation.

Note that since I don't have a Windows install I didn't test this in production.

Should this also be backported to 1.14 once merged?