### PR TITLE
Fixes #20700 - templates are passed with spaces in kind

### DIFF
--- a/modules/templates/template_proxy_request.rb
+++ b/modules/templates/template_proxy_request.rb
@@ -16,15 +16,16 @@ module Proxy::Templates
       opts.delete("hostgroup")
       opts.delete("splat")
       opts.delete("captures")
+      # in hostgroup provisioning there are spaces
+      kind = kind.split('/').map{|x| CGI.escape(x)}.join('/')
+      logger.debug "Template: request for #{kind} using #{opts.inspect} at #{uri.host}"
       proxy_headers = extract_request_headers(env).merge("X-Forwarded-For" => "#{env['REMOTE_ADDR']}, #{proxy_ip}")
       proxy_req = request_factory.create_get("/unattended/#{kind}", opts, proxy_headers)
       logger.debug "Retrieving a template from %s%s" % [uri, proxy_req.path]
       logger.debug "HTTP headers: #{proxy_headers.inspect}"
       res = send_request(proxy_req)
-
       # You get a 201 from the 'built' URL
       raise "Error retrieving #{kind} for #{opts.inspect} from #{uri.host}: #{res.class}" unless ["200", "201"].include?(res.code)
-      logger.debug "Template: request for #{kind} using #{opts.inspect} at #{uri.host}"
       res.body
     end
 

--- a/test/templates/template_api_test.rb
+++ b/test/templates/template_api_test.rb
@@ -46,4 +46,11 @@ class TemplateApiTest < Test::Unit::TestCase
     assert last_response.ok?, "Last response was ok"
     assert_match("An API template", last_response.body)
   end
+
+  def test_api_can_ask_for_a_hostgroup_template_2
+    stub_request(:get, "#{@foreman_url}/unattended/kind+space/temp+space/hg+space").with(query: {"url" => @template_url}).to_return(:body => 'An API template')
+    get "/kind%20space/temp%20space/hg%20space", {}
+    assert last_response.ok?, "Last response was ok"
+    assert_match("An API template", last_response.body)
+  end
 end


### PR DESCRIPTION
When there are spaces, template proxy API does not proxy correctly:

    curl -3 -H "Accept:application/json" -H "Content-Type: application/json" -d '{}' -k -X GET http://zzzap.lab.eng.brq.redhat.com:8000/unattended/template/Generic%20Kickstart/CentOS%207.0

Currently ends up with

    Failed to retrieve template hostgroup template for {"splat"=>[], "captures"=>["template", "Generic Kickstart", "CentOS 7.0"], "kind"=>"template", "template"=>"Generic Kickstart", "hostgroup"=>"CentOS 7.0"}: bad URI(is not URI?): /unattended/template/Generic Kickstart/CentOS 7.0

This fixes it and adds a test.