### PR TITLE
Fixes #18443: Introduce Webhook realm provider

### DIFF
--- a/config/settings.d/realm_webhook.yml.example
+++ b/config/settings.d/realm_webhook.yml.example
@@ -1,0 +1,37 @@
+---
+# Host parameters, mandatory
+:host: localhost
+:port: 9090
+:path: /hooks
+
+# Will both default to true
+:use_ssl: false
+:verify_ssl: false
+
+# Additional headers
+:headers:
+  HTTP_X_ACME_SENDER: foreman
+  Content-Type: application/vnd.acme.hostevent+json
+
+# If signing is enabled an header within every request
+# will contain a HMAC hashed version of the request body to enable
+# the Webhook server to verify the origin using the shared secret.
+# See https://developer.github.com/webhooks/securing/
+# Algorithms: md2, md4, md5, SHA, sha1, sha224, sha256, sha384, sha512
+# See https://ruby-doc.org/stdlib-2.0.0/libdoc/openssl/rdoc/OpenSSL/Digest.html
+:signing:
+  :enabled: true
+  :algorithm: sha512
+  :secret: secret_shared_with_webhook_server
+  :header_name: HTTP_X_ACME_SIGNATURE
+
+# The keys to use in the JSON body are defined here.
+# :operation is either "create" or "delete"
+# :hostname is the name of the host of interest
+# :params will contain a hash of other parameters
+# This example configuration results in something like:
+# {"action":"create","hostname":"host.foo","parameters":{...}}
+:json_keys:
+  :operation: action
+  :hostname: hostname
+  :params: parameters

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -79,6 +79,7 @@ module Proxy
   require 'bmc/bmc'
   require 'realm/realm'
   require 'realm_freeipa/realm_freeipa'
+  require 'realm_webhook/realm_webhook'
   require 'logs/logs'
 
   def self.version

--- a/modules/realm_webhook/configuration_loader.rb
+++ b/modules/realm_webhook/configuration_loader.rb
@@ -1,0 +1,11 @@
+module Proxy::WebhookRealm
+  class ConfigurationLoader
+    def load_classes
+      require 'realm_webhook/provider'
+    end
+
+    def load_dependency_injection_wirings(container_instance, settings)
+      container_instance.dependency :realm_provider_impl, lambda {::Proxy::WebhookRealm::Provider.new(settings)}
+    end
+  end
+end

--- a/modules/realm_webhook/provider.rb
+++ b/modules/realm_webhook/provider.rb
@@ -1,0 +1,66 @@
+require 'net/https'
+require 'openssl'
+
+module Proxy::WebhookRealm
+  class Provider
+    def initialize(config)
+      @config = config
+    end
+
+    def configure_webhook
+      wh = Net::HTTP.new(config[:host], config[:port])
+      wh.use_ssl = config[:use_ssl]
+      wh.verify_mode = OpenSSL::SSL::VERIFY_NONE unless config[:verify_ssl]
+      wh
+    end
+
+    def construct_request operation, hostname, params
+      req = Net::HTTP::Post.new(config[:path])
+      data = JSON.generate(config[:json_keys][:params] => params, config[:json_keys][:operation] => operation, config[:json_keys][:hostname] => hostname) # Sending all params
+      req.body = data
+      if config[:signing][:enabled]
+        req[config[:signing][:header_name]] = "sha1=#{hmac(data)}"
+      end
+      req["User-Agent"] = "Foreman Smart Proxy"
+      req["Accept"] = "application/json"
+      req["Content-Type"] = "application/json"
+      config[:headers].each { |k,v| req[k] = v }
+      req
+    end
+
+    def create realm, hostname, params
+      params.delete("hostname")
+      request "create", hostname, params
+    end
+
+    def delete realm, hostname
+      request "delete", hostname, {}
+    end
+
+    def find hostname
+      {}
+    end
+
+    private
+
+    def config
+      @config
+    end
+
+    def webhook
+      @webhook ||= configure_webhook
+    end
+
+    def hmac data
+      OpenSSL::HMAC.hexdigest(
+        OpenSSL::Digest.new(config[:signing][:algorithm]),
+        config[:signing][:secret],
+        data
+      )
+    end
+
+    def request operation, hostname, params
+      webhook.request(construct_request(operation, hostname, params)).body
+    end
+  end
+end

--- a/modules/realm_webhook/realm_webhook.rb
+++ b/modules/realm_webhook/realm_webhook.rb
@@ -1,0 +1,2 @@
+require 'realm_webhook/configuration_loader'
+require 'realm_webhook/realm_webhook_plugin'

--- a/modules/realm_webhook/realm_webhook_plugin.rb
+++ b/modules/realm_webhook/realm_webhook_plugin.rb
@@ -1,0 +1,11 @@
+module Proxy::WebhookRealm
+  class Plugin < Proxy::Provider
+    load_classes ::Proxy::WebhookRealm::ConfigurationLoader
+    load_dependency_injection_wirings ::Proxy::WebhookRealm::ConfigurationLoader
+
+    default_settings headers: {}, use_ssl: true, verify_ssl: true, signing: {enabled: false}, json_keys: {operation: "operation", hostname: "hostname", params: "params"}
+    validate_presence :host, :port, :path
+
+    plugin :realm_webhook, ::Proxy::VERSION
+  end
+end

--- a/test/realm/webhook_provider_test.rb
+++ b/test/realm/webhook_provider_test.rb
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+require 'test_helper'
+require 'realm_webhook/provider'
+
+class WebhookTest < Test::Unit::TestCase
+  DEFAULT_CONFIG = {
+    host: "localhost",
+    port: 9999,
+    path: "/hooks",
+    use_ssl: true,
+    verify_ssl: false,
+    headers: {},
+    signing: {
+      enabled: false
+    },
+    json_keys: {
+      operation: "operation",
+      hostname: "hostname",
+      params: "params"
+    }
+  }
+  def test_find
+    provider = Proxy::WebhookRealm::Provider.new(DEFAULT_CONFIG)
+    assert_equal provider.find("Host"), {}
+  end
+
+  def test_construct_request
+    provider = Proxy::WebhookRealm::Provider.new(DEFAULT_CONFIG)
+    params = {"a" => "a", "b" => "b"}
+    req = provider.construct_request("foo", "bar.host", params)
+    assert_equal JSON.parse(req.body), {"operation" => "foo", "hostname" => "bar.host", "params" => params}
+    assert_equal req["Content-Type"], "application/json"
+    assert_equal req["Accept"], "application/json"
+    assert_equal req["User-Agent"], "Foreman Smart Proxy"
+    assert_equal req.path, "/hooks"
+
+    config = DEFAULT_CONFIG.merge({
+      headers: {
+        "X-ACME-Auth" => "token",
+        "Content-Type" => "application/vnd.acme.foo+json"
+      },
+      signing: {
+        enabled: true,
+        algorithm: "sha1",
+        secret: "some_secret",
+        header_name: "X-ACME-SIGNATURE"
+      }
+    })
+    provider = Proxy::WebhookRealm::Provider.new(config)
+    req = provider.construct_request "bar", "foo.host", params
+    assert_equal JSON.parse(req.body), {"operation" => "bar", "hostname" => "foo.host", "params" => params}
+    assert_equal req["Content-Type"], "application/vnd.acme.foo+json"
+    assert_equal req["Accept"], "application/json"
+    assert_equal req["User-Agent"], "Foreman Smart Proxy"
+    assert_equal req["X-ACME-Auth"], "token"
+    assert_equal req["X-ACME-SIGNATURE"], "sha1=65167b13f5e9c5bd5f4cad9ceba1adee45ff7327"
+  end
+
+  def test_create
+    provider = Proxy::WebhookRealm::Provider.new(DEFAULT_CONFIG)
+    provider.expects(:request).with("create", "a_host", {"a" => "a"}).returns("somedata")
+    assert_equal "somedata", provider.create("test", 'a_host', {"a" => "a"})
+  end
+
+  def test_delete
+    provider = Proxy::WebhookRealm::Provider.new(DEFAULT_CONFIG)
+    provider.expects(:request).with("delete", "a_host", {}).returns("somedata")
+    assert_equal "somedata", provider.delete("test", 'a_host')
+  end
+
+  def test_configure_webhook
+    provider = Proxy::WebhookRealm::Provider.new(DEFAULT_CONFIG)
+    wh = provider.configure_webhook
+    assert_equal wh.port, 9999
+    assert_equal wh.address, "localhost"
+    assert_equal wh.use_ssl?, true
+    assert_equal wh.verify_mode, OpenSSL::SSL::VERIFY_NONE
+  end
+end


### PR DESCRIPTION
Generic realm provider notifying other services/realms about the creation or deletion of hosts via HTTP Webhooks. (See redmine ticket, too)

This provider is able to send custumizable HTTP POST-requests ("Webhook") to a HTTP-Server. E.g.

```json
{"operation":"create","hostname":"host.lan","params":{"userclass":"User class",...}}
```

The HTTP-Server should respond with JSON, too. E.g. on creation:
```json
{"randompassword": "foo"}
```

As Webhooks are not a strict standard, the HTTP headers can be extended and the JSON keys in the body are also customizable.

There is opt-in support for a request signing procedure described in https://developer.github.com/webhooks/securing/