### PR TITLE
Fixes #21236 - No ping check causes duplicated IP with MS DHCP

### DIFF
--- a/modules/dhcp_common/free_ips.rb
+++ b/modules/dhcp_common/free_ips.rb
@@ -1,10 +1,12 @@
 require 'concurrent'
 require 'logger'
 require 'set'
+require 'dhcp_common/pingable'
 
 module Proxy::DHCP
   class FreeIps
     include ::Proxy::Log
+    include ::Proxy::DHCP::Pingable
 
     DEFAULT_CLEANUP_INTERVAL = 60 # 1 min
 
@@ -98,61 +100,6 @@ module Proxy::DHCP
         next if past_indices.add?(current_index).nil?
         yield(current_index)
       end
-    end
-
-    def tcp_pingable? ip
-      # This code is from net-ping, and stripped down for use here
-      # We don't need all the ldap dependencies net-ping brings in
-
-      @service_check = true
-      @port          = 7
-      @timeout       = 1
-      @exception     = nil
-      bool           = false
-      tcp            = nil
-
-      begin
-        Timeout.timeout(@timeout) do
-          begin
-            tcp = Socket.tcp(ip, @port, connect_timeout: @timeout)
-            tcp = TCPSocket.new(ip, @port)
-          rescue Errno::ECONNREFUSED => err
-            if @service_check
-              bool = true
-            else
-              @exception = err
-            end
-          rescue Exception => err
-            @exception = err
-          else
-            bool = true
-          end
-        end
-      rescue Timeout::Error => err
-        @exception = err
-      ensure
-        tcp.close if tcp
-      end
-
-      bool
-    rescue
-      # We failed to check this address so we should not use it
-      true
-    end
-
-    def icmp_pingable? ip
-      # Always shell to ping, instead of using net-ping
-      if PLATFORM =~ /mingw/
-        # Windows uses different options for ping and does not have /dev/null
-        system("ping -n 1 -w 1000 #{ip} > NUL")
-      else
-        # Default to Linux ping options and send to /dev/null
-        system("ping -c 1 -W 1 #{ip} > /dev/null")
-      end
-    rescue => err
-      # We failed to check this address so we should not use it
-      logger.warn "Unable to icmp ping #{ip} because #{err.inspect}. Skipping this address..."
-      true
     end
   end
 end

--- a/modules/dhcp_common/pingable.rb
+++ b/modules/dhcp_common/pingable.rb
@@ -1,0 +1,58 @@
+require 'timeout'
+require 'socket'
+
+module Proxy::DHCP::Pingable
+  def tcp_pingable? ip
+    # This code is from net-ping, and stripped down for use here
+    # We don't need all the ldap dependencies net-ping brings in
+
+    @service_check = true
+    @port          = 7
+    @timeout       = 1
+    @exception     = nil
+    bool           = false
+    tcp            = nil
+
+    begin
+      Timeout.timeout(@timeout) do
+        begin
+          tcp = TCPSocket.new(ip, @port)
+        rescue Errno::ECONNREFUSED => err
+          if @service_check
+            bool = true
+          else
+            @exception = err
+          end
+        rescue Exception => err
+          @exception = err
+        else
+          bool = true
+        end
+      end
+    rescue Timeout::Error => err
+      @exception = err
+    ensure
+      tcp.close if tcp
+    end
+
+    bool
+  rescue
+    # We failed to check this address so we should not use it
+    true
+  end
+
+  def icmp_pingable? ip
+    # Always shell to ping, instead of using net-ping
+    if PLATFORM =~ /mingw/
+      # Windows uses different options for ping and does not have /dev/null
+      system("ping -n 1 -w 1000 #{ip} > NUL")
+    else
+      # Default to Linux ping options and send to /dev/null
+      system("ping -c 1 -W 1 #{ip} > /dev/null")
+    end
+  rescue => err
+    # We failed to check this address so we should not use it
+    logger.warn "Unable to icmp ping #{ip} because #{err.inspect}. Skipping this address..."
+    true
+  end
+end

--- a/modules/dhcp_common/server.rb
+++ b/modules/dhcp_common/server.rb
@@ -3,6 +3,7 @@ require "dhcp_common/record"
 require "dhcp_common/record/lease"
 require "dhcp_common/record/reservation"
 require 'dhcp_common/record/deleted_reservation'
+require 'dhcp_common/pingable'
 
 module Proxy::DHCP
   class Server
@@ -10,6 +11,7 @@ module Proxy::DHCP
     alias_method :to_s, :name
 
     include Proxy::DHCP
+    include Proxy::DHCP::Pingable
     include Proxy::Log
     include Proxy::Validations
 

--- a/modules/dhcp_common/subnet.rb
+++ b/modules/dhcp_common/subnet.rb
@@ -3,9 +3,8 @@ require 'ipaddr'
 require 'dhcp_common/monkey_patches' unless IPAddr.new.respond_to?('to_range')
 require 'dhcp_common/monkey_patch_subnet' unless Array.new.respond_to?('rotate')
 require 'proxy/validations'
-require 'socket'
-require 'timeout'
 require 'tmpdir'
+require 'dhcp_common/pingable'
 
 module Proxy::DHCP
   class Subnet
@@ -15,6 +14,7 @@ module Proxy::DHCP
     include Proxy::DHCP
     include Proxy::Log
     include Proxy::Validations
+    include Proxy::DHCP::Pingable
 
     def initialize network, netmask, options = {}
       @network = validate_ip network


### PR DESCRIPTION
DHCP reservation created from 10.3.28.100 to 10.3.28.116
Static IPs configured from 10.3.28.117 to 10.3.28.130

DHCP range: 10.3.28.40-10.3.28.250
Foreman range: 10.3.18.100-10.3.28.250
```
D, [2017-10-09T12:55:35.391212 ] DEBUG -- : Searching for free IP in subnet 10.3.28.0
D, [2017-10-09T12:55:35.438011 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.117
D, [2017-10-09T12:55:35.469210 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.118
D, [2017-10-09T12:55:35.500412 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.119
D, [2017-10-09T12:55:35.516017 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.120
D, [2017-10-09T12:55:35.562813 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.121
D, [2017-10-09T12:55:35.578416 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.122
D, [2017-10-09T12:55:35.609617 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.123
D, [2017-10-09T12:55:35.640813 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.124
D, [2017-10-09T12:55:35.672014 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.125
D, [2017-10-09T12:55:35.687616 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.126
D, [2017-10-09T12:55:35.718814 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.127
D, [2017-10-09T12:55:35.734413 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.128
D, [2017-10-09T12:55:35.734413 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.129
D, [2017-10-09T12:55:35.765619 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.130
I, [2017-10-09T12:55:36.795268 ]  INFO -- : Found free IP 10.3.28.131
```

DHCP range: 10.3.28.40-10.3.28.250
Foreman range: 10.3.18.100-10.3.28.116
```
D, [2017-10-09T13:06:47.615083 ] DEBUG -- : Searching for free IP in subnet 10.3.28.0
W, [2017-10-09T13:06:47.615083 ]  WARN -- : No free IP returned by DHCP for subnet 10.3.28.0
```

DHCP range: 10.3.28.40-10.3.28.250
Foreman range: 10.3.18.100-10.3.28.130
```
D, [2017-10-09T12:58:49.506604 ] DEBUG -- : Searching for free IP in subnet 10.3.28.0
D, [2017-10-09T12:58:49.537784 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.117
D, [2017-10-09T12:58:49.568989 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.118
D, [2017-10-09T12:58:49.600186 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.119
D, [2017-10-09T12:58:49.631391 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.120
D, [2017-10-09T12:58:49.662586 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.121
D, [2017-10-09T12:58:49.678193 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.122
D, [2017-10-09T12:58:49.709387 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.123
D, [2017-10-09T12:58:49.740585 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.124
D, [2017-10-09T12:58:49.771789 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.125
D, [2017-10-09T12:58:49.787389 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.126
D, [2017-10-09T12:58:49.943386 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.127
D, [2017-10-09T12:58:49.958992 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.128
D, [2017-10-09T12:58:49.974595 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.129
D, [2017-10-09T12:58:49.990186 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.130
W, [2017-10-09T12:58:49.990186 ]  WARN -- : All IPs returned by the DHCP are already in use
```


Foreman range not specified:
DHCP range: 10.3.28.100-10.3.28.250
```
D, [2017-10-09T13:10:52.109268 ] DEBUG -- : Searching for free IP in subnet 10.3.28.0
D, [2017-10-09T13:10:52.140445 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.117
D, [2017-10-09T13:10:52.156043 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.118
D, [2017-10-09T13:10:52.187241 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.119
D, [2017-10-09T13:10:52.218438 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.120
D, [2017-10-09T13:10:52.234044 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.121
D, [2017-10-09T13:10:52.265242 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.122
D, [2017-10-09T13:10:52.296447 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.123
D, [2017-10-09T13:10:52.312043 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.124
D, [2017-10-09T13:10:52.343244 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.125
D, [2017-10-09T13:10:52.359001 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.126
D, [2017-10-09T13:10:52.374439 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.127
D, [2017-10-09T13:10:52.390041 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.128
D, [2017-10-09T13:10:52.405641 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.129
D, [2017-10-09T13:10:52.421241 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.130
I, [2017-10-09T13:10:53.294893 ]  INFO -- : Found free IP 10.3.28.131
```

Foreman range not specified:
DHCP range: 10.3.28.100-10.3.28.116
```
D, [2017-10-09T13:15:09.889732 ] DEBUG -- : Searching for free IP in subnet 10.3.28.0
W, [2017-10-09T13:15:09.889732 ]  WARN -- : No free IP returned by DHCP for subnet 10.3.28.0
```

Foreman range not specified:
DHCP range: 10.3.28.100-10.3.28.130
```
D, [2017-10-09T13:13:15.320630 ] DEBUG -- : Searching for free IP in subnet 10.3.28.0
D, [2017-10-09T13:13:15.351821 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.117
D, [2017-10-09T13:13:15.383017 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.118
D, [2017-10-09T13:13:15.398616 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.119
D, [2017-10-09T13:13:15.445418 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.120
D, [2017-10-09T13:13:15.476618 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.121
D, [2017-10-09T13:13:15.507817 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.122
D, [2017-10-09T13:13:15.539020 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.123
D, [2017-10-09T13:13:15.554624 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.124
D, [2017-10-09T13:13:15.601423 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.125
D, [2017-10-09T13:13:15.617016 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.126
D, [2017-10-09T13:13:15.632628 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.127
D, [2017-10-09T13:13:15.648221 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.128
D, [2017-10-09T13:13:15.663818 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.129
D, [2017-10-09T13:13:15.679417 ] DEBUG -- : Found a pingable IP address which does not have a DHCP record: 10.3.28.130
E, [2017-10-09T13:13:15.679417 ] ERROR -- : Error looking up a free ip address in subnet 10.3.28.0. One or more of the parameters were invalid.
D, [2017-10-09T13:13:15.679417 ] DEBUG -- : Error looking up a free ip address in subnet 10.3.28.0. One or more of the parameters were invalid. (DhcpsApi::Error)
C:/Ruby24-x64/lib/ruby/gems/2.4.0/gems/dhcpsapi-0.0.11/lib/dhcpsapi/misc.rb:30:in `get_free_ip_address'
...
```

The last case will be corrected by https://github.com/theforeman/smart-proxy/pull/545


