### PR TITLE
fixes #21350 - allow disabling of TLS versions

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -8,10 +8,15 @@
 #:ssl_private_key: ssl/private_keys/fqdn.key
 
 # Use this option only if you need to disable certain cipher suites.
-# Note: we use the OpenSSL suite name, such as "RC4-MD5". 
-# The complete list of cipher suite names can be found at: 
+# Note: we use the OpenSSL suite name, such as "RC4-MD5".
+# The complete list of cipher suite names can be found at:
 # https://www.openssl.org/docs/manmaster/man1/ciphers.html#CIPHER-SUITE-NAMES
 #:ssl_disabled_ciphers: [CIPHER-SUITE-1, CIPHER-SUITE-2]
+
+# Use this option only if you need to strictly specify TLS
+# versions to be used. SSLv3 is disabled and cannot be configured.
+# TLSv1.1 and TLSv1.2 are available are the default configurations.
+#:ssl_versions: ['TLSv1.2']
 
 # Hosts which the proxy accepts connections from
 # commenting the following lines would mean every verified SSL connection allowed

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -13,10 +13,10 @@
 # https://www.openssl.org/docs/manmaster/man1/ciphers.html#CIPHER-SUITE-NAMES
 #:ssl_disabled_ciphers: [CIPHER-SUITE-1, CIPHER-SUITE-2]
 
-# Use this option only if you need to strictly specify TLS
-# versions to be used. SSLv3 is disabled and cannot be configured.
-# TLSv1.1 and TLSv1.2 are available are the default configurations.
-#:ssl_versions: ['TLSv1.2']
+# Use this option only if you need to strictly specify TLS versions to be
+# disabled. SSLv3 and TLS v1.0 are always disabled and cannot be configured.
+# Specify versions like: '1.1', or '1.2'
+#:tls_disabled_versions: []
 
 # Hosts which the proxy accepts connections from
 # commenting the following lines would mean every verified SSL connection allowed

--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -80,7 +80,7 @@ module Proxy
             logger.info "TLSv#{version} will be disabled."
             ssl_options |= constant
           else
-            logger.warn "TLSv#{version} cannot be disabled, it was not found."
+            logger.warn "TLSv#{version} was not found."
           end
         end
       end

--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -72,6 +72,13 @@ module Proxy
       ssl_options |= OpenSSL::SSL::OP_NO_SSLv3 if defined?(OpenSSL::SSL::OP_NO_SSLv3)
       ssl_options |= OpenSSL::SSL::OP_NO_TLSv1 if defined?(OpenSSL::SSL::OP_NO_TLSv1)
 
+      if Proxy::SETTINGS.ssl_versions &&
+          defined?(OpenSSL::SSL::OP_NO_TLSv1_1) &&
+            !Proxy::SETTINGS.ssl_versions.include?('TLSv1.1')
+          ssl_options |= OpenSSL::SSL::OP_NO_TLSv1_1
+        end
+      end
+
       {
         :app => app,
         :server => :webrick,

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -12,7 +12,7 @@ module ::Proxy::Settings
       :log_buffer => 2000,
       :log_buffer_errors => 1000,
       :ssl_disabled_ciphers => [],
-      :ssl_versions => ['TLSv1.1', 'TLSv1.2']
+      :tls_disabled_versions => []
     }
 
     HOW_TO_NORMALIZE = {

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -11,7 +11,8 @@ module ::Proxy::Settings
       :bind_host => ["*"],
       :log_buffer => 2000,
       :log_buffer_errors => 1000,
-      :ssl_disabled_ciphers => []
+      :ssl_disabled_ciphers => [],
+      :ssl_versions => ['TLSv1.1', 'TLSv1.2']
     }
 
     HOW_TO_NORMALIZE = {


### PR DESCRIPTION
Taking over https://github.com/theforeman/smart-proxy/pull/547 for @ehelms.

You can specify arbitrary TLS versions to disable.  Once 1.3 is available, this should still work assuming they keep the same convention for the constant name as 1.1 and 1.2 