### PR TITLE
Fixes #18210 - Nametag shouldnt be set if record has no name

### DIFF
--- a/modules/dhcp_libvirt/libvirt_dhcp_network.rb
+++ b/modules/dhcp_libvirt/libvirt_dhcp_network.rb
@@ -12,15 +12,21 @@ module ::Proxy::DHCP::Libvirt
     end
 
     def add_dhcp_record(record)
-      nametag = "name=\"#{record.name}\"" if record.name
+      nametag = get_nametag(record)
       xml = "<host mac=\"#{record.mac}\" ip=\"#{record.ip}\" #{nametag}/>"
       network_update ::Libvirt::Network::UPDATE_COMMAND_ADD_LAST, ::Libvirt::Network::NETWORK_SECTION_IP_DHCP_HOST, xml
     end
 
     def del_dhcp_record(record)
-      nametag = "name=\"#{record.name}\"" if record.name
+      nametag = get_nametag(record)
       xml = "<host mac=\"#{record.mac}\" ip=\"#{record.ip}\" #{nametag}/>"
       network_update ::Libvirt::Network::UPDATE_COMMAND_DELETE, ::Libvirt::Network::NETWORK_SECTION_IP_DHCP_HOST, xml
+    end
+
+    private
+
+    def get_nametag(record)
+      "name=\"#{record.name}\"" if record.respond_to?(:name) && record.name
     end
   end
 end


### PR DESCRIPTION
To set the nametag we call record.name, which might not be available.
In such a case, record.name fails with

] pry(#<Proxy::DHCP::Libvirt::LibvirtDHCPNetwork>)> record.name
0x005654f2c66798>

and the entire deletion fails. It should not call .name if it's not
there.