### PR TITLE
Fixes #17906 - Move {create,remove}_*_record to dns_common

### DIFF
--- a/modules/dns_common/dns_common.rb
+++ b/modules/dns_common/dns_common.rb
@@ -20,6 +20,74 @@ module Proxy::Dns
       Resolv::DNS.new(:nameserver => @server)
     end
 
+    def create_a_record(fqdn, ip)
+      case a_record_conflicts(fqdn, ip) #returns -1, 0, 1
+        when 1 then
+          raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
+        when 0 then
+          return nil
+        else
+          do_create(fqdn, ip, "A")
+      end
+    end
+
+    def create_aaaa_record(fqdn, ip)
+      case aaaa_record_conflicts(fqdn, ip) #returns -1, 0, 1
+        when 1 then
+          raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
+        when 0 then
+          return nil
+        else
+          do_create(fqdn, ip, "AAAA")
+      end
+    end
+
+    def create_cname_record(fqdn, target)
+      case cname_record_conflicts(fqdn, target) #returns -1, 0, 1
+        when 1 then
+          raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
+        when 0 then
+          return nil
+        else
+          do_create(fqdn, target, "CNAME")
+      end
+    end
+
+    def create_ptr_record(fqdn, ptr)
+      case ptr_record_conflicts(fqdn, ptr) #returns -1, 0, 1
+        when 1 then
+          raise(Proxy::Dns::Collision, "'#{ptr}' is already in use")
+        when 0
+          return nil
+        else
+          do_create(ptr, fqdn, "PTR")
+      end
+    end
+
+    def do_create(name, value, type)
+      raise(Proxy::Dns::Error, "Creation of #{type} not implemented")
+    end
+
+    def remove_a_record(fqdn)
+      do_remove(fqdn, "A")
+    end
+
+    def remove_aaaa_record(fqdn)
+      do_remove(fqdn, "AAAA")
+    end
+
+    def remove_cname_record(fqdn)
+      do_remove(fqdn, "CNAME")
+    end
+
+    def remove_ptr_record(name)
+      do_remove(name, "PTR")
+    end
+
+    def do_remove(name, type)
+      raise(Proxy::Dns::Error, "Deletion of #{type} not implemented")
+    end
+
     def dns_find(key)
       logger.warn(%q{Proxy::Dns::Record#dns_find has been deprecated and will be removed in future versions of Smart-Proxy.
                       Please use ::Proxy::Dns::Record#get_name or ::Proxy::Dns::Record#get_address instead.})
@@ -124,14 +192,6 @@ module Proxy::Dns
 
     def to_ipaddress ip
       IPAddr.new(ip) rescue false
-    end
-
-    def create_cname_record(fqdn, target)
-      raise Proxy::Dns::Error.new("This DNS provider does not support CNAME management")
-    end
-
-    def remove_cname_record(fqdn)
-      raise Proxy::Dns::Error.new("This DNS provider does not support CNAME management")
     end
   end
 end

--- a/modules/dns_nsupdate/dns_nsupdate_main.rb
+++ b/modules/dns_nsupdate/dns_nsupdate_main.rb
@@ -12,39 +12,6 @@ module Proxy::Dns::Nsupdate
       super(a_server, a_ttl)
     end
 
-    def create_a_record(fqdn, ip)
-      case a_record_conflicts(fqdn, ip) #returns -1, 0, 1
-      when 1
-        raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
-      when 0 then
-        return nil
-      else
-        do_create(fqdn, ip, "A")
-      end
-    end
-
-    def create_aaaa_record(fqdn, ip)
-      case aaaa_record_conflicts(fqdn, ip) #returns -1, 0, 1
-      when 1
-        raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
-      when 0 then
-        return nil
-      else
-        do_create(fqdn, ip, "AAAA")
-      end
-    end
-
-    def create_ptr_record(fqdn, ptr)
-      case ptr_record_conflicts(fqdn, ptr) #returns -1, 0, 1
-      when 1
-        raise(Proxy::Dns::Collision, "'#{fqdn} 'is already in use")
-      when 0 then
-        return nil
-      else
-        do_create(ptr, fqdn, "PTR")
-      end
-    end
-
     def do_create(id, value, type)
       nsupdate_connect
       nsupdate "update add #{id}. #{@ttl} #{type} #{value}"
@@ -52,21 +19,6 @@ module Proxy::Dns::Nsupdate
       nil
     ensure
       nsupdate_close
-    end
-
-    def remove_a_record(fqdn)
-      get_ipv4_address!(fqdn)
-      do_remove(fqdn, "A")
-    end
-
-    def remove_aaaa_record(fqdn)
-      get_ipv6_address!(fqdn)
-      do_remove(fqdn, "AAAA")
-    end
-
-    def remove_ptr_record(ip)
-      get_name!(ip)
-      do_remove(ip, "PTR")
     end
 
     def do_remove(id, type)

--- a/test/dns_common/record_test.rb
+++ b/test/dns_common/record_test.rb
@@ -171,6 +171,114 @@ class DnsRecordTest < Test::Unit::TestCase
     assert_equal false, Proxy::Dns::Record.new.to_ipaddress('some.host')
   end
 
+  def test_create_a_record
+    Proxy::Dns::Record.any_instance.expects(:a_record_conflicts).returns(-1)
+    Proxy::Dns::Record.any_instance.expects(:do_create).with('some.host', '192.168.33.22', 'A')
+
+    assert_nil Proxy::Dns::Record.new.create_a_record('some.host', '192.168.33.22')
+  end
+
+  def test_overwrite_a_record
+    Proxy::Dns::Record.any_instance.expects(:a_record_conflicts).returns(0)
+
+    assert_nil Proxy::Dns::Record.new.create_a_record('some.host', '192.168.33.22')
+  end
+
+  def test_create_duplicate_a_record_fails
+    Proxy::Dns::Record.any_instance.expects(:a_record_conflicts).returns(1)
+
+    assert_raise Proxy::Dns::Collision do
+      Proxy::Dns::Record.new.create_a_record('some.host', '2001:db8::1')
+    end
+  end
+
+  def test_create_aaaa_record
+    Proxy::Dns::Record.any_instance.expects(:aaaa_record_conflicts).returns(-1)
+    Proxy::Dns::Record.any_instance.expects(:do_create).with('some.host', '2001:db8::1', 'AAAA')
+
+    assert_nil Proxy::Dns::Record.new.create_aaaa_record('some.host', '2001:db8::1')
+  end
+
+  def test_overwrite_aaaa_record
+    Proxy::Dns::Record.any_instance.expects(:aaaa_record_conflicts).returns(0)
+
+    assert_nil Proxy::Dns::Record.new.create_aaaa_record('some.host', '2001:db8::1')
+  end
+
+  def test_create_duplicate_aaaa_record_fails
+    Proxy::Dns::Record.any_instance.expects(:aaaa_record_conflicts).returns(1)
+
+    assert_raise Proxy::Dns::Collision do
+      Proxy::Dns::Record.new.create_aaaa_record('some.host', '2001:db8::1')
+    end
+  end
+
+  def test_create_cname_record
+    Proxy::Dns::Record.any_instance.expects(:cname_record_conflicts).returns(-1)
+    Proxy::Dns::Record.any_instance.expects(:do_create).with('some.host', 'target.example.com', 'CNAME')
+
+    assert_nil Proxy::Dns::Record.new.create_cname_record('some.host', 'target.example.com')
+  end
+
+  def test_overwrite_cname_record
+    Proxy::Dns::Record.any_instance.expects(:cname_record_conflicts).returns(0)
+
+    assert_nil Proxy::Dns::Record.new.create_cname_record('some.host', 'target.example.com')
+  end
+
+  def test_create_duplicate_cname_record_fails
+    Proxy::Dns::Record.any_instance.expects(:cname_record_conflicts).returns(1)
+
+    assert_raise Proxy::Dns::Collision do
+      Proxy::Dns::Record.new.create_cname_record('some.host', 'target.example.com')
+    end
+  end
+
+  def test_create_ptr_record
+    Proxy::Dns::Record.any_instance.expects(:ptr_record_conflicts).returns(-1)
+    Proxy::Dns::Record.any_instance.expects(:do_create).with('22.33.168.192.in-addr.arpa', 'some.host', 'PTR')
+
+    assert_nil Proxy::Dns::Record.new.create_ptr_record('some.host', '22.33.168.192.in-addr.arpa')
+  end
+
+  def test_overwrite_ptr_record
+    Proxy::Dns::Record.any_instance.expects(:ptr_record_conflicts).returns(0)
+
+    assert_nil Proxy::Dns::Record.new.create_ptr_record('some.host', '22.33.168.192.in-addr.arpa')
+  end
+
+  def test_create_duplicate_ptr_record_fails
+    Proxy::Dns::Record.any_instance.expects(:ptr_record_conflicts).returns(1)
+
+    assert_raise Proxy::Dns::Collision do
+      Proxy::Dns::Record.new.create_ptr_record('some.host', '22.33.168.192.in-addr.arpa')
+    end
+  end
+
+  def test_remove_a_record
+    Proxy::Dns::Record.any_instance.expects(:do_remove).with('some.host', 'A')
+
+    assert_nil Proxy::Dns::Record.new.remove_a_record('some.host')
+  end
+
+  def test_remove_aaaa_record
+    Proxy::Dns::Record.any_instance.expects(:do_remove).with('some.host', 'AAAA')
+
+    assert_nil Proxy::Dns::Record.new.remove_aaaa_record('some.host')
+  end
+
+  def test_remove_cname_record
+    Proxy::Dns::Record.any_instance.expects(:do_remove).with('some.host', 'CNAME')
+
+    assert_nil Proxy::Dns::Record.new.remove_cname_record('some.host')
+  end
+
+  def test_remove_ptr_record
+    Proxy::Dns::Record.any_instance.expects(:do_remove).with('22.33.168.192.in-addr.arpa', 'PTR')
+
+    assert_nil Proxy::Dns::Record.new.remove_ptr_record('22.33.168.192.in-addr.arpa')
+  end
+
   def ips(*ips)
     ips.map {|ip| ip =~  Resolv::IPv4::Regex ? Resolv::DNS::Resource::IN::A.new(ip) : Resolv::DNS::Resource::IN::AAAA.new(ip) }
   end

--- a/test/dns_dnscmd/dnscmd_config_test.rb
+++ b/test/dns_dnscmd/dnscmd_config_test.rb
@@ -1,6 +1,8 @@
 require 'test_helper'
+require 'dns_common/dns_common'
 require 'dns_dnscmd/plugin_configuration'
 require 'dns_dnscmd/dns_dnscmd_plugin'
+require 'dns_dnscmd/dns_dnscmd_main'
 
 class DnsCmdConfigTest < Test::Unit::TestCase
   def test_default_configuration

--- a/test/dns_nsupdate/dns_nsupdate_config_test.rb
+++ b/test/dns_nsupdate/dns_nsupdate_config_test.rb
@@ -1,6 +1,9 @@
 require 'test_helper'
+require 'dns_common/dns_common'
 require 'dns_nsupdate/dns_nsupdate'
+require 'dns_nsupdate/dns_nsupdate_main'
 require 'dns_nsupdate/dns_nsupdate_gss'
+require 'dns_nsupdate/dns_nsupdate_gss_main'
 
 class DnsNsupdateConfigTest < Test::Unit::TestCase
   def test_nsupdate_default_settings

--- a/test/dns_nsupdate/dns_nsupdate_test.rb
+++ b/test/dns_nsupdate/dns_nsupdate_test.rb
@@ -1,31 +1,17 @@
 require 'test_helper'
-require 'dns/dns'
+require 'dns_common/dns_common'
+require 'dns_nsupdate/nsupdate_configuration'
 require 'dns_nsupdate/dns_nsupdate_plugin'
 require 'dns_nsupdate/dns_nsupdate_main'
-require 'dns_nsupdate/dns_nsupdate_gss_main'
 
 class DnsNsupdateTest < Test::Unit::TestCase
-  def test_create_ptr_record
+  def test_do_create_ptr
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_connect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update add 33.33.168.192.in-addr.arpa. 100 PTR some.host').returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_disconnect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_close)
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:ptr_record_conflicts).with('some.host', '33.33.168.192.in-addr.arpa').returns(-1)
 
-    assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_ptr_record('some.host', '33.33.168.192.in-addr.arpa')
-  end
-
-  def test_overwrite_ptr_record
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:ptr_record_conflicts).with('some.host', '33.33.168.192.in-addr.arpa').returns(0)
-    assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_ptr_record('some.host', '33.33.168.192.in-addr.arpa')
-  end
-
-  def test_create_duplicate_ptr_record_fails
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:ptr_record_conflicts).with('some.host', '33.33.168.192.in-addr.arpa').returns(1)
-
-    assert_raise Proxy::Dns::Collision do
-      Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_ptr_record('some.host', '33.33.168.192.in-addr.arpa')
-    end
+    assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).do_create('33.33.168.192.in-addr.arpa', 'some.host', 'PTR')
   end
 
   def test_create_address_record
@@ -33,29 +19,8 @@ class DnsNsupdateTest < Test::Unit::TestCase
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update add some.host. 100 A 192.168.33.33').returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_disconnect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_close)
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:a_record_conflicts).with('some.host', '192.168.33.33').returns(-1)
 
-    assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_a_record('some.host', '192.168.33.33')
-  end
-
-  def test_overwrite_address_record
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:a_record_conflicts).with('some.host', '192.168.33.33').returns(0)
-
-    assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_a_record('some.host', '192.168.33.33')
-  end
-
-  def test_create_duplicate_address_record_fails
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:a_record_conflicts).with('some.host', '192.168.33.33').returns(1)
-
-    assert_raise Proxy::Dns::Collision do
-      Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_a_record('some.host', '192.168.33.33')
-    end
-  end
-
-  def test_remove_cname_record_fails
-    assert_raise Proxy::Dns::Error do
-      Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).remove_cname_record('some.host')
-    end
+    assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).do_create('some.host', '192.168.33.33', 'A')
   end
 
   def test_create_aaaa_record
@@ -63,23 +28,17 @@ class DnsNsupdateTest < Test::Unit::TestCase
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update add some.host. 100 AAAA 2001:db8::1').returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_disconnect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_close)
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:aaaa_record_conflicts).with('some.host', '2001:db8::1').returns(-1)
 
-    assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_aaaa_record('some.host', '2001:db8::1')
+    assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).do_create('some.host', '2001:db8::1', 'AAAA')
   end
 
-  def test_overwrite_aaaa_record
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:aaaa_record_conflicts).with('some.host', '2001:db8::1').returns(0)
+  def test_create_cname_record
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_connect).returns(true)
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update add alias.host. 100 CNAME some.host').returns(true)
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_disconnect).returns(true)
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_close)
 
-    assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_aaaa_record('some.host', '2001:db8::1')
-  end
-
-  def test_create_duplicate_aaaa_record_fails
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:aaaa_record_conflicts).with('some.host', '2001:db8::1').returns(1)
-
-    assert_raise Proxy::Dns::Collision do
-      Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).create_aaaa_record('some.host', '2001:db8::1')
-    end
+    assert_nil Proxy::Dns::Nsupdate::Record.new(nil, 100, nil).do_create('alias.host', 'some.host', 'CNAME')
   end
 
   def test_remove_ptr_v4_record
@@ -87,9 +46,8 @@ class DnsNsupdateTest < Test::Unit::TestCase
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update delete 33.33.168.192.in-addr.arpa PTR').returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_disconnect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_close)
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:get_name!).with('33.33.168.192.in-addr.arpa').returns('some.host')
 
-    assert_nil Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).remove_ptr_record('33.33.168.192.in-addr.arpa')
+    assert_nil Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).do_remove('33.33.168.192.in-addr.arpa', 'PTR')
   end
 
   def test_remove_ptr_v6_record
@@ -97,9 +55,8 @@ class DnsNsupdateTest < Test::Unit::TestCase
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update delete 1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa PTR').returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_disconnect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_close)
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:get_name!).with('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa').returns('some.host')
 
-    assert_nil Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).remove_ptr_record('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa')
+    assert_nil Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).do_remove('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.8.b.d.0.1.0.0.2.ip6.arpa', 'PTR')
   end
 
   def test_remove_address_record
@@ -107,16 +64,8 @@ class DnsNsupdateTest < Test::Unit::TestCase
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update delete some.host A').returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_disconnect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_close)
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:get_ipv4_address!).with('some.host').returns('192.168.33.33')
 
-    assert_nil Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).remove_a_record('some.host')
-  end
-
-  def test_remove_address_record_raises_exception_if_host_does_not_exist
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:get_ipv4_address!).with('not_existing.example.com').raises(Proxy::Dns::NotFound)
-    assert_raise Proxy::Dns::NotFound do
-      Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).remove_a_record('not_existing.example.com')
-    end
+    assert_nil Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).do_remove('some.host', 'A')
   end
 
   def test_remove_aaaa_record
@@ -124,23 +73,17 @@ class DnsNsupdateTest < Test::Unit::TestCase
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update delete some.host AAAA').returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_disconnect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_close)
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:get_ipv6_address!).with('some.host').returns('2001:db8::1')
 
-    assert_nil Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).remove_aaaa_record('some.host')
+    assert_nil Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).do_remove('some.host', 'AAAA')
   end
 
-  def test_remove_aaaa_record_raises_exception_if_host_does_not_exist
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:get_ipv6_address!).with('not_existing.example.com').raises(Proxy::Dns::NotFound)
-    assert_raise Proxy::Dns::NotFound do
-      Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).remove_aaaa_record('not_existing.example.com')
-    end
-  end
+  def test_remove_cname_record
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_connect).returns(true)
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update delete alias.host CNAME').returns(true)
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_disconnect).returns(true)
+    Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_close)
 
-  def test_remove_ptr_record_raises_exception_if_host_does_not_exist
-    Proxy::Dns::Nsupdate::Record.any_instance.expects(:get_name!).with('33.33.168.192.in-addr.arpa').raises(Proxy::Dns::NotFound)
-    assert_raise Proxy::Dns::NotFound do
-      Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).remove_ptr_record('33.33.168.192.in-addr.arpa')
-    end
+    assert_nil Proxy::Dns::Nsupdate::Record.new('a_server', 999, nil).do_remove('alias.host', 'CNAME')
   end
 
   def test_uses_dns_key_if_defined


### PR DESCRIPTION
This includes https://github.com/theforeman/smart-proxy/pull/491 because it makes the diff of the actual patch smaller.