### PR TITLE
Fixes #18398: Use consistent DNS parameter naming

### DIFF
--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -9,11 +9,11 @@ module Proxy::Dns::Dnscmd
       super(a_server, a_ttl)
     end
 
-    def do_create(name, value, type)
+    def do_create(name, content, type)
       zone = match_zone(name, enum_zones)
-      msg = "Added #{type} entry #{name} => #{value}"
-      value = "#{value}." if type == "PTR"
-      cmd = "/RecordAdd #{zone} #{name}. #{type} #{value}"
+      msg = "Added #{type} entry #{name} => #{content}"
+      content = "#{content}." if type == "PTR"
+      cmd = "/RecordAdd #{zone} #{name}. #{type} #{content}"
       execute(cmd, msg)
       nil
     end

--- a/modules/dns_libvirt/dns_libvirt_main.rb
+++ b/modules/dns_libvirt/dns_libvirt_main.rb
@@ -13,27 +13,27 @@ module Proxy::Dns::Libvirt
       super(@network)
     end
 
-    def create_a_record(fqdn, ip)
-      libvirt_network.add_dns_a_record fqdn, ip
+    def create_a_record(name, content)
+      libvirt_network.add_dns_a_record name, content
     rescue ::Libvirt::Error => e
       logger.error msg = "Error adding DNS A record: #{e}"
       raise Proxy::Dns::Error, msg
     end
     alias :create_aaaa_record :create_a_record
 
-    def create_ptr_record(fqdn, ip)
+    def create_ptr_record(name, content)
       # libvirt does not support PTR
     end
 
-    def remove_a_record(fqdn)
-      libvirt_network.del_dns_a_record fqdn, find_ip_for_host(fqdn)
+    def remove_a_record(name)
+      libvirt_network.del_dns_a_record name, find_ip_for_host(fqdn)
     rescue ::Libvirt::Error => e
       logger.error msg = "Error adding DNS A record: #{e}"
       raise Proxy::Dns::Error, msg
     end
     alias :remove_aaaa_record :remove_a_record
 
-    def remove_ptr_record(ip)
+    def remove_ptr_record(name)
       # libvirt does not support PTR
     end
 

--- a/modules/dns_nsupdate/dns_nsupdate_main.rb
+++ b/modules/dns_nsupdate/dns_nsupdate_main.rb
@@ -12,18 +12,18 @@ module Proxy::Dns::Nsupdate
       super(a_server, a_ttl)
     end
 
-    def do_create(id, value, type)
+    def do_create(name, content, type)
       nsupdate_connect
-      nsupdate "update add #{id}. #{@ttl} #{type} #{value}"
+      nsupdate "update add #{name}. #{@ttl} #{type} #{content}"
       nsupdate_disconnect
       nil
     ensure
       nsupdate_close
     end
 
-    def do_remove(id, type)
+    def do_remove(name, type)
       nsupdate_connect
-      nsupdate "update delete #{id} #{type}"
+      nsupdate "update delete #{name} #{type}"
       nsupdate_disconnect
       nil
     ensure


### PR DESCRIPTION
* fqdn is what is defined in the API and should only be in dns_api.rb
* value is what is defined in the API and should only be in dns_api.rb
* name is the DNS name you query for
* content is the result your DNS server should return

This should avoid confusion with types where the content is also a valid
hostname so fqdn is ambigious.