### PR TITLE
Fixes #18209 - Destroy DHCP lease only when its found

### DIFF
--- a/modules/dhcp_libvirt/dhcp_libvirt_main.rb
+++ b/modules/dhcp_libvirt/dhcp_libvirt_main.rb
@@ -92,5 +92,10 @@ module Proxy::DHCP::Libvirt
       logger.error msg = "Error removing DHCP record: #{e}"
       raise Proxy::DHCP::Error, msg
     end
+
+    def find_record(_, record)
+      return unless libvirt_network.leased_ip?(record.ip)
+      super(_, record)
+    end
   end
 end

--- a/modules/dhcp_libvirt/libvirt_dhcp_network.rb
+++ b/modules/dhcp_libvirt/libvirt_dhcp_network.rb
@@ -22,5 +22,9 @@ module ::Proxy::DHCP::Libvirt
       xml = "<host mac=\"#{record.mac}\" ip=\"#{record.ip}\" #{nametag}/>"
       network_update ::Libvirt::Network::UPDATE_COMMAND_DELETE, ::Libvirt::Network::NETWORK_SECTION_IP_DHCP_HOST, xml
     end
+
+    def leased_ip?(ip)
+      !dhcp_leases.select { |lease| lease['ip'] == ip }.empty?
+    end
   end
 end


### PR DESCRIPTION
Currently it's possible to find a DHCP record in libvirt, but at
deletion time it might not be on the leases for that IP. Such operation
fails with a 400 error now with

=> #&lt;Libvirt::Error: Call to virNetworkUpdate failed: Requested
operation is not valid: couldn't locate a matching dhcp host entry in
network 'vagrant-libvirt'&gt;

To fix it, I've modified the search method to take into account the
leases list.