### PR TITLE
Fixes #992 - Make NFS a recognized protocol

### DIFF
--- a/test/tftp/tftp_test.rb
+++ b/test/tftp/tftp_test.rb
@@ -49,4 +49,23 @@ class TftpTest < Test::Unit::TestCase
   def test_boot_filename_uses_dash_when_prefix_does_not_end_with_slash
     assert_equal "a/b/c-somefile", Proxy::TFTP.boot_filename('a/b/c', '/d/somefile')
   end
+
+  def test_choose_protocol_and_fetch_wget
+    ::Proxy::HttpDownload.any_instance.expects(:start).returns(true).times(3)
+    %w(http://proxy.test https://proxy.test ftp://proxy.test).each do |src|
+      Proxy::TFTP.choose_protocol_and_fetch src, '/destination'
+    end
+  end
+
+  def test_choose_protocol_and_fetch_nfs
+    assert_nothing_raised RuntimeError do
+      Proxy::TFTP.choose_protocol_and_fetch 'nfs://proxy.test', '/destination'
+    end
+  end
+
+  def test_choose_protocol_and_fetch_unknown
+    assert_raises RuntimeError do
+      Proxy::TFTP.choose_protocol_and_fetch 'git://proxy.test', '/destination'
+    end
+  end
 end


### PR DESCRIPTION
Currently, if we use a medium with NFS path during provisioning, wget will fail because it cannot handle nfs.
```
16934 D, [2017-03-21T13:30:35.699595 ] DEBUG -- : Starting task: /usr/bin/wget --timeout=10 --tries=3 --no-check-certificate -nv -c "nfs://nfs-server/nfs-path/nfs-subdir/images/pxeboot/initrd.img" -O "/var/oprazak_tftproot/boot/NFS-7-x86_64-initrd.img"
16935 I, [2017-03-21T13:30:35.699901 ]  INFO -- : 192.168.100.136 - - [21/Mar/2017 13:30:35] "POST /tftp/fetch_boot_file HTTP/1.1" 200 - 0.0013
16937 D, [2017-03-21T13:30:35.708337 ] DEBUG -- : close: 192.168.100.136:58232
16938 E, [2017-03-21T13:30:35.709638 ] ERROR -- : [15621] nfs://nfs-server/nfs-path/nfs-subdir/images/pxeboot/initrd.img: Unsupported scheme ‘nfs’.
```

This allows using NFS in semi-automatic way:

1. create a Medium: path - nfs://nfs-server/nfs-medium
2. create Operating System: name - Custom, version - 7, Architecture - x86_64, add installation medium created in previous step
3. copy images/pxeboot/initrd.img and images/pxeboot/vmlinuz from your NFS-shared medium to /var/lib/tftpboot/boot on your proxy. Make sure the newly copied files have names corresponding to your OS (Custom-7-x86_64-initrd.img and Custom-7-x86_64-vmlinuz for OS created in step 2). Files should be owned by foreman-proxy user and have 544 permissions.
4. try to provision a new host with your NFS medium. When everything is configured correctly, proxy will serve the files you just copied and installer will mount the NFS medium for installation.
