### PR TITLE
Fixes #2595 - Add more Rubyipmi methods to BMC API

### DIFF
--- a/modules/bmc/base.rb
+++ b/modules/bmc/base.rb
@@ -108,6 +108,101 @@ module Proxy
         raise NotImplementedError.new
       end
 
+      # return the SNMP community string of the bmc device
+      def snmp
+        raise NotImplementedError.new
+      end
+
+      # return the VLAN ID of the bmc device
+      def vlanid
+        raise NotImplementedError.new
+      end
+
+      # return IP source of BMC device
+      def ipsrc
+        raise NotImplementedError.new
+      end
+
+      # return all LAN details of BMC device
+      def lanprint
+        raise NotImplementedError.new
+      end
+
+      # BMC information
+      def info
+        raise NotImplementedError.new
+      end
+
+      # BMC GUID information
+      def guid
+        raise NotImplementedError.new
+      end
+
+      # BMC firmware version
+      def version
+        raise NotImplementedError.new
+      end
+
+      # BMC reset
+      def reset
+        raise NotImplementedError.new
+      end
+
+      # print all FRU information
+      def frulist
+        raise NotImplementedError.new
+      end
+
+      # HW manufacturer
+      def manufacturer
+        raise NotImplementedError.new
+      end
+
+      # Product name
+      def model
+        raise NotImplementedError.new
+      end
+
+      # Product serial number
+      def serial
+        raise NotImplementedError.new
+      end
+
+      # Asset tag
+      def asset_tag
+        raise NotImplementedError.new
+      end
+
+      # Sensor list
+      def sensorlist
+        raise NotImplementedError.new
+      end
+
+      # Sensor count
+      def sensorcount
+        raise NotImplementedError.new
+      end
+
+      # Sensor names
+      def sensornames
+        raise NotImplementedError.new
+      end
+
+      # Fan sensors
+      def fanlist
+        raise NotImplementedError.new
+      end
+
+      # Temparature sensors
+      def templist
+        raise NotImplementedError.new
+      end
+
+      # Get the readings of a particular sensor
+      def sensorget(sensor)
+        raise NotImplementedError.new
+      end
+
       protected
       attr_reader :host
     end

--- a/modules/bmc/bmc_api.rb
+++ b/modules/bmc/bmc_api.rb
@@ -35,7 +35,7 @@ module Proxy::BMC
 
     # returns host operations
     get "/:host" do
-      { :actions => %w[chassis lan test] }.to_json
+      { :actions => %w[chassis lan test fru bmc sensors] }.to_json
     end
 
     # runs a test against the bmc device and returns true if the connection was successful
@@ -83,7 +83,7 @@ module Proxy::BMC
 
     get "/:host/lan/?:action?" do
       if params[:action].nil?
-        return { :actions => ["ip", "netmask", "mac", "gateway"] }.to_json
+        return { :actions => ["ip", "netmask", "mac", "gateway", "snmp", "vlanid", "ipsrc", "print"] }.to_json
       end
       bmc_setup
       begin
@@ -96,6 +96,14 @@ module Proxy::BMC
             { :action => params[:action], :result => @bmc.mac }.to_json
           when "gateway"
             { :action => params[:action], :result => @bmc.gateway }.to_json
+          when "snmp"
+            { :action => params[:action], :result => @bmc.snmp }.to_json
+          when "vlanid"
+            { :action => params[:action], :result => @bmc.vlanid }.to_json
+          when "ipsrc"
+            { :action => params[:action], :result => @bmc.ipsrc }.to_json
+          when "print"
+            { :action => params[:action], :result => @bmc.lanprint }.to_json
           else
             { :error => "The action: #{params[:action]} is not a valid action" }.to_json
         end
@@ -154,7 +162,7 @@ module Proxy::BMC
     put "/:host/chassis/power/?:action?" do
       # return hint on valid options
       if params[:action].nil?
-        return { :actions => ["on", "off", "cycle", "soft"] }.to_json
+        return { :actions => ["on", "off", "cycle", "soft", "reset"] }.to_json
       end
       bmc_setup
       begin
@@ -167,6 +175,8 @@ module Proxy::BMC
             { :action => params[:action], :result => @bmc.powercycle }.to_json
           when "soft"
             { :action => params[:action], :result => @bmc.poweroff(true) }.to_json
+          when "reset"
+            { :action => params[:action], :result => @bmc.powerreset }.to_json
           else
             { :error => "The action: #{params[:action]} is not a valid action" }.to_json
         end
@@ -187,7 +197,7 @@ module Proxy::BMC
 
           when "bootdevice"
             if params[:action].nil?
-              return { :actions => @bmc.bootdevices, :options => ["reboot", "persistent"] }.to_json
+              return { :actions => @bmc.bootdevices, :options => ["reboot=true|false", "persistent=true|false"] }.to_json
             end
             case params[:action]
               when /pxe/
@@ -232,6 +242,115 @@ module Proxy::BMC
             { :action => params[:action], :result => @bmc.identifyoff }.to_json
           else
             { :error => "The action: #{params[:function]} is not a valid function" }.to_json
+        end
+      rescue NotImplementedError => e
+        log_halt 501, e
+      rescue => e
+        log_halt 400, e
+      end
+    end
+
+    get "/:host/fru/?:action?" do
+      if params[:action].nil?
+        return { :actions => %w[list serial manufacturer model asset_tag] }.to_json
+      end
+      bmc_setup
+      begin
+        case params[:action]
+          when "list"
+            { :action => params[:action], :result => @bmc.frulist }.to_json
+          when "serial"
+            { :action => params[:action], :result => @bmc.serial }.to_json
+          when "manufacturer"
+            { :action => params[:action], :result => @bmc.manufacturer }.to_json
+          when "model"
+            { :action => params[:action], :result => @bmc.model }.to_json
+          when "asset_tag"
+            { :action => params[:action], :result => @bmc.asset_tag}.to_json
+          else
+            { :error => "The action: #{params[:action]} is not a valid action" }.to_json
+        end
+      rescue NotImplementedError => e
+        log_halt 501, e
+      rescue => e
+        log_halt 400, e
+      end
+    end
+
+    get "/:host/bmc/?:action?" do
+      if params[:action].nil?
+        return { :actions => %w[info guid version] }.to_json
+      end
+      bmc_setup
+      begin
+        case params[:action]
+          when "info"
+            { :action => params[:action], :result => @bmc.info }.to_json
+          when "guid"
+            { :action => params[:action], :result => @bmc.guid }.to_json
+          when "version"
+            { :action => params[:action], :result => @bmc.version }.to_json
+          else
+            { :error => "The action: #{params[:action]} is not a valid action" }.to_json
+        end
+      rescue NotImplementedError => e
+        log_halt 501, e
+      rescue => e
+        log_halt 400, e
+      end
+    end
+
+    put "/:host/bmc/?:action?" do
+      if params[:action].nil?
+        return { :actions => %w[reset] }.to_json
+      end
+      bmc_setup
+      begin
+        case params[:action]
+          when "reset"
+            if params[:type].nil?
+              return { :options => "type=cold|warm" }.to_json
+            end
+            case params[:type]
+              when /cold|warm/
+                { :action => params[:action], :result => @bmc.reset(params[:type])}.to_json
+              else
+                { :error => "The type: #{params[:type]} is not a valid type" }.to_json
+            end
+          else
+            { :error => "The action: #{params[:action]} is not a valid action" }.to_json
+        end
+      rescue NotImplementedError => e
+        log_halt 501, e
+      rescue => e
+        log_halt 400, e
+      end
+    end
+
+    get "/:host/sensors/?:action?/?:sensor?" do
+      if params[:action].nil?
+        return { :actions => %w[list count names fanlist templist get] }.to_json
+      end
+      bmc_setup
+      begin
+        case params[:action]
+          when "list"
+            { :action => params[:action], :result => @bmc.sensorlist }.to_json
+          when "count"
+            { :action => params[:action], :result => @bmc.sensorcount }.to_json
+          when "names"
+            { :action => params[:action], :result => @bmc.sensornames }.to_json
+          when "fanlist"
+            { :action => params[:action], :result => @bmc.fanlist }.to_json
+          when "templist"
+            { :action => params[:action], :result => @bmc.templist }.to_json
+          when "get"
+            if params[:sensor].nil?
+              return { :options => "sensor=<name>" }.to_json
+            end
+            { :action => params[:action], :result => @bmc.sensorget(params[:sensor]) }.to_json
+          else
+            { :error => "The action: #{params[:action]} is not a valid action" }.to_json
         end
       rescue NotImplementedError => e
         log_halt 501, e

--- a/test/bmc/bmc_test.rb
+++ b/test/bmc/bmc_test.rb
@@ -21,55 +21,221 @@ class BmcTest < Test::Unit::TestCase
   end
 
   def test_should_run_connection_test
-    Rubyipmi::Ipmitool::Connection.any_instance.stubs(:connection_works?).returns(true)
+    Rubyipmi::Ipmitool::Connection.any_instance.expects(:connection_works?).returns(true)
     assert bmc.test
-    Rubyipmi::Ipmitool::Connection.any_instance.stubs(:connection_works?).returns(false)
+    Rubyipmi::Ipmitool::Connection.any_instance.expects(:connection_works?).returns(false)
     assert !bmc.test
   end
 
   def test_should_turnoff_led
-    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:identify).returns(true)
+    Rubyipmi::Ipmitool::Chassis.any_instance.expects(:identify).returns(true)
     assert bmc.identifyoff
   end
 
   def test_should_turnon_led
-    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:identify).returns(true)
+    Rubyipmi::Ipmitool::Chassis.any_instance.expects(:identify).returns(true)
     assert bmc.identifyon
   end
 
   def test_should_power_off
-    Rubyipmi::Ipmitool::Power.any_instance.stubs(:off).returns(true)
+    Rubyipmi::Ipmitool::Power.any_instance.expects(:off).returns(true)
     assert bmc.poweroff
   end
 
   def test_should_power_on
-    Rubyipmi::Ipmitool::Power.any_instance.stubs(:on).returns(true)
+    Rubyipmi::Ipmitool::Power.any_instance.expects(:on).returns(true)
     assert bmc.poweron
   end
 
   def test_should_power_cycle
-    Rubyipmi::Ipmitool::Power.any_instance.stubs(:cycle).returns(true)
+    Rubyipmi::Ipmitool::Power.any_instance.expects(:cycle).returns(true)
     assert bmc.powercycle
   end
 
+  def test_should_power_reset
+    Rubyipmi::Ipmitool::Power.any_instance.expects(:reset).returns(true)
+    assert bmc.powerreset
+  end
+
   def test_should_bootpxe
-    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:bootpxe).returns(true)
+    Rubyipmi::Ipmitool::Chassis.any_instance.expects(:bootpxe).returns(true)
     bmc.bootpxe
   end
 
   def test_should_bootdisk
-    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:bootdisk).returns(true)
+    Rubyipmi::Ipmitool::Chassis.any_instance.expects(:bootdisk).returns(true)
     bmc.bootdisk
   end
 
   def test_should_bootbios
-    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:bootbios).returns(true)
+    Rubyipmi::Ipmitool::Chassis.any_instance.expects(:bootbios).returns(true)
     bmc.bootbios
   end
 
   def test_should_bootcdrom
-    Rubyipmi::Ipmitool::Chassis.any_instance.stubs(:bootcdrom).returns(true)
+    Rubyipmi::Ipmitool::Chassis.any_instance.expects(:bootcdrom).returns(true)
     bmc.bootcdrom
+  end
+
+  def test_should_ip
+    Rubyipmi::Ipmitool::Lan.any_instance.expects(:ip).returns(true)
+    bmc.ip
+  end
+
+  def test_should_mac
+    Rubyipmi::Ipmitool::Lan.any_instance.expects(:mac).returns(true)
+    bmc.mac
+  end
+
+  def test_should_gateway
+    Rubyipmi::Ipmitool::Lan.any_instance.expects(:gateway).returns(true)
+    bmc.gateway
+  end
+
+  def test_should_netmask
+    Rubyipmi::Ipmitool::Lan.any_instance.expects(:netmask).returns(true)
+    bmc.netmask
+  end
+
+  def test_should_snmp
+    Rubyipmi::Ipmitool::Lan.any_instance.expects(:snmp).returns(true)
+    bmc.snmp
+  end
+
+  def test_should_vlanid
+    Rubyipmi::Ipmitool::Lan.any_instance.expects(:vlanid).returns(true)
+    bmc.vlanid
+  end
+
+  def test_ipsrc_true
+    Rubyipmi::Ipmitool::Lan.any_instance.expects(:dhcp?).returns(true)
+    assert_equal bmc.ipsrc, "dhcp"
+  end
+
+  def test_ipsrc_false
+    Rubyipmi::Ipmitool::Lan.any_instance.expects(:dhcp?).returns(false)
+    assert_equal bmc.ipsrc, "static"
+  end
+
+  def test_should_lanprint
+    Rubyipmi::Ipmitool::Lan.any_instance.expects(:info).returns(true)
+    bmc.lanprint
+  end
+
+  def test_should_info
+    Rubyipmi::Ipmitool::Bmc.any_instance.expects(:info).returns(true)
+    bmc.info
+  end
+
+  def test_should_guid
+    Rubyipmi::Ipmitool::Bmc.any_instance.expects(:guid).returns(true)
+    bmc.guid
+  end
+
+  def test_should_version
+    Rubyipmi::Ipmitool::Bmc.any_instance.expects(:version).returns(true)
+    bmc.version
+  end
+
+  def test_should_reset_default
+    Rubyipmi::Ipmitool::Bmc.any_instance.expects(:reset).with('cold').returns(true)
+    bmc.reset
+  end
+
+  def test_should_reset_cold
+    Rubyipmi::Ipmitool::Bmc.any_instance.expects(:reset).with('cold').returns(true)
+    bmc.reset('cold')
+  end
+
+  def test_should_reset_warm
+    Rubyipmi::Ipmitool::Bmc.any_instance.expects(:reset).with('warm').returns(true)
+    bmc.reset('warm')
+  end
+
+  def test_should_frulist
+    Rubyipmi::Ipmitool::Fru.any_instance.expects(:list).returns(true)
+    bmc.frulist
+  end
+
+  def test_frulist_2xquirk_freeipmi
+    Rubyipmi::Freeipmi::Fru.any_instance.expects(:list).times(2).raises(StandardError).then.returns(true)
+    args = { :username => "user", :password => "pass", :bmc_provider => "freeipmi", :host => "host" }
+    bmc  = Proxy::BMC::IPMI.new(args)
+    assert_equal bmc.frulist, true
+  end
+
+  def test_frulist_2xquirk_ipmitool
+    Rubyipmi::Ipmitool::Fru.any_instance.expects(:list).times(1).returns({})
+    args = { :username => "user", :password => "pass", :bmc_provider => "ipmitool", :host => "host" }
+    bmc  = Proxy::BMC::IPMI.new(args)
+    assert_equal bmc.frulist, "Unknown error getting fru list. Try bmc_provider=freeipmi for possible quirk workaround."
+  end
+
+  def test_frulist_2xquirk_fail
+    Rubyipmi::Freeipmi::Fru.any_instance.expects(:list).times(2).raises(StandardError)
+    args = { :username => "user", :password => "pass", :bmc_provider => "freeipmi", :host => "host" }
+    bmc  = Proxy::BMC::IPMI.new(args)
+    assert_equal bmc.frulist, "Error getting fru list: StandardError"
+  end
+
+  def test_frulist_fail_ipmitool
+    Rubyipmi::Ipmitool::Fru.any_instance.expects(:list).times(1).raises(StandardError)
+    assert_equal bmc.frulist, "Error getting fru list: StandardError"
+  end
+
+  def test_should_manufacturer
+    Rubyipmi::Ipmitool::Fru.any_instance.expects(:manufacturer).returns(true)
+    bmc.manufacturer
+  end
+
+  def test_should_model
+    Rubyipmi::Ipmitool::Fru.any_instance.expects(:product_name).returns(true)
+    bmc.model
+  end
+
+  def test_should_serial
+    Rubyipmi::Ipmitool::Fru.any_instance.expects(:product_serial).returns(true)
+    bmc.serial
+  end
+
+  def test_should_asset_tag
+    Rubyipmi::Ipmitool::Fru.any_instance.expects(:product_asset_tag).returns(true)
+    bmc.asset_tag
+  end
+
+  def test_should_sensorlist
+    Rubyipmi::Ipmitool::Sensors.any_instance.expects(:list).returns(true)
+    bmc.sensorlist
+  end
+
+  def test_should_sensorcount
+    Rubyipmi::Ipmitool::Sensors.any_instance.expects(:count).returns(true)
+    bmc.sensorcount
+  end
+
+  def test_should_sensornames
+    Rubyipmi::Ipmitool::Sensors.any_instance.expects(:names).returns(true)
+    bmc.sensornames
+  end
+
+  def test_should_fanlist
+    Rubyipmi::Ipmitool::Sensors.any_instance.expects(:fanlist).returns(true)
+    bmc.fanlist
+  end
+
+  def test_should_templist
+    Rubyipmi::Ipmitool::Sensors.any_instance.expects(:templist).returns(true)
+    bmc.templist
+  end
+
+  def test_should_sensorget
+    Rubyipmi::Ipmitool::Sensors.any_instance.expects(:list).returns(true)
+    bmc.sensorget('anything')
+  end
+
+  def test_sensorget
+    Rubyipmi::Ipmitool::Sensors.any_instance.expects(:list).returns('test_sensor' => {'key' => 'value'}, 'not_my_sensor' => {'foo' => 'bar'})
+    assert_equal({'key' => 'value'}, bmc.sensorget('test_sensor'))
   end
 
   private


### PR DESCRIPTION
Replaces: theforeman/smart-proxy#505
Replaces: 051b285aaa9b595ea9513ff5fa197eb830b942c1

This commit implements the same features as
051b285aaa9b595ea9513ff5fa197eb830b942c1, with some differences:

 - Added unit tests for all new features
 - Added interfaces to `modules/bmc/base.rb`
 - Cleared up some ambiguous method names
 - Changed some unit test stubs to expects
 - Fixed bugs in the original implementation

New API methods:

 - GET /bmc/:host/fru
   Shows available actions: "list", "serial", "manufacturer", "model",
   and "asset_tag"

 - GET /bmc/:host/bmc
   Shows available actions: "info", "guid", and "version"

 - GET /bmc/:host/sensors
   Shows available actions: "list", "count", "names", "fanlist",
   "templist", and "get"

 - GET /bmc/:host/lan/snmp
   Shows BMC host's SNMP community string

 - GET /bmc/:host/lan/vlanid
   Shows BMC host's VLAN ID

 - GET /bmc/:host/lan/ipsrc
   Shows whether BMC host's LAN was configured "static" or "dhcp"

 - GET /bmc/:host/lan/print
   Shows BMC hosts's LAN configuration

 - PUT /bmc/:host/chassis/power/reset
   Performs power reset on chassis

 - GET /bmc/:host/fru/list
   Shows all of host's FRU information. Includes workaround for
   undocumented IBM/Lenovo IPMI bug.

 - GET /bmc/:host/fru/serial
   Shows host's serial number

 - GET /bmc/:host/fru/manufacturer
   Shows host's manufacturer

 - GET /bmc/:host/fru/model
   Shows host's product model

 - GET /bmc/:host/fru/asset_tag
   Shows host's asset tag string, if Rubyipmi has this method. It's in
   the spec, but doesn't seem to be implemented today. See spec [here](https://github.com/logicminds/rubyipmi/blob/master/spec/unit/ipmitool/fru_spec.rb).

 - GET /bmc/:host/bmc/info
   Shows information about the BMC

 - GET /bmc/:host/bmc/guid
   Shows system's GUID

 - GET /bmc/:host/version
   Shows BMC's version

 - PUT /bmc/:host/bmc/reset?type=warm
   Performs warm reset on BMC

 - PUT /bmc/:host/bmc/reset?type=cold
   Performs cold reset on BMC

 - GET /bmc/:host/sensors/list
   Shows all of host's sensors

 - GET /bmc/:host/sensors/count
   Shows number of sensors on host

 - GET /bmc/:host/sensors/names
   Shows list of sensor names on host

 - GET /bmc/:host/sensors/fanlist
   Shows all of host's fan sensors

 - GET /bmc/:host/sensors/templist
   Shows all of host's temperature sensors

 - GET /bmc/:host/sensors/get
   Shows available option "sensor" for this action

 - GET /bmc/:host/sensors/get/:sensor
   Shows information about sensor :sensor on host