### PR TITLE
Fixes #19104 - ignore tagged includes for ISC DHCP

### DIFF
--- a/modules/dhcp_common/isc/configuration_file.rb
+++ b/modules/dhcp_common/isc/configuration_file.rb
@@ -27,10 +27,12 @@ module Proxy::DHCP::CommonISC
 
         if /^include\s+"(.*)"\s*;.*/ =~ line
           conf = $1
-          raise "Unable to find the included DHCP configuration file: #{conf}" unless File.exist?(conf)
-          # concat modifies the receiver rather than creating a new array
-          # and does not create a multidimensional array
-          to_return.concat([File.open(conf, 'r') {|f| load(f)}])
+          if conf !~ /\/ignored-by-foreman\//
+            raise "Unable to find the included DHCP configuration file: #{conf}" unless File.exist?(conf)
+            # concat modifies the receiver rather than creating a new array
+            # and does not create a multidimensional array
+            to_return.concat([File.open(conf, 'r') {|f| load(f)}])
+          end
         else
           to_return << line
         end

--- a/test/dhcp/isc_configuration_file_test.rb
+++ b/test/dhcp/isc_configuration_file_test.rb
@@ -18,6 +18,12 @@ class IscConfigurationFileTest < Test::Unit::TestCase
     assert whole_config.include?("host test.example.com")
   end
 
+  def test_read_config_file_ignores_some_includes
+    whole_config = @config.load(StringIO.new("# Test that the ISC DHCP config file parser include ignore\ninclude \"test/fixtures/ignored-by-foreman/dhcp_subnets.conf\";"))
+    refute whole_config.include?("subnet 192.168.122.0 netmask 255.255.255.0")
+    refute whole_config.include?("host test.example.com")
+  end
+
   def test_read_config_file_should_raise_error_if_included_file_isn_not_readable
     assert_raises(RuntimeError) { @config.load(StringIO.new("include \"non_existent_config\";")) }
   end


### PR DESCRIPTION
Our parser limitations is a real pain, I stubmbled this upon at customer again. This is a simple idea to allow at least workarounding this by including files from a directory with "igored-by-foreman" element. All these files will not be included at all, so the workaround is then:

```
subnet XYZ {
    valid_syntax;
    include "/etc/dhcpd/ignored-by-foreman/invalid_subnet_xyz.conf"
}
```