### PR TITLE
Fixes #19053 - properly respond to reload action

### DIFF
--- a/extra/systemd/foreman-proxy.service
+++ b/extra/systemd/foreman-proxy.service
@@ -7,6 +7,7 @@ After=basic.target network.target
 Type=notify
 User=foreman-proxy
 ExecStart=/usr/share/foreman-proxy/bin/smart-proxy --no-daemonize
+ExecReload=/bin/kill -USR1 $MAINPID
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
So the problem here is the standard practice is to send SIGHUP to daemons to release log files after rotating, base RHEL SELinux policy includes rules to allow logrotate to send this via systemctl reload command. Our proxy only supports SIGUSR1 which is not standard and therefore the only way supporting this is by doing changes in our SELinux policy. This includes creating two types, domain, macro, file contexts - this is too complicated. It is much better to follow what is expected and change our service to respond to reload properly, then we can change our logrotate script as well.

Therefore I am opening this and making the change in proxy to properly reopen logs when "reload" init command is sent.