### PR TITLE
Fixes #19597 - fallback DHCP hostname pattern

### DIFF
--- a/modules/dhcp_common/record/lease.rb
+++ b/modules/dhcp_common/record/lease.rb
@@ -5,7 +5,7 @@ module Proxy::DHCP
     attr_reader :name, :starts, :ends, :state
 
     def initialize(name, ip_address, mac_address, subnet, starts, ends, state, options = {})
-      @name = name || "*lease*"
+      @name = name || "lease-#{mac_address.tr(':-','')}"
       @starts = starts
       @ends = ends
       @state = state


### PR DESCRIPTION
I stumbled upon situation during host renaming with libvirt provider when hostname was not passed and it defaulted to '*lease*' which failed for incorrect characters. Apparently * is not allowed there, therefore I renaming this to something that will always work. Also adding MAC address so it's unique hostname.

To reproduce use libvirt provider, create a host in foreman using libvirt provider, then rename the hostname - it conflicts with entry which is created by libvirt itself. That's anoter story, in this patch I just want to fix the "fallback" name.