### PR TITLE
fixes #19480 - add systemd notify support

### DIFF
--- a/extra/systemd/foreman-proxy.service
+++ b/extra/systemd/foreman-proxy.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Foreman Proxy
+Wants=basic.target
+After=basic.target network.target
+
+[Service]
+Type=notify
+User=foreman-proxy
+ExecStart=/usr/share/foreman-proxy/bin/smart-proxy --no-daemonize
+
+[Install]
+WantedBy=multi-user.target

--- a/lib/proxy/sd_notify.rb
+++ b/lib/proxy/sd_notify.rb
@@ -1,0 +1,30 @@
+require 'socket'
+
+# Implementation of libsystemd's sd_notify API, sends current state via socket
+module Proxy
+  class SdNotify
+    def active?
+      !ENV['NOTIFY_SOCKET'].nil?
+    end
+
+    def notify(message)
+      create_socket.tap do |socket|
+        socket.sendmsg(message.chomp + "\n") # ensure trailing \n
+        socket.close
+      end
+    end
+
+    def ready(state = 1)
+      notify("READY=#{state}")
+    end
+
+    private
+
+    def create_socket
+      raise 'Missing NOTIFY_SOCKET environment variable, is this process running under systemd?' unless active?
+      Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM, 0).tap do |socket|
+        socket.connect(Socket.pack_sockaddr_un(ENV['NOTIFY_SOCKET']))
+      end
+    end
+  end
+end

--- a/lib/proxy/settings.rb
+++ b/lib/proxy/settings.rb
@@ -7,8 +7,10 @@ module Proxy::Settings
 
   SETTINGS_PATH = Pathname.new(__FILE__).join("..","..","..","config","settings.yml")
 
-  def self.load_global_settings(settings_path = nil)
-    ::Proxy::Settings::Global.new(YAML.load(File.read(settings_path || SETTINGS_PATH)))
+  def self.initialize_global_settings(settings_path = nil, argv = ARGV)
+    global = ::Proxy::Settings::Global.new(YAML.load(File.read(settings_path || SETTINGS_PATH)))
+    global.apply_argv(argv)
+    global
   end
 
   def self.load_plugin_settings(defaults, settings_file, settings_directory = nil)

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -42,5 +42,10 @@ module ::Proxy::Settings
       return value unless how_to.has_key?(key)
       how_to[key].call(value)
     end
+
+    def apply_argv(args)
+      self.daemon = true if args.include?('--daemonize')
+      self.daemon = false if args.include?('--no-daemonize')
+    end
   end
 end

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -42,7 +42,7 @@ require 'sinatra/default_not_found_page'
 require 'webrick-patch'
 
 module Proxy
-  SETTINGS = Settings.load_global_settings
+  SETTINGS = Settings.initialize_global_settings
   VERSION = File.read(File.join(File.dirname(__FILE__), '../VERSION')).chomp
 
   ::Sinatra::Base.set :run, false

--- a/test/global_settings_test.rb
+++ b/test/global_settings_test.rb
@@ -28,4 +28,16 @@ class GlobalSettingsTest < Test::Unit::TestCase
     assert_equal ['127.0.0.1'], ::Proxy::Settings::Global.new(:bind_host => '127.0.0.1').bind_host
     assert_equal ['127.0.0.1'], ::Proxy::Settings::Global.new(:bind_host => ['127.0.0.1']).bind_host
   end
+
+  def test_apply_argv_daemonize
+    settings = ::Proxy::Settings::Global.new(daemon: false)
+    settings.apply_argv(['--daemonize'])
+    assert_equal true, settings.daemon
+  end
+
+  def test_apply_argv_no_daemonize
+    settings = ::Proxy::Settings::Global.new(daemon: true)
+    settings.apply_argv(['--no-daemonize'])
+    assert_equal false, settings.daemon
+  end
 end

--- a/test/sd_notify_test.rb
+++ b/test/sd_notify_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+require 'proxy/sd_notify'
+
+class SdNotifyTest < Test::Unit::TestCase
+  def test_active_with_notify_socket
+    with_notify_socket('/mock/systemd/notify') do
+      assert Proxy::SdNotify.new.active?
+    end
+  end
+
+  def test_active_without_notify_socket
+    with_notify_socket(nil) do
+      refute Proxy::SdNotify.new.active?
+    end
+  end
+
+  def test_notify
+    assert_equal("TEST=42\n", with_test_socket { Proxy::SdNotify.new.notify('TEST=42') })
+  end
+
+  def test_notify_when_inactive
+    assert_raises(RuntimeError) { with_notify_socket(nil) { Proxy::SdNotify.new.notify('TEST=42') } }
+  end
+
+  def test_ready
+    assert_equal("READY=1\n", with_test_socket { Proxy::SdNotify.new.ready })
+  end
+
+  private
+
+  def with_notify_socket(socket)
+    old_socket = ENV.delete('NOTIFY_SOCKET')
+    begin
+      ENV['NOTIFY_SOCKET'] = socket unless socket.nil?
+      yield
+    ensure
+      if old_socket.nil?
+        ENV.delete('NOTIFY_SOCKET')
+      else
+        ENV['NOTIFY_SOCKET'] = old_socket
+      end
+    end
+  end
+
+  def with_test_socket(&block)
+    socket_path = File.expand_path('../tmp/test_systemd.socket', __FILE__)
+    File.delete(socket_path) if File.exist?(socket_path)
+
+    socket = Socket.new(Socket::AF_UNIX, Socket::SOCK_DGRAM, 0)
+    begin
+      socket.bind(Socket.pack_sockaddr_un(socket_path))
+      with_notify_socket(socket_path, &block)
+      socket.recv_nonblock(256)
+    ensure
+      socket.close
+    end
+  end
+end


### PR DESCRIPTION
When started under systemd, the launcher now logs via the notify socket
API when all configured WEBrick servers have started so the service
state is reported accurately (rather than the daemonization point).

An example unit file is now shipped that uses a --no-daemonize
argument to override the config file, so misconfiguration will not
prevent the service from starting correctly.