### PR TITLE
Fixes #18290 - increased puppet classes api timeout

### DIFF
--- a/config/settings.d/puppet_proxy_puppet_api.yml.example
+++ b/config/settings.d/puppet_proxy_puppet_api.yml.example
@@ -12,3 +12,6 @@
 #:puppet_ssl_ca: /var/lib/puppet/ssl/certs/ca.pem
 #:puppet_ssl_cert: /var/lib/puppet/ssl/certs/puppet.example.com.pem
 #:puppet_ssl_key: /var/lib/puppet/ssl/private_keys/puppet.example.com.pem
+#
+# Smart Proxy api timeout when Puppet's environment classes api is used and classes cache is disabled
+#:api_timeout: 30

--- a/modules/puppet_proxy_puppet_api/plugin_configuration.rb
+++ b/modules/puppet_proxy_puppet_api/plugin_configuration.rb
@@ -34,7 +34,8 @@ module ::Proxy::PuppetApi
                                                     settings[:puppet_url],
                                                     settings[:puppet_ssl_ca],
                                                     settings[:puppet_ssl_cert],
-                                                    settings[:puppet_ssl_key])
+                                                    settings[:puppet_ssl_key],
+                                                    settings[:api_timeout])
                                                 end)
         container_instance.dependency :class_cache_initializer,
                                       (lambda do

--- a/modules/puppet_proxy_puppet_api/puppet_proxy_puppet_api_plugin.rb
+++ b/modules/puppet_proxy_puppet_api/puppet_proxy_puppet_api_plugin.rb
@@ -1,6 +1,6 @@
 module Proxy::PuppetApi
   class Plugin < Proxy::Provider
-    default_settings :puppet_ssl_ca => '/var/lib/puppet/ssl/certs/ca.pem'
+    default_settings :puppet_ssl_ca => '/var/lib/puppet/ssl/certs/ca.pem', :api_timeout => 30
 
     plugin :puppet_proxy_puppet_api, ::Proxy::VERSION
 

--- a/test/puppet/puppet_api_configuration_test.rb
+++ b/test/puppet/puppet_api_configuration_test.rb
@@ -19,6 +19,7 @@ class PuppetApiDefaultSettingsTest < Test::Unit::TestCase
   def test_default_settings
     Proxy::PuppetApi::Plugin.load_test_settings({})
     assert_equal '/var/lib/puppet/ssl/certs/ca.pem', Proxy::PuppetApi::Plugin.settings.puppet_ssl_ca
+    assert_equal 30, Proxy::PuppetApi::Plugin.settings.api_timeout
   end
 end
 
@@ -67,6 +68,7 @@ class PuppetApiDIWiringsTest < Test::Unit::TestCase
                                                      :puppet_ssl_ca => "path_to_ca_cert",
                                                      :puppet_ssl_cert => "path_to_ssl_cert",
                                                      :puppet_ssl_key => "path_to_ssl_key",
+                                                     :api_timeout => 100,
                                                      :puppet_version => "4.4")
 
     assert @container.get_dependency(:class_retriever_impl).instance_of?(::Proxy::PuppetApi::V3EnvironmentClassesApiClassesRetriever)
@@ -74,5 +76,6 @@ class PuppetApiDIWiringsTest < Test::Unit::TestCase
     assert_equal "path_to_ca_cert", @container.get_dependency(:class_retriever_impl).ssl_ca
     assert_equal "path_to_ssl_cert", @container.get_dependency(:class_retriever_impl).ssl_cert
     assert_equal "path_to_ssl_key", @container.get_dependency(:class_retriever_impl).ssl_key
+    assert_equal 100, @container.get_dependency(:class_retriever_impl).api_timeout
   end
 end


### PR DESCRIPTION
But only when puppet server class cache is disabled. Additionally, a warning is logged to notify users about potenitally degraded performance.