### PR TITLE
Fixes #18399 - use warning instead when cache init fails

### DIFF
--- a/modules/puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever.rb
+++ b/modules/puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever.rb
@@ -121,7 +121,7 @@ class Proxy::PuppetApi::EnvironmentClassesCacheInitializer
                        end
                        .flat_map { |futures| Concurrent::Promise.all?(*futures) }
                        .then { logger.info("Finished puppet class cache initialization") }
-                       .on_error { logger.error("Failed to initialize puppet class cache, will use lazy initialization instead") }
+                       .on_error { logger.warning("Failed to initialize puppet class cache, deferring initialization. Is puppetserver running?") }
                        .execute
   end
 end


### PR DESCRIPTION
With a clearer message. Currently, when such an issue occurs, users aren't clear about what they need to do to correct the error.