### PR TITLE
Fixes #19205 - Add IPMI IP scanning to BMC API

### DIFF
--- a/config/settings.d/bmc.yml.example
+++ b/config/settings.d/bmc.yml.example
@@ -17,3 +17,20 @@
 #:bmc_ssh_powercycle: "shutdown -r +1"
 #:bmc_ssh_poweroff: "shutdown +1"
 #:bmc_ssh_poweron: "false"
+
+#####################################
+# Settings for scanner at /bmc/scan #
+#####################################
+# The largest number of IP addresses that may be scanned in one request. Set
+# this value to 0 to turn off the scanner.  Defaults to 65536, which covers a
+# CIDR prefixlen of /16.
+#:bmc_scanner_max_range_size: 65536
+
+# The maximum number of IP addresses to scan at the same time, per request.
+# Defaults to 500.  Before increasing this number, you should increase the
+# maximum number of open files for Smart Proxy.
+#:bmc_scanner_max_threads_per_request: 500
+
+# How many seconds to wait for each scanned IP address to respond before timing
+# out. Defaults to 1.
+#:bmc_scanner_socket_timeout_seconds: 1

--- a/modules/bmc/basescanner.rb
+++ b/modules/bmc/basescanner.rb
@@ -1,0 +1,50 @@
+require 'ipaddr'
+
+module Proxy
+  module BMC
+    # This is the interface for scanning BMC IP address ranges.
+    class BaseScanner
+      def initialize(args = { })
+        if args.key? :address_first
+          address_first = IPAddr.new args[:address_first]
+          address_last  = IPAddr.new args[:address_last]
+          @range = (address_first..address_last)
+        elsif args.key?(:address) && args.key?(:netmask)
+          @range = IPAddr.new("#{args[:address]}/#{args[:netmask]}").to_range
+        else
+          @range = IPAddr.new(args[:address]).to_range
+        end
+        # Disallow range too large
+        scanner_max_range_size = max_range_size
+        if @range.first(scanner_max_range_size+1).size > scanner_max_range_size
+          @range = nil
+          @invalid_reason = "Range too large. Batch supports only #{scanner_max_range_size} IP addresses at a time."
+        end
+      rescue
+        @range = nil
+        if args.is_a?(Hash) && args.key?(:address)
+          @invalid_reason = "Invalid CIDR provided"
+        else
+          @invalid_reason = "Invalid IP address provided"
+        end
+      end
+
+      def valid?
+        @range.is_a? Range
+      end
+
+      def error_string
+        @invalid_reason
+      end
+
+      def max_range_size
+        Proxy::BMC::Plugin.settings.bmc_scanner_max_range_size || 65_536
+      end
+
+      # Run the scanner and return results as array
+      def scan_to_list
+        raise NotImplementedError.new
+      end
+    end
+  end
+end

--- a/modules/bmc/bmc_api.rb
+++ b/modules/bmc/bmc_api.rb
@@ -1,4 +1,5 @@
 require 'bmc/ipmi'
+require 'bmc/ipmiscanner'
 
 module Proxy::BMC
   class Api < ::Sinatra::Base
@@ -31,6 +32,40 @@ module Proxy::BMC
     # returns a helpful message that the user should supply a hostname
     get "/host" do
       { :message => "You need to supply the hostname or ip of the actual bmc device"}.to_json
+    end
+
+    # Scan IP range for BMC hosts
+    # Returns a list of available scanning options
+    get "/scan" do
+      { :available_resources => %w[range cidr] }.to_json
+    end
+
+    # Returns a helpful message that the user should supply a beginning IP and ending IP
+    get "/scan/range" do
+      { :message => "You need to supply a range with /bmc/scan/range/:address_first/:address_last"}.to_json
+    end
+
+    # Returns a helpful message that the user should supply a CIDR
+    get "/scan/cidr" do
+      { :message => "You need to supply a CIDR with /bmc/scan/cidr/:address/:netmask (e.g. \"192.168.1.1/24\" or \"192.168.1.1/255.255.255.0\")"}.to_json
+    end
+
+    get "/scan/range/:address_first/?:address_last?" do
+      bmc_setup
+      if !@scanner.valid?
+        { :error => @scanner.error_string}.to_json
+      else
+        { :result => @scanner.scan_to_list}.to_json
+      end
+    end
+
+    get "/scan/cidr/:address/?:netmask?" do
+      bmc_setup
+      if !@scanner.valid?
+        { :error => @scanner.error_string}.to_json
+      else
+        { :result => @scanner.scan_to_list}.to_json
+      end
     end
 
     # returns host operations
@@ -277,6 +312,21 @@ module Proxy::BMC
 
       case provider_type
         when 'freeipmi', 'ipmitool'
+          # /scan/cidr/:address/:netmask
+          if params.key? "address"
+            args = { :address => params[:address],
+                     :netmask => params[:netmask] }
+            @scanner = Proxy::BMC::IPMIScanner.new(args)
+            return
+          # /scan/range/:address_first/:address_last
+          elsif params.key? "address_first"
+            args = { :address_first => params[:address_first],
+                     :address_last  => params[:address_last] }
+            @scanner = Proxy::BMC::IPMIScanner.new(args)
+            return
+          end
+
+          # /:host
           log_halt 401, "unauthorized" unless auth.provided?
           log_halt 401, "bad_authentication_request, credentials are not in auth.basic format" unless auth.basic?
           username, password = auth.credentials

--- a/modules/bmc/ipmiscanner.rb
+++ b/modules/bmc/ipmiscanner.rb
@@ -1,0 +1,82 @@
+require 'bmc/basescanner'
+require 'concurrent'
+require 'bmc/bmc_plugin'
+
+module Proxy
+  module BMC
+    class IPMIScanner < BaseScanner
+      include Proxy::Log
+      include Proxy::Util
+
+      # This is an IPMI ping, not an ICMP ping.
+      def address_pings?(address)
+        begin
+          socket = UDPSocket.new
+        rescue Errno::EMFILE
+          logger.warn "IPMIScanner: Ran out of free file descriptors while creating UDPSocket! Consider increasing file open limit."
+          retry
+        end
+        socket.connect(address.to_s, 623)
+        socket.send([0x6, 0x0, 0xff, 0x6, 0x0, 0x0, 0x11, 0xbe, 0x80, 0x0, 0x0, 0x0].pack('C*'), 0)
+        selections = IO.select([socket], nil, nil, (Proxy::BMC::Plugin.settings.bmc_scanner_socket_timeout_seconds || 1))
+        socket.close
+        !selections.nil?
+      end
+
+      # Not used because of slowness
+      def scan_unthreaded_to_list
+        return false if !valid?
+        pinged = Array.new
+        @range.each do |address|
+          if address_pings?(address)
+            pinged << address
+          end
+        end
+        pinged
+      end
+
+      # Determine maximum number of threads
+      def calculate_max_threads
+        max_threads = Proxy::BMC::Plugin.settings.bmc_scanner_max_threads_per_request || 500
+        begin
+          sockets = Array.new
+          # @range.first(max_threads).size performs much better than @range.count if @range is large.
+          (1..[max_threads, @range.first(max_threads).size].min).each do
+            socket = UDPSocket.new
+            sockets << socket
+          end
+        rescue Errno::EMFILE
+          # Running low on free file descriptors; only allow use of half of the remaining
+          max_threads = [sockets.length / 2, 1].max
+          # Clean up sockets
+          sockets.each do |sock|
+            sock.close
+          end
+          logger.warn "IPMIScanner: Running low on free file descriptors! Can only allocate #{sockets.length}, so using #{max_threads} to avoid hitting the limit."
+        end
+        max_threads
+      end
+
+      def scan_threaded_to_list
+        return false if !valid?
+        pinged = Array.new
+        pool = Concurrent::ThreadPoolExecutor.new(max_threads: calculate_max_threads)
+        @range.each do |address|
+          pool.post do
+            if address_pings?(address)
+              pinged << address
+            end
+          end
+        end
+        pool.shutdown
+        pool.wait_for_termination
+        pinged
+      end
+
+      def scan_to_list
+        return false if !valid?
+        scan_threaded_to_list
+      end
+    end
+  end
+end

--- a/test/bmc/bmc_api_test.rb
+++ b/test/bmc/bmc_api_test.rb
@@ -492,6 +492,142 @@ class BmcApiTest < Test::Unit::TestCase
     assert_match(/not a valid/, data["error"])
   end
 
+# /scan
+  def test_api_scan_can_get_resources
+    get "/scan", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    expected = ['range', 'cidr']
+    assert_equal(expected, data["available_resources"])
+  end
+
+# /scan/range
+  def test_api_scan_range_returns_help
+    get "/scan/range", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/You need to supply a range/, data["message"])
+  end
+
+  def test_api_scan_range_returns_error_when_invalid_first_address_provided
+    get "/scan/range/bogus/192.168.1.254", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/nvalid IP address provided/, data["error"])
+  end
+
+  def test_api_scan_range_returns_error_when_no_second_address_provided
+    get "/scan/range/192.168.1.1", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/nvalid IP address provided/, data["error"])
+  end
+
+  def test_api_scan_range_returns_error_when_invalid_last_address_provided
+    get "/scan/range/192.168.1.1/bogus", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/nvalid IP address provided/, data["error"])
+  end
+
+  def test_api_scan_range_returns_error_when_range_too_large
+    Proxy::BMC::Plugin.settings.expects(:bmc_scanner_max_range_size).returns(256)
+    Proxy::BMC::IPMIScanner.any_instance.stubs(:scan_to_list).returns([])
+    get "/scan/range/15.0.0.0/16.255.255.255", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/too large/, data["error"])
+  end
+  
+  def test_api_scan_range_returns_list_when_valid_range_provided
+    Proxy::BMC::IPMIScanner.any_instance.expects(:scan_to_list).returns(['192.168.1.5', '192.168.1.10', '192.168.1.253'])
+    get "/scan/range/192.168.1.0/192.168.1.254", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal(data['result'].length, 3)
+    assert_send([data['result'], :include?, '192.168.1.5'])
+    assert_send([data['result'], :include?, '192.168.1.10'])
+    assert_send([data['result'], :include?, '192.168.1.253'])
+  end
+
+  def test_api_scan_range_returns_empty_list_when_scanner_returns_empty_list
+    Proxy::BMC::IPMIScanner.any_instance.expects(:scan_to_list).returns([])
+    get "/scan/range/192.168.1.0/192.168.1.254", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal(data['result'].length, 0)
+  end
+
+# /scan/cidr
+  def test_api_scan_cidr_returns_help
+    get "/scan/cidr", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/You need to supply a CIDR/, data["message"])
+  end
+
+  def test_api_scan_cidr_returns_error_when_invalid_address_provided
+    get "/scan/cidr/bogus/24", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/nvalid CIDR provided/, data["error"])
+  end
+
+  def test_api_scan_cidr_returns_error_when_invalid_netmask_provided
+    get "/scan/cidr/192.168.1.1/bogus", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/nvalid CIDR provided/, data["error"])
+  end
+
+  def test_api_scan_cidr_works_with_single_ip
+    Proxy::BMC::IPMIScanner.any_instance.expects(:scan_to_list).returns(['192.168.1.1'])
+    get "/scan/cidr/192.168.1.1", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal(data['result'].length, 1)
+    assert_send([data['result'], :include?, '192.168.1.1'])
+  end
+
+  def test_api_scan_cidr_returns_error_when_range_too_large
+    Proxy::BMC::Plugin.settings.expects(:bmc_scanner_max_range_size).returns(256)
+    Proxy::BMC::IPMIScanner.any_instance.stubs(:scan_to_list).returns([])
+    get "/scan/cidr/15.0.0.0/8", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_match(/too large/, data["error"])
+  end
+  
+  def test_api_scan_cidr_returns_list_when_prefixlen_range_provided
+    Proxy::BMC::IPMIScanner.any_instance.expects(:scan_to_list).returns(['192.168.1.5', '192.168.1.10', '192.168.1.253'])
+    get "/scan/cidr/192.168.1.0/24", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal(data['result'].length, 3)
+    assert_send([data['result'], :include?, '192.168.1.5'])
+    assert_send([data['result'], :include?, '192.168.1.10'])
+    assert_send([data['result'], :include?, '192.168.1.253'])
+  end
+
+  def test_api_scan_cidr_returns_list_when_dotdecimal_range_provided
+    Proxy::BMC::IPMIScanner.any_instance.expects(:scan_to_list).returns(['192.168.1.5', '192.168.1.10', '192.168.1.253'])
+    get "/scan/cidr/192.168.1.0/255.255.255.0", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal(data['result'].length, 3)
+    assert_send([data['result'], :include?, '192.168.1.5'])
+    assert_send([data['result'], :include?, '192.168.1.10'])
+    assert_send([data['result'], :include?, '192.168.1.253'])
+  end
+
+  def test_api_scan_cidr_returns_empty_list_when_scanner_returns_empty_list
+    Proxy::BMC::IPMIScanner.any_instance.expects(:scan_to_list).returns([])
+    get "/scan/cidr/192.168.1.0/255.255.255.0", args
+    assert last_response.ok?, "Last response was not ok"
+    data = JSON.parse(last_response.body)
+    assert_equal(data['result'].length, 0)
+  end
+
   private
   attr_reader :host, :args
 end

--- a/test/bmc/bmc_scanner_test.rb
+++ b/test/bmc/bmc_scanner_test.rb
@@ -1,0 +1,195 @@
+require 'test_helper'
+require 'bmc/ipmiscanner'
+require 'logger'
+
+class BmcScannerTest < Test::Unit::TestCase
+
+  def setup
+   @args = { :address_first => '192.168.1.2', :address_last => '192.168.1.7' }
+   @scanner = Proxy::BMC::IPMIScanner.new(@args)
+  end
+
+  def test_create_scanner_from_combined_argument
+    args = { :address => '192.168.1.0/24' }
+    scanner = Proxy::BMC::IPMIScanner.new(args)
+    assert(scanner.valid?)
+    address_first = IPAddr.new '192.168.1.0'
+    address_last  = IPAddr.new '192.168.1.255'
+    assert_equal(scanner.instance_variable_get(:@range), (address_first..address_last))
+  end
+
+  def test_create_scanner_from_address_and_prefixlen
+    args = { :address => '192.168.1.0', :netmask => '24' }
+    scanner = Proxy::BMC::IPMIScanner.new(args)
+    assert(scanner.valid?)
+    address_first = IPAddr.new '192.168.1.0'
+    address_last  = IPAddr.new '192.168.1.255'
+    assert_equal(scanner.instance_variable_get(:@range), (address_first..address_last))
+  end
+
+  def test_create_scanner_from_address_and_netmask
+    args = { :address => '192.168.1.0', :netmask => '255.255.255.0' }
+    scanner = Proxy::BMC::IPMIScanner.new(args)
+    assert(scanner.valid?)
+    address_first = IPAddr.new '192.168.1.0'
+    address_last  = IPAddr.new '192.168.1.255'
+    assert_equal(scanner.instance_variable_get(:@range), (address_first..address_last))
+  end
+
+  def test_create_scanner_from_range
+    args = { :address_first => '192.168.1.0', :address_last => '192.168.1.255' }
+    scanner = Proxy::BMC::IPMIScanner.new(args)
+    assert(scanner.valid?)
+    address_first = IPAddr.new '192.168.1.0'
+    address_last  = IPAddr.new '192.168.1.255'
+    assert_equal(scanner.instance_variable_get(:@range), (address_first..address_last))
+  end
+
+  def test_fail_create_scanner_from_invalid_argument
+    scanner = Proxy::BMC::IPMIScanner.new('bogus')
+    assert !scanner.valid?
+    assert scanner.instance_variable_get(:@range).nil?
+  end
+
+  def test_fail_create_scanner_when_range_too_large_with_default_max_range_size
+    Proxy::BMC::Plugin.settings.expects(:bmc_scanner_max_range_size).returns(nil)
+    args = { :address_first => '15.0.0.0', :address_last => '16.255.255.255' }
+    scanner = Proxy::BMC::IPMIScanner.new(args)
+    assert !scanner.valid?
+    assert scanner.instance_variable_get(:@range).nil?
+  end
+
+  def test_fail_create_scanner_when_range_too_large_with_custom_max_range_size
+    Proxy::BMC::Plugin.settings.expects(:bmc_scanner_max_range_size).returns(8)
+    args = { :address_first => '15.0.0.0', :address_last => '15.0.0.9' }
+    scanner = Proxy::BMC::IPMIScanner.new(args)
+    assert !scanner.valid?
+    assert scanner.instance_variable_get(:@range).nil?
+  end
+
+  def test_fail_scan_when_scanner_not_valid
+    scanner = Proxy::BMC::IPMIScanner.new('bogus')
+    assert !scanner.valid?
+    assert !scanner.scan_to_list
+  end
+
+  def test_address_pings
+    mock_socket = mock()
+    mock_socket.expects(:connect).returns(true)
+    mock_socket.expects(:send).returns(nil)
+    mock_socket.expects(:close).returns(true)
+    UDPSocket.stubs(:new).returns(mock_socket)
+    IO.expects(:select).returns([mock_socket, nil, nil])
+    assert @scanner.address_pings?('192.168.1.2')
+  end
+
+  def test_address_does_not_ping
+    mock_socket = mock()
+    mock_socket.expects(:connect).returns(true)
+    mock_socket.expects(:send).returns(nil)
+    mock_socket.expects(:close).returns(true)
+    UDPSocket.stubs(:new).returns(mock_socket)
+    IO.expects(:select).returns(nil)
+    assert !@scanner.address_pings?('192.168.1.2')
+  end
+
+  def test_default_socket_timeout_in_address_ping
+    expected = 1
+    Proxy::BMC::Plugin.settings.stubs(:bmc_scanner_socket_timeout_seconds).returns(nil)
+    mock_socket = mock()
+    mock_socket.expects(:connect).returns(true)
+    mock_socket.expects(:send).returns(nil)
+    mock_socket.expects(:close).returns(true)
+    UDPSocket.stubs(:new).returns(mock_socket)
+    IO.expects(:select).with{|read, write, error, timeout| timeout == expected }.returns([mock_socket, nil, nil])
+    assert @scanner.address_pings?('192.168.1.2')
+  end
+
+  def test_custom_socket_timeout_in_address_ping
+    expected = 3
+    Proxy::BMC::Plugin.settings.stubs(:bmc_scanner_socket_timeout_seconds).returns(expected)
+    mock_socket = mock()
+    mock_socket.expects(:connect).returns(true)
+    mock_socket.expects(:send).returns(nil)
+    mock_socket.expects(:close).returns(true)
+    UDPSocket.stubs(:new).returns(mock_socket)
+    IO.expects(:select).with{|read, write, error, timeout| timeout == expected }.returns([mock_socket, nil, nil])
+    assert @scanner.address_pings?('192.168.1.2')
+  end
+
+  def test_default_number_of_max_threads
+    Proxy::BMC::Plugin.settings.stubs(:bmc_scanner_max_threads_per_request).returns(nil)
+    mock_socket = mock()
+    UDPSocket.stubs(:new).returns(mock_socket)
+    result = @scanner.calculate_max_threads
+    assert_equal(result, 500)
+  end
+
+  def test_custom_number_of_max_threads
+    Proxy::BMC::Plugin.settings.stubs(:bmc_scanner_max_threads_per_request).returns(418)
+    mock_socket = mock()
+    UDPSocket.stubs(:new).returns(mock_socket)
+    result = @scanner.calculate_max_threads
+    assert_equal(result, 418)
+  end
+
+  def test_half_number_of_500_max_threads_when_large_range
+    remaining_sockets =     [1, 2, 5, 10, 25, 100, 250, 499, 500, 750, 1000]
+    expected_sockets_used = [1, 1, 2,  5, 12,  50, 125, 249, 500, 500,  500]
+    args = { :address => '15.0.0.0/16' }
+    Proxy::BMC::Plugin.settings.expects(:bmc_scanner_max_range_size).returns(65_536)
+    Proxy::BMC::Plugin.settings.stubs(:bmc_scanner_max_threads_per_request).returns(500)
+    scanner = Proxy::BMC::IPMIScanner.new(args)
+    assert scanner.valid?
+    mock_socket = mock()
+    mock_socket.stubs(:close).returns(true)
+    for i in 0..(remaining_sockets.size-1)
+      UDPSocket.stubs(:new).returns(*[mock_socket] * remaining_sockets[i]).then.raises(Errno::EMFILE)
+      result = scanner.calculate_max_threads
+      assert_equal(result, expected_sockets_used[i])
+    end
+  end
+
+  def test_half_number_of_245_max_threads_when_large_range
+    remaining_sockets =     [1, 2, 5, 10, 25, 100, 243, 244, 245, 500]
+    expected_sockets_used = [1, 1, 2,  5, 12,  50, 121, 122, 245, 245]
+    args = { :address => '16.0.0.0/16' }
+    Proxy::BMC::Plugin.settings.expects(:bmc_scanner_max_range_size).returns(65_536)
+    Proxy::BMC::Plugin.settings.stubs(:bmc_scanner_max_threads_per_request).returns(245)
+    scanner = Proxy::BMC::IPMIScanner.new(args)
+    assert scanner.valid?
+    mock_socket = mock()
+    mock_socket.stubs(:close).returns(true)
+    for i in 0..(remaining_sockets.size-1)
+      UDPSocket.stubs(:new).returns(*[mock_socket] * remaining_sockets[i]).then.raises(Errno::EMFILE)
+      result = scanner.calculate_max_threads
+      assert_equal(result, expected_sockets_used[i])
+    end
+  end
+
+  def test_should_scan_to_list
+    expected = ['192.168.1.3', '192.168.1.5', '192.168.1.6']
+    Proxy::BMC::IPMIScanner.any_instance.expects(:address_pings?).with(){|address| address == '192.168.1.2'}.returns(false)
+    Proxy::BMC::IPMIScanner.any_instance.expects(:address_pings?).with(){|address| address == '192.168.1.3'}.returns(true)
+    Proxy::BMC::IPMIScanner.any_instance.expects(:address_pings?).with(){|address| address == '192.168.1.4'}.returns(false)
+    Proxy::BMC::IPMIScanner.any_instance.expects(:address_pings?).with(){|address| address == '192.168.1.5'}.returns(true)
+    Proxy::BMC::IPMIScanner.any_instance.expects(:address_pings?).with(){|address| address == '192.168.1.6'}.returns(true)
+    Proxy::BMC::IPMIScanner.any_instance.expects(:address_pings?).with(){|address| address == '192.168.1.7'}.returns(false)
+    result = @scanner.scan_to_list
+    assert_equal(expected.length, result.length)
+    expected.each do |address|
+      assert_send([result, :include?, address])
+    end
+  end
+
+  def test_should_scan_to_list_unthreaded
+    expected = ['192.168.1.3', '192.168.1.5', '192.168.1.6']
+    Proxy::BMC::IPMIScanner.any_instance.stubs(:address_pings?).returns(false, true, false, true, true, false)
+    result = @scanner.scan_unthreaded_to_list
+    assert_equal(expected.length, result.length)
+    expected.each do |address|
+      assert_send([result, :include?, address])
+    end
+  end
+end
+


### PR DESCRIPTION
This commit adds a new feature to smart-proxy's bmc module. This new
feature is an IP address range scanner that returns a list of IP
addresses that respond to IPMI ping packets on UDP port 623.

The use case for this is the discovery of IPMI hosts. Once the API
method has returned the list of responding IPMI hosts, another
application (perhaps Foreman in the future) can iterate over the list to
add the associated servers into Foreman as Foreman hosts and/or
configure the IPMI hosts in existing Foreman hosts' interfaces.

Scanning for IPMI hosts would be an important first step to onboard new
servers into Foreman if the current data center infrastructure
management does not yet have a reliable source of truth of which servers
have which IPMI hosts. Knowing which IP addresses are IPMI hosts would
simplify finding servers and IPMI NICs that are not in Foreman.

New API methods:

 - GET /bmc/scan
   Shows available resources /scan/range and /scan/cidr

 - GET /bmc/scan/range
   Shows usage on specifying a beginning IP address and an ending IP
   address for making a scan request

 - GET /bmc/scan/cidr
   Shows usage on specifying an IP address and its netmask in dot
   decimal format or prefixlen format for making a scan request

 - GET /bmc/scan/range/:address_first/:address_last
   Performs an IPMI ping scan from :address_first to :address_last and
   returns the result in key "result" of a JSON hash

 - GET /bmc/scan/cidr/:address/:netmask
   Performs an IPMI ping scan in the CIDR range of :address/:netmask,
   where :netmask is in decimal format (e.g. "255.255.255.0") or in
   prefixlen format (e.g. "24")

New classes:

 - Proxy::BMC::BaseScanner
   The interface for IP range scanning

 - Proxy::BMC::IPMIScanner
   An IP range scanner for IPMI. Implements Proxy::BMC::BaseScanner.
   Loosely based on ipmiutil_discover: http://ipmiutil.sourceforge.net/
   This class is used when the bmc_provider or bmc_default_provider is
   set to "freeipmi" or "ipmitool" because those imply IPMI BMC.

New configurable items in "bmc.yml":

 - :bmc_scanner_max_range_size
   The largest number of IP addresses that may be scanned in one
   request. Set this value to 0 to turn off the scanner.  Defaults to
   65536, which covers a CIDR prefixlen of /16.

 - :bmc_scanner_max_threads_per_request
   The maximum number of IP addresses to scan at the same time, per
   request. Defaults to 500.  Before increasing this number, you should
   increase the system limit on the maximum number of open files for the
   Smart Proxy process.

 - :bmc_scanner_socket_timeout_seconds
   How many seconds to wait for each scanned IP address to respond
   before timing out. Defaults to 1.