### PR TITLE
Fixes #19053 - rotate logs on SIGHUP

### DIFF
--- a/lib/proxy/signal_handler.rb
+++ b/lib/proxy/signal_handler.rb
@@ -8,7 +8,10 @@ class Proxy::SignalHandler
     handler.install_ttin_trap unless RUBY_PLATFORM =~ /mingw/
     handler.install_int_trap
     handler.install_term_trap
-    handler.install_usr1_trap unless RUBY_PLATFORM =~ /mingw/
+    unless RUBY_PLATFORM =~ /mingw/
+      handler.install_hup_trap
+      handler.install_usr1_trap
+    end
   end
 
   def install_ttin_trap
@@ -33,6 +36,13 @@ class Proxy::SignalHandler
     trap(:TERM) { exit(0) }
   end
 
+  def install_hup_trap
+    trap(:HUP) do
+      ::Proxy::LogBuffer::Decorator.instance.roll_log
+    end
+  end
+
+  # for backward compatibility
   def install_usr1_trap
     trap(:USR1) do
       ::Proxy::LogBuffer::Decorator.instance.roll_log


### PR DESCRIPTION
This is an anternative solution to the SELinux logrotate problem. SIGHUP is allowed by the default policy, so I am making smart-proxy to respond to that signal as expected and leaving SIGUSR1 behavior untouched for backward compatibility. This allows me to change the logrotate script to send HUP instead SIG1 which will just work.

Replaces https://github.com/theforeman/smart-proxy/pull/544

As part of this effort I will also add `delaycompress` to the logrotate script to solve missing lines during rotation.

Edit: Moved the issue to the project.