### PR TITLE
Update register-service.rb

### DIFF
--- a/extra/register-service.rb
+++ b/extra/register-service.rb
@@ -23,10 +23,10 @@ default_user         = ENV["USERDOMAIN"] + '\\' + default_user if ENV["USERDOMAI
 default_service_name = 'smart proxy'
 
 puts "This service must be run under an account that is a member of 'DHCP Administrators' group"
-puts 'The acount can be local or a domain account. If it is a domain account then use the domain\account syntax'
-service_name = ask("Enter the name of the service ")  {|s| s.default = default_service_name}
-user         = ask("Run this service as this user? ") {|u| u.default = default_user}
-pass1        = ask("Enter the user's password ") {|p| p.echo = "x"}
+puts 'The account can be local or a domain account. If it is a domain account then use the domain\account syntax'
+service_name = ask("Enter the name of the service. ")  {|s| s.default = default_service_name}
+user         = ask("Enter the user to run the service as, or press enter to use the following user: ") {|u| u.default = default_user}
+pass1        = ask("Enter the user's password. ") {|p| p.echo = "x"}
 
 description = 'Foreman Smart Proxy'
 description += " (#{service_name})" unless service_name == default_service_name

--- a/extra/register-service.rb
+++ b/extra/register-service.rb
@@ -25,7 +25,7 @@ default_service_name = 'smart proxy'
 puts "This service must be run under an account that is a member of 'DHCP Administrators' group"
 puts 'The account can be local or a domain account. If it is a domain account then use the domain\account syntax'
 service_name = ask("Enter the name of the service. ")  {|s| s.default = default_service_name}
-user         = ask("Enter the user to run the service as, or press enter to use the following user: ") {|u| u.default = default_user}
+user         = ask("Enter the user to run the service as: ") {|u| u.default = default_user}
 pass1        = ask("Enter the user's password. ") {|p| p.echo = "x"}
 
 description = 'Foreman Smart Proxy'


### PR DESCRIPTION
The question asking what user to run as was confusing for us as it defaults on the screen to "default user/logged in user", and was presented in a manner making a user think it's a yes or no question.  There are numerous other reasons why the windows service might fail to get created.  We thought for the longest time it was because the service creation file (this file), didnt allow a domain\username to be entered.  It wasn't until we looked at the file that we realized its not a yes or no question, but asking what user you want use (and only showing what the current default would be if you hit enter).

Also, account was spelled wrong.