### PR TITLE
fixes #4917 - add active directory realm provider

### DIFF
--- a/bundler.d/realm_ad.rb
+++ b/bundler.d/realm_ad.rb
@@ -1,0 +1,3 @@
+group :realm_ad do
+  gem 'radcli'
+end

--- a/config/settings.d/realm.yml.example
+++ b/config/settings.d/realm.yml.example
@@ -4,4 +4,5 @@
 
 # Available providers:
 #   realm_freeipa
+#   realm_ad
 :use_provider: realm_freeipa

--- a/config/settings.d/realm_ad.yml.example
+++ b/config/settings.d/realm_ad.yml.example
@@ -1,0 +1,24 @@
+---
+# Authentication for Kerberos-based Realms
+:realm: EXAMPLE.COM
+
+# Kerberos pricipal used to authenticate against Active Directory
+:principal: realm-proxy@EXAMPLE.COM
+
+# Path to the keytab used to authenticate against Active Directory
+:keytab_path:  /etc/foreman-proxy/realm_ad.keytab
+
+# FQDN of the Domain Controller
+:domain_controller: dc.example.com
+
+# Optional: OU where the machine account shall be placed
+#:ou: OU=Linux,OU=Servers,DC=example,DC=com
+
+# Optional: Prefix for the computername
+#:computername_prefix: ''
+
+# Optional: Generate the computername by calculating the SHA256 hexdigest of the hostname
+#:computername_hash: false
+
+# Optional:  use the fqdn of the host to generate the computername
+#:computername_use_fqdn: false

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -79,6 +79,7 @@ module Proxy
   require 'bmc/bmc'
   require 'realm/realm'
   require 'realm_freeipa/realm_freeipa'
+  require 'realm_ad/realm_ad'
   require 'logs/logs'
 
   def self.version

--- a/modules/realm_ad/configuration_loader.rb
+++ b/modules/realm_ad/configuration_loader.rb
@@ -1,0 +1,23 @@
+module Proxy::AdRealm
+  class ConfigurationLoader
+    def load_classes
+      require 'realm_ad/provider'
+    end
+
+    def load_dependency_injection_wirings(container_instance, settings)
+      container_instance.dependency :realm_provider_impl,
+                                    lambda {
+                                      ::Proxy::AdRealm::Provider.new(
+                                        realm: settings[:realm],
+                                        keytab_path: settings[:keytab_path],
+                                        principal: settings[:principal],
+                                        domain_controller: settings[:domain_controller],
+                                        ou: settings[:ou],
+                                        computername_prefix: settings[:computername_prefix],
+                                        computername_hash: settings[:computername_hash],
+                                        computername_use_fqdn: settings[:computername_use_fqdn]
+                                      )
+                                    }
+    end
+  end
+end

--- a/modules/realm_ad/provider.rb
+++ b/modules/realm_ad/provider.rb
@@ -1,0 +1,131 @@
+require 'proxy/kerberos'
+require 'radcli'
+require 'digest'
+
+module Proxy::AdRealm
+  class Provider
+    include Proxy::Log
+    include Proxy::Util
+    include Proxy::Kerberos
+
+    attr_reader :realm, :keytab_path, :principal, :domain_controller, :domain, :ou, :computername_prefix, :computername_hash, :computername_use_fqdn
+
+    def initialize(options = {})
+      @realm = options[:realm]
+      @keytab_path = options[:keytab_path]
+      @principal = options[:principal]
+      @domain_controller = options[:domain_controller]
+      @domain = options[:realm].downcase
+      @ou = options[:ou]
+      @computername_prefix = options[:computername_prefix]
+      @computername_hash = options[:computername_hash]
+      @computername_use_fqdn = options[:computername_use_fqdn]
+      logger.info 'Proxy::AdRealm: initialize...'
+    end
+
+    def check_realm(realm)
+      raise Exception, "Unknown realm #{realm}" unless realm.casecmp(@realm).zero?
+    end
+
+    def find(_hostfqdn)
+      true
+    end
+
+    def create(realm, hostfqdn, params)
+      logger.info "Proxy::AdRealm: create... #{realm}, #{hostfqdn}, #{params}"
+      check_realm(realm)
+      kinit_radcli_connect
+
+      password = generate_password
+      result = { randompassword: password }
+
+      computername = hostfqdn_to_computername(hostfqdn)
+
+      if params[:rebuild] == 'true'
+        radcli_password(computername, password)
+      else
+        radcli_join(hostfqdn, computername, password)
+      end
+
+      JSON.pretty_generate(result)
+    end
+
+    def delete(realm, hostfqdn)
+      logger.info "Proxy::AdRealm: delete... #{realm}, #{hostfqdn}"
+      kinit_radcli_connect
+      check_realm(realm)
+      computername = hostfqdn_to_computername(hostfqdn)
+      radcli_delete(computername)
+    end
+
+    private
+
+    def hostfqdn_to_computername(hostfqdn)
+      computername = hostfqdn
+
+      # strip the domain from the host
+      computername = computername.split('.').first unless computername_use_fqdn
+
+      # generate the SHA256 hexdigest from the computername
+      computername = Digest::SHA256.hexdigest(computername) if computername_hash
+
+      # apply prefix if it has not already been applied
+      computername = computername_prefix + computername if apply_computername_prefix?(computername)
+
+      # limit length to 15 characters and upcase the computername
+      # see https://support.microsoft.com/en-us/kb/909264
+      computername[0, 15].upcase
+    end
+
+    def apply_computername_prefix?(computername)
+      !computername_prefix.nil? && !computername_prefix.empty? && (computername_hash || !computername[0, computername_prefix.size].casecmp(computername_prefix).zero?)
+    end
+
+    def kinit_radcli_connect
+      init_krb5_ccache(@keytab_path, @principal)
+      @adconn = radcli_connect
+    end
+
+    def radcli_connect
+      # Connect to active directory
+      conn = Adcli::AdConn.new(@domain)
+      conn.set_domain_realm(@realm)
+      conn.set_domain_controller(@domain_controller)
+      conn.set_login_ccache_name('')
+      conn.connect
+      conn
+    end
+
+    def radcli_join(hostfqdn, computername, password)
+      # Join computer
+      enroll = Adcli::AdEnroll.new(@adconn)
+      enroll.set_computer_name(computername)
+      enroll.set_host_fqdn(hostfqdn)
+      enroll.set_domain_ou(@ou) if @ou
+      enroll.set_computer_password(password)
+      enroll.join
+    end
+
+    def generate_password
+      characters = ('A'..'Z').to_a + ('a'..'z').to_a + (0..9).to_a
+      Array.new(20) { characters.sample }.join
+    end
+
+    def radcli_password(computername, password)
+      # Reset a computer's password
+      enroll = Adcli::AdEnroll.new(@adconn)
+      enroll.set_computer_name(computername)
+      enroll.set_domain_ou(@ou) if @ou
+      enroll.set_computer_password(password)
+      enroll.password
+    end
+
+    def radcli_delete(computername)
+      # Delete a computer's account
+      enroll = Adcli::AdEnroll.new(@adconn)
+      enroll.set_computer_name(computername)
+      enroll.set_domain_ou(@ou) if @ou
+      enroll.delete
+    end
+  end
+end

--- a/modules/realm_ad/realm_ad.rb
+++ b/modules/realm_ad/realm_ad.rb
@@ -1,0 +1,2 @@
+require 'realm_ad/configuration_loader'
+require 'realm_ad/realm_ad_plugin'

--- a/modules/realm_ad/realm_ad_plugin.rb
+++ b/modules/realm_ad/realm_ad_plugin.rb
@@ -1,0 +1,13 @@
+module Proxy::AdRealm
+  class Plugin < Proxy::Provider
+    default_settings :computername_prefix => '', :computername_prefix => false, :computername_use_fqdn => false
+
+    load_classes ::Proxy::AdRealm::ConfigurationLoader
+    load_dependency_injection_wirings ::Proxy::AdRealm::ConfigurationLoader
+
+    validate_presence :realm, :keytab_path, :principal, :domain_controller
+    validate_readable :keytab_path
+
+    plugin :realm_ad, ::Proxy::VERSION
+  end
+end

--- a/test/realm/ad_provider_test.rb
+++ b/test/realm/ad_provider_test.rb
@@ -1,0 +1,124 @@
+require 'test_helper'
+require 'realm_ad/provider'
+require 'radcli'
+
+class RealmAdTest < Test::Unit::TestCase
+  def setup
+    @realm = 'test_realm'
+    @provider = Proxy::AdRealm::Provider.new(
+      realm: 'example.com',
+      keytab_path: 'keytab_path',
+      principal: 'principal',
+      domain_controller: 'domain-controller',
+      ou: nil,
+      computername_prefix: nil,
+      computername_hash: false,
+      computername_use_fqdn: false
+    )
+  end
+
+  def test_create_host
+    hostname = 'host.example.com'
+    computername = 'HOST'
+    params = {
+      rebuild: 'false'
+    }
+    @provider.expects(:check_realm).with(@realm)
+    @provider.expects(:kinit_radcli_connect)
+    @provider.expects(:generate_password).returns('password')
+    @provider.expects(:radcli_join).with(hostname, computername, 'password')
+    @provider.create(@realm, hostname, params)
+  end
+
+  def test_create_host_generates_password
+    hostname = 'host.example.com'
+    params = {
+      rebuild: 'false'
+    }
+    @provider.expects(:check_realm).with(@realm)
+    @provider.expects(:kinit_radcli_connect)
+    @provider.expects(:radcli_join)
+    response = JSON.parse(@provider.create(@realm, hostname, params))
+    assert_kind_of String, response['randompassword']
+    assert_equal 20, response['randompassword'].size
+  end
+
+  def test_create_host_prefixes_computername
+    hostname = 'host.example.com'
+    computername = 'ORG-HOST'
+    params = {
+      rebuild: 'false'
+    }
+    @provider.stubs(:computername_prefix).returns('ORG-')
+    @provider.expects(:check_realm).with(@realm)
+    @provider.expects(:kinit_radcli_connect)
+    @provider.expects(:generate_password).returns('password')
+    @provider.expects(:radcli_join).with(hostname, computername, 'password')
+    @provider.create(@realm, hostname, params)
+  end
+
+  def test_create_host_limits_computername_to_15_characters
+    hostname = 'superlonghostname.example.com'
+    computername = 'SUPERLONGHOSTNA'
+    params = {
+      rebuild: 'false'
+    }
+    @provider.expects(:check_realm).with(@realm)
+    @provider.expects(:kinit_radcli_connect)
+    @provider.expects(:generate_password).returns('password')
+    @provider.expects(:radcli_join).with(hostname, computername, 'password')
+    @provider.create(@realm, hostname, params)
+  end
+
+  def test_create_host_applies_sha256_to_computername
+    hostname = 'host.example.com'
+    computername = '4740AE6347B0172'
+    params = {
+      rebuild: 'false'
+    }
+    @provider.stubs(:computername_hash).returns(true)
+    @provider.expects(:check_realm).with(@realm)
+    @provider.expects(:kinit_radcli_connect)
+    @provider.expects(:generate_password).returns('password')
+    @provider.expects(:radcli_join).with(hostname, computername, 'password')
+    @provider.create(@realm, hostname, params)
+  end
+
+  def test_create_with_unrecognized_realm_raises_exception
+    assert_raises(Exception) { @provider.create('unknown_realm', 'a_host', {}) }
+  end
+
+  def test_create_rebuild
+    hostname = 'host.example.com'
+    params = {}
+    params[:rebuild] = 'true'
+    @provider.expects(:check_realm).with(@realm)
+    @provider.expects(:kinit_radcli_connect)
+    @provider.expects(:radcli_password)
+    response = JSON.parse(@provider.create(@realm, hostname, params))
+    assert_kind_of String, response['randompassword']
+    assert_equal 20, response['randompassword'].size
+  end
+
+  def test_rebuild_with_unrecognized_realm_raises_exception
+    params = {}
+    params[:rebuild] = 'true'
+    assert_raises(Exception) { @provider.create('unknown_realm', 'a_host', params) }
+  end
+
+  def test_find
+    assert_true @provider.find('a_host_fqdn')
+  end
+
+  def test_delete
+    @provider.expects(:check_realm).with(@realm)
+    @provider.expects(:kinit_radcli_connect)
+    @provider.expects(:radcli_delete)
+    @provider.delete(@realm, 'a_host')
+  end
+
+  def test_delete_unrecognized_realm_raises_exception
+    @provider.expects(:kinit_radcli_connect)
+    assert_raises(Exception) { @provider.delete('unkown_realm', 'a_host') }
+  end
+end


### PR DESCRIPTION
This is an attempt to add active directory as a core realm provider to smart-proxy.

This is a port of [smart_proxy_realm_ad_plugin](https://github.com/martencassel/smart_proxy_realm_ad_plugin).

To interact with active directory, this used the [radcli gem](https://github.com/martencassel/radcli). The gem is not available on rubygems for now and should probably be reviewed as well. I have no real knowledge of the C programming language, so I can't say anything about it. We might want to consider moving it to the foreman org and maintaining it there. But that's just a bold suggestion :-)

I'm opening this for discussion. Please let me know your thoughts.

cc: @martencassel