### PR TITLE
Fixes #20370 - Add sshfp DNS record support

### DIFF
--- a/modules/dns/dns_api.rb
+++ b/modules/dns/dns_api.rb
@@ -29,6 +29,9 @@ module Proxy::Dns
         when 'CNAME'
           validate_dns_name!(value, type)
           server.create_cname_record(fqdn, value)
+        when 'SSHFP'
+          validate_sshfp_data!(value)
+          server.create_sshfp_record(fqdn, value)
         when 'PTR'
           validate_reverse_dns_name!(value)
           server.create_ptr_record(fqdn, value)
@@ -63,6 +66,8 @@ module Proxy::Dns
           server.remove_aaaa_record(name)
         when 'CNAME'
           server.remove_cname_record(name)
+        when 'SSHFP'
+          server.remove_sshfp_records(name)
         when 'PTR'
           validate_reverse_dns_name!(name)
           server.remove_ptr_record(name)
@@ -107,6 +112,10 @@ module Proxy::Dns
     def validate_reverse_dns_name!(name)
       validate_dns_name!(name, 'PTR')
       raise Proxy::Dns::Error.new("Invalid reverse DNS #{name}") unless name =~ /\.(in-addr|ip6)\.arpa$/
+    end
+
+    def validate_sshfp_data!(data)
+      raise Proxy::Dns::Error.new("Invalid SSHFP data #{data}") unless data =~/^[0-9]\s+[0-9]\s+[0-9a-f]+$/i
     end
   end
 end

--- a/modules/dns_common/dns_resources.rb
+++ b/modules/dns_common/dns_resources.rb
@@ -1,0 +1,35 @@
+# Additional DNS resource types not (yet) in rubysl-resolv
+
+require 'resolv'
+
+module DnsResources
+  class SSHFP < Resolv::DNS::Resource
+    TypeValue = 44 # :nodoc:
+    ClassValue = 1
+
+    def initialize(algorithm, type, fingerprint)
+      @algorithm = algorithm
+      @type = type
+      @fingerprint = fingerprint
+    end
+
+    attr_reader :algorithm
+    attr_reader :type
+    attr_reader :fingerprint
+
+    def encode_rdata(msg) # :nodoc:
+      msg.put_pack('CC', @algorithm, @type)
+      msg.put_bytes([@fingerprint].pack('H*'))
+    end
+
+    def self.decode_rdata(msg) # :nodoc:
+      algorithm, type = msg.get_unpack('CC')
+      fingerprint = msg.get_bytes.unpack('H*')[0]
+      return self.new(algorithm, type, fingerprint)
+    end
+
+    def to_s # :nodoc:
+      return "#{@algorithm} #{@type} #{@fingerprint}"
+    end
+  end
+end

--- a/test/dns_common/resource_test.rb
+++ b/test/dns_common/resource_test.rb
@@ -1,0 +1,29 @@
+require 'test_helper'
+require 'dns_common/dns_resources'
+
+class DnsResourceTest < Test::Unit::TestCase
+  def setup
+    @sshfp = DnsResources::SSHFP.new(1, 2, "D87F5D91F1153AE4C9490144F3E1A9CA7CAEE634")
+  end
+
+  def test_sshfp_converts_to_string
+    assert_equal "1 2 D87F5D91F1153AE4C9490144F3E1A9CA7CAEE634", @sshfp.to_s
+  end
+
+  def test_sshfp_encode
+    msg = Resolv::DNS::Message.new
+    msg.expects(:put_pack).with('CC', 1, 2)
+    msg.expects(:put_bytes).with(['D87F5D91F1153AE4C9490144F3E1A9CA7CAEE634'].pack('H*'))
+    assert_nil @sshfp.encode_rdata(msg)
+  end
+
+  def test_sshfp_decode
+    msg = Resolv::DNS::Message.new
+    msg.expects(:get_unpack).with('CC').returns([1, 2])
+    msg.expects(:get_bytes).with().returns(['D87F5D91F1153AE4C9490144F3E1A9CA7CAEE634'].pack('H*'))
+    result = DnsResources::SSHFP.decode_rdata(msg)
+    assert_equal 1, result.algorithm
+    assert_equal 2, result.type
+    assert_equal "D87F5D91F1153AE4C9490144F3E1A9CA7CAEE634", result.fingerprint.upcase
+  end
+end


### PR DESCRIPTION
as per

    https://tools.ietf.org/html/rfc4255
    https://tools.ietf.org/html/rfc6594

looks like

    $ curl -d 'fqdn=testsshfp.example.com&value=3 2 1235&type=SSHFP' \
        http://localhost:8000/dns
    $ host -t SSHFP testsshfp.example.com
    testsshfp.example.com has SSHFP record 3 2 1235
    $ curl -X DELETE http://localhost:8000/dns/testsshfp.example.com/SSHFP
    $ host -t SSHFP testsshfp.example.com
    Host testsshfp.example.com not found: 3(NXDOMAIN)

Due to the current smart-proxy API this is a bit unsymmetric.  While we
can create individual records we can only delete all of them.

That's fine for my use case: Letting a Foreman plugin handle SSH-keys
via SSHFP records so one gets rid of "host key has changed prompts once
and for all" (making ssh keys part of the VM life cycle) - but we might
want to extend this at a later point.

This needs

    https://github.com/rubysl/rubysl-resolv/pull/1