### PR TITLE
Fixes #20539 - foreman-debug shouldn't save private key

### DIFF
--- a/extra/foreman-debug-proxy
+++ b/extra/foreman-debug-proxy
@@ -6,7 +6,7 @@
 #
 
 # proxy-related configs and logs
-add_files /etc/foreman{-proxy,-proxy/settings.d}/*
+add_files /etc/foreman{-proxy,-proxy/settings.d}/*.{yml,yaml,conf}
 add_files /etc/{sysconfig,default}/foreman-proxy
 add_files /var/log/foreman-proxy/cron*.log*
 add_files /var/log/foreman-proxy/migrate_settings*.log*


### PR DESCRIPTION
Currently foreman-debug adds everything in /etc/foreman-proxy to the
tarball. Recently there was [a fix in Foreman](https://github.com/theforeman/foreman/pull/3952) to not add private keys,
however foreman-proxy keys are still logged.