### PR TITLE
fixes #21463 - new reservations are deletable

### DIFF
--- a/modules/dhcp_common/isc/subnet_service_initialization.rb
+++ b/modules/dhcp_common/isc/subnet_service_initialization.rb
@@ -93,7 +93,12 @@ module Proxy::DHCP::CommonISC
         all
       end
 
-      options_and_attributes = parsed_host.dhcp_options.inject({:hostname => name}.merge(attributes_only)) do |all, current|
+      default_attributes = {
+        :hostname => name,
+        :deleteable => false
+      }
+
+      options_and_attributes = parsed_host.dhcp_options.inject(default_attributes.merge(attributes_only)) do |all, current|
         key, values = process_dhcpd_option(current[0], current[1])
         all[key] = values
         all

--- a/modules/dhcp_common/record/lease.rb
+++ b/modules/dhcp_common/record/lease.rb
@@ -13,7 +13,7 @@ module Proxy::DHCP
       super(ip_address, mac_address, subnet, options)
     end
 
-    def deletable?
+    def deleteable?
       false
     end
 

--- a/modules/dhcp_common/record/reservation.rb
+++ b/modules/dhcp_common/record/reservation.rb
@@ -7,7 +7,7 @@ module Proxy::DHCP
     def initialize(name, ip_address, mac_address, subnet, options = {})
       @type = "reservation"
       @name = name
-      super(ip_address, mac_address, subnet, options)
+      super(ip_address, mac_address, subnet, {:deleteable => true}.merge(options))
     end
 
     def to_s

--- a/test/dhcp/dhcp_api_test.rb
+++ b/test/dhcp/dhcp_api_test.rb
@@ -151,12 +151,13 @@ class DhcpApiTest < Test::Unit::TestCase
 
     assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
     expected = [{
-      "type"     => "reservation",
-      "hostname" => "test.example.com",
-      "ip"       => "192.168.122.1",
-      "mac"      => "00:11:bb:cc:dd:ee",
-      "name"     => 'test.example.com',
-      "subnet"   => "192.168.122.0/255.255.255.0"
+      "deleteable" => true,
+      "type"       => "reservation",
+      "hostname"   => "test.example.com",
+      "ip"         => "192.168.122.1",
+      "mac"        => "00:11:bb:cc:dd:ee",
+      "name"       => 'test.example.com',
+      "subnet"     => "192.168.122.0/255.255.255.0"
     }]
     assert_equal expected, JSON.parse(last_response.body)
   end
@@ -200,12 +201,13 @@ class DhcpApiTest < Test::Unit::TestCase
 
     assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
     expected = {
-      "type"     => "reservation",
-      "hostname" =>"test.example.com",
-      "ip"       =>"192.168.122.1",
-      "mac"      =>"00:11:bb:cc:dd:ee",
-      "name"     => 'test.example.com',
-      "subnet"   =>"192.168.122.0/255.255.255.0" # NOTE: 'subnet' attribute isn't being used by foreman, which adds a 'network' attribute instead
+      "deleteable" => true,
+      "type"       => "reservation",
+      "hostname"   =>"test.example.com",
+      "ip"         =>"192.168.122.1",
+      "mac"        =>"00:11:bb:cc:dd:ee",
+      "name"       => 'test.example.com',
+      "subnet"     =>"192.168.122.0/255.255.255.0" # NOTE: 'subnet' attribute isn't being used by foreman, which adds a 'network' attribute instead
     }
     assert_equal expected, JSON.parse(last_response.body)
   end

--- a/test/dhcp/dhcp_isc_subnet_service_initialization_test.rb
+++ b/test/dhcp/dhcp_isc_subnet_service_initialization_test.rb
@@ -115,7 +115,7 @@ END
     @initialization.load_leases_file(File.read("./test/fixtures/dhcp/dhcp.leases"))
     parsed = @subnet_service.all_hosts + @subnet_service.all_leases
 
-    assert_equal 11, parsed.size
+    assert_equal 12, parsed.size
     assert_equal 'bravo.example.com', @subnet_service.find_host_by_hostname("bravo2.example.com").hostname
   end
 
@@ -158,6 +158,20 @@ END
     @subnet_service.add_subnet(subnet)
     @initialization.load_leases_file(File.read("./test/fixtures/dhcp/dhcp.leases"))
     assert_equal 'bravo.example.com', @subnet_service.find_host_by_hostname("bravo2.example.com").hostname
+  end
+
+  def test_dynamic_host_should_be_deleteable
+    subnet = Proxy::DHCP::Subnet.new("192.168.122.0", "255.255.255.0")
+    @subnet_service.add_subnet(subnet)
+    @initialization.load_leases_file(File.read("./test/fixtures/dhcp/dhcp.leases"))
+    assert_equal true, @subnet_service.find_host_by_hostname("bravo2.example.com").deleteable?
+  end
+
+  def test_static_host_should_not_be_deleteable
+    subnet = Proxy::DHCP::Subnet.new("192.168.122.0", "255.255.255.0")
+    @subnet_service.add_subnet(subnet)
+    @initialization.load_leases_file(File.read("./test/fixtures/dhcp/dhcp.leases"))
+    assert_equal false, @subnet_service.find_host_by_hostname("static.example.com").deleteable?
   end
 
   def test_parsing_and_loading_leases

--- a/test/dhcp/server_test.rb
+++ b/test/dhcp/server_test.rb
@@ -13,7 +13,7 @@ class DHCPServerTest < Test::Unit::TestCase
     @subnet = Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0")
     @service.add_subnet(@subnet)
 
-    @record = Proxy::DHCP::Reservation.new('test', "192.168.0.11", "aa:bb:cc:dd:ee:ff", @subnet, :hostname => 'test')
+    @record = Proxy::DHCP::Reservation.new('test', "192.168.0.11", "aa:bb:cc:dd:ee:ff", @subnet, :hostname => 'test', :deleteable => true)
     @service.add_host(@subnet.network, @record)
   end
 

--- a/test/fixtures/dhcp/dhcp.leases
+++ b/test/fixtures/dhcp/dhcp.leases
@@ -198,6 +198,12 @@ host alpha.example.com {
   fixed-address 192.168.122.42;
 }
 
+# Not a dynamic host
+host static.example.com {
+  hardware ethernet 44:1e:a1:11:36:15;
+  fixed-address 192.168.122.80;
+}
+
 # Prevent deletion of a reserved record via expired lease
 host quux.example.org {
   dynamic;


### PR DESCRIPTION
This should make smart proxy detect that a record already exists when the record to be created does not have `options[:deleteable]` set.