### PR TITLE
Fixes #19666 - add DHCP record type field

### DIFF
--- a/modules/dhcp_common/record.rb
+++ b/modules/dhcp_common/record.rb
@@ -5,7 +5,7 @@ module Proxy::DHCP
   # represent a DHCP Record
   class Record
 
-    attr_reader :ip, :mac, :subnet, :options
+    attr_reader :ip, :mac, :subnet, :options, :type
     include Proxy::DHCP
     include Proxy::Log
     include Proxy::Validations

--- a/modules/dhcp_common/record/lease.rb
+++ b/modules/dhcp_common/record/lease.rb
@@ -5,6 +5,7 @@ module Proxy::DHCP
     attr_reader :name, :starts, :ends, :state
 
     def initialize(name, ip_address, mac_address, subnet, starts, ends, state, options = {})
+      @type = "lease"
       @name = name || "lease-#{mac_address.tr(':-','')}"
       @starts = starts
       @ends = ends
@@ -21,7 +22,7 @@ module Proxy::DHCP
     end
 
     def to_json(*opts)
-      Hash[[:name, :ip, :mac, :subnet, :starts, :ends, :state].map{|s| [s, send(s)]}].merge(options).to_json(*opts)
+      Hash[[:name, :ip, :mac, :subnet, :starts, :ends, :state, :type].map{|s| [s, send(s)]}].merge(options).to_json(*opts)
     end
   end
 end

--- a/modules/dhcp_common/record/reservation.rb
+++ b/modules/dhcp_common/record/reservation.rb
@@ -5,6 +5,7 @@ module Proxy::DHCP
     attr_reader :name
 
     def initialize(name, ip_address, mac_address, subnet, options = {})
+      @type = "reservation"
       @name = name
       super(ip_address, mac_address, subnet, options)
     end
@@ -22,7 +23,7 @@ module Proxy::DHCP
     end
 
     def to_json(*opts)
-      Hash[[:name, :ip, :mac, :subnet].map{|s| [s, send(s)]}].merge(options).to_json(*opts)
+      Hash[[:name, :ip, :mac, :subnet, :type].map{|s| [s, send(s)]}].merge(options).to_json(*opts)
     end
   end
 end

--- a/test/dhcp/dhcp_api_test.rb
+++ b/test/dhcp/dhcp_api_test.rb
@@ -144,18 +144,39 @@ class DhcpApiTest < Test::Unit::TestCase
     assert_equal 404, last_response.status
   end
 
-  def test_get_record_by_ip
+  def test_get_reservation_record_by_ip
     @server.expects(:find_records_by_ip).with("192.168.122.0", "192.168.122.1").returns([@reservations.first])
 
     get "/192.168.122.0/ip/192.168.122.1"
 
     assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
     expected = [{
-      "hostname" =>"test.example.com",
-      "ip"       =>"192.168.122.1",
-      "mac"      =>"00:11:bb:cc:dd:ee",
+      "type"     => "reservation",
+      "hostname" => "test.example.com",
+      "ip"       => "192.168.122.1",
+      "mac"      => "00:11:bb:cc:dd:ee",
       "name"     => 'test.example.com',
-      "subnet"   =>"192.168.122.0/255.255.255.0" # NOTE: 'subnet' attribute isn't being used by foreman, which adds a 'network' attribute instead
+      "subnet"   => "192.168.122.0/255.255.255.0"
+    }]
+    assert_equal expected, JSON.parse(last_response.body)
+  end
+
+  def test_get_lease_record_by_ip
+    @server.expects(:find_records_by_ip).with("192.168.122.0", "192.168.122.1").returns([@leases.first])
+
+    get "/192.168.122.0/ip/192.168.122.1"
+
+    assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
+
+    expected = [{
+      "ends" => nil,
+      "ip" => "192.168.122.2",
+      "mac" => "00:aa:bb:cc:dd:ee",
+      "name" => "lease-00aabbccddee",
+      "starts" => "2014-07-12 10:08:29 UTC",
+      "state" => "active",
+      "subnet" => "192.168.122.0/255.255.255.0",
+      "type" => "lease"
     }]
     assert_equal expected, JSON.parse(last_response.body)
   end
@@ -179,6 +200,7 @@ class DhcpApiTest < Test::Unit::TestCase
 
     assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
     expected = {
+      "type"     => "reservation",
       "hostname" =>"test.example.com",
       "ip"       =>"192.168.122.1",
       "mac"      =>"00:11:bb:cc:dd:ee",


### PR DESCRIPTION
There are two changes in this patch. First, we do not show if a record is type of lease or reservation. This can be useful information. But more importantly, this removes unnecessary "name" field from lease record, which is treatened as a hostname in Foreman. This will fix:

http://projects.theforeman.org/issues/19634


I am filing this for #19634 bug but I might end up not use this information, still I would like Smart Proxy to report this.