### PR TITLE
Fixes #21350 - Allow restricting to TLSv1.2

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -8,10 +8,15 @@
 #:ssl_private_key: ssl/private_keys/fqdn.key
 
 # Use this option only if you need to disable certain cipher suites.
-# Note: we use the OpenSSL suite name, such as "RC4-MD5". 
-# The complete list of cipher suite names can be found at: 
+# Note: we use the OpenSSL suite name, such as "RC4-MD5".
+# The complete list of cipher suite names can be found at:
 # https://www.openssl.org/docs/manmaster/man1/ciphers.html#CIPHER-SUITE-NAMES
 #:ssl_disabled_ciphers: [CIPHER-SUITE-1, CIPHER-SUITE-2]
+
+# Use this option only if you need to strictly specify TLS
+# versions to be used. SSLv3 is disabled and cannot be configured.
+# TLSv1.1 and TLSv1.2 are available are the default configurations.
+#:ssl_versions: ['TLSv1.2']
 
 # Hosts which the proxy accepts connections from
 # commenting the following lines would mean every verified SSL connection allowed

--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -72,6 +72,13 @@ module Proxy
       ssl_options |= OpenSSL::SSL::OP_NO_SSLv3 if defined?(OpenSSL::SSL::OP_NO_SSLv3)
       ssl_options |= OpenSSL::SSL::OP_NO_TLSv1 if defined?(OpenSSL::SSL::OP_NO_TLSv1)
 
+      if Proxy::SETTINGS.ssl_versions &&
+          defined?(OpenSSL::SSL::OP_NO_TLSv1_1) &&
+            !Proxy::SETTINGS.ssl_versions.include?('TLSv1.1')
+          ssl_options |= OpenSSL::SSL::OP_NO_TLSv1_1
+        end
+      end
+
       {
         :app => app,
         :server => :webrick,

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -11,7 +11,8 @@ module ::Proxy::Settings
       :bind_host => ["*"],
       :log_buffer => 2000,
       :log_buffer_errors => 1000,
-      :ssl_disabled_ciphers => []
+      :ssl_disabled_ciphers => [],
+      :ssl_versions => ['TLSv1.1', 'TLSv1.2']
     }
 
     HOW_TO_NORMALIZE = {


### PR DESCRIPTION
This is not the best way to do this, however, given the versions of Ruby we have to support I cannot add min_version and max_version support for multi-version support. Instead, the only way I could sumise to allow locking to TLSv1.2 or the use of both v1.1 and v1.2 was to disable TLSv1.1 if not configured.