### PR TITLE
Fixes #22292 - Config option for tftp timeout

### DIFF
--- a/config/settings.d/tftp.yml.example
+++ b/config/settings.d/tftp.yml.example
@@ -5,3 +5,15 @@
 #:tftproot: /var/lib/tftpboot
 # Defines the TFTP Servername to use, overrides the name in the subnet declaration
 #:tftp_servername: tftp.domain.com
+
+# Defines the default read timeout in seconds needed to download tftp artifacts
+# like initrd and vmlinuz. Default value 60 seconds
+#:tftp_read_timeout: 60
+
+# Defines the default connection timeout in seconds needed to download tftp artifacts
+# like initrd and vmlinuz. Default value 10 seconds
+#:tftp_connect_timeout: 10
+
+# Defines the default dns timeout in seconds needed to download tftp artifacts
+# like initrd and vmlinuz. Default value 10 seconds
+#:tftp_dns_timeout: 10

--- a/lib/proxy/http_download.rb
+++ b/lib/proxy/http_download.rb
@@ -3,11 +3,19 @@ require 'proxy/file_lock'
 module Proxy
   class HttpDownload < Proxy::Util::CommandTask
     include Util
+    DEFAULT_READ_TIMEOUT = 60
+    DEFAULT_CONNECT_TIMEOUT = 10
+    DEFAULT_DNS_TIMEOUT = 10
 
-    def initialize(src, dst)
+    def initialize(src, dst, read_timeout = nil, connect_timeout = nil, dns_timeout = nil)
       @dst = dst
       wget = which("wget")
-      super("#{wget} --timeout=10 --tries=3 --no-check-certificate -nv -c \"#{escape_for_shell(src.to_s)}\" -O \"#{escape_for_shell(dst.to_s)}\"")
+      read_timeout ||= DEFAULT_READ_TIMEOUT
+      dns_timeout ||= DEFAULT_CONNECT_TIMEOUT
+      connect_timeout ||= DEFAULT_DNS_TIMEOUT
+
+      super("#{wget} --connect-timeout=#{connect_timeout} --dns-timeout=#{dns_timeout} --read-timeout=#{read_timeout}"\
+            " --tries=3 --no-check-certificate -nv -c \"#{escape_for_shell(src.to_s)}\" -O \"#{escape_for_shell(dst.to_s)}\"")
     end
 
     def start

--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -153,7 +153,11 @@ module Proxy::TFTP
   def self.choose_protocol_and_fetch(src, destination)
     case URI(src).scheme
     when 'http', 'https', 'ftp'
-      ::Proxy::HttpDownload.new(src.to_s, destination.to_s).start
+      ::Proxy::HttpDownload.new(src.to_s,
+                                destination.to_s,
+                                Proxy::TFTP::Plugin.settings.tftp_read_timeout,
+                                Proxy::TFTP::Plugin.settings.tftp_connect_timeout,
+                                Proxy::TFTP::Plugin.settings.tftp_dns_timeout).start
     when 'nfs'
       logger.debug "NFS as a protocol for installation medium detected."
     else

--- a/modules/tftp/tftp_plugin.rb
+++ b/modules/tftp/tftp_plugin.rb
@@ -5,6 +5,10 @@ module Proxy::TFTP
     http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
-    default_settings :tftproot => '/var/lib/tftpboot'
+    default_settings :tftproot => '/var/lib/tftpboot',
+                     :tftp_read_timeout => 60,
+                     :tftp_connect_timeout => 10,
+                     :tftp_dns_timeout => 10
+
   end
 end

--- a/test/http_download_test.rb
+++ b/test/http_download_test.rb
@@ -7,9 +7,32 @@ class HttpDownloadsTest < Test::Unit::TestCase
   end
 
   def test_should_construct_escaped_wget_command
-    expected = "/wget --timeout=10 --tries=3 --no-check-certificate -nv -c \"src\" -O \"dst\""
+    default_read = Proxy::HttpDownload::DEFAULT_READ_TIMEOUT
+    default_connect = Proxy::HttpDownload::DEFAULT_CONNECT_TIMEOUT
+    default_dns = Proxy::HttpDownload::DEFAULT_DNS_TIMEOUT
+
+    expected = "/wget --connect-timeout=#{default_connect} --dns-timeout=#{default_dns} --read-timeout=#{default_read} --tries=3 --no-check-certificate -nv -c \"src\" -O \"dst\""
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst').command
+  end
+
+  def test_should_construct_escaped_wget_command_only_read
+    default_connect = Proxy::HttpDownload::DEFAULT_CONNECT_TIMEOUT
+    default_dns = Proxy::HttpDownload::DEFAULT_DNS_TIMEOUT
+
+    read_timeout = 1000
+    expected = "/wget --connect-timeout=#{default_connect} --dns-timeout=#{default_dns} --read-timeout=#{read_timeout} --tries=3 --no-check-certificate -nv -c \"src\" -O \"dst\""
+    Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
+    assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, nil, nil).command
+  end
+
+  def test_should_construct_escaped_wget_command_all_timeout_options
+    read_timeout = 1000
+    connect_timeout = 99
+    dns_timeout = 27
+    expected = "/wget --connect-timeout=#{connect_timeout} --dns-timeout=#{dns_timeout} --read-timeout=#{read_timeout} --tries=3 --no-check-certificate -nv -c \"src\" -O \"dst\""
+    Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
+    assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, connect_timeout, dns_timeout).command
   end
 
   def test_should_skip_download_if_one_is_in_progress

--- a/test/tftp/tftp_test.rb
+++ b/test/tftp/tftp_test.rb
@@ -57,6 +57,39 @@ class TftpTest < Test::Unit::TestCase
     end
   end
 
+  def test_choose_protocol_and_fetch_wget_with_timeouts
+    src = "https://proxy.test"
+    dst = "/destination"
+    tftp_read_timeout = "1000"
+    tftp_connect_timeout = "40"
+    tftp_dns_timeout = "14300"
+    Proxy::TFTP::Plugin.load_test_settings(
+        :tftp_read_timeout => tftp_read_timeout,
+        :tftp_connect_timeout => tftp_connect_timeout,
+        :tftp_dns_timeout => tftp_dns_timeout
+    )
+
+    ::Proxy::HttpDownload.expects(:new).returns(stub(:start)).
+      with(src, dst, tftp_read_timeout, tftp_connect_timeout, tftp_dns_timeout)
+
+    Proxy::TFTP.choose_protocol_and_fetch src, dst
+  end
+
+  def test_choose_protocol_and_fetch_wget_with_read_timeout
+    src = "https://proxy.test"
+    dst = "/destination"
+    tftp_read_timeout = "1000"
+    tftp_connect_timeout = Proxy::TFTP::Plugin.settings.tftp_connect_timeout
+    tftp_dns_timeout = Proxy::TFTP::Plugin.settings.tftp_dns_timeout
+
+    Proxy::TFTP::Plugin.load_test_settings(:tftp_read_timeout => tftp_read_timeout)
+
+    ::Proxy::HttpDownload.expects(:new).returns(stub(:start)).
+      with(src, dst, tftp_read_timeout, tftp_connect_timeout, tftp_dns_timeout)
+
+    Proxy::TFTP.choose_protocol_and_fetch src, dst
+  end
+
   def test_choose_protocol_and_fetch_nfs
     assert_nothing_raised RuntimeError do
       Proxy::TFTP.choose_protocol_and_fetch 'nfs://proxy.test', '/destination'


### PR DESCRIPTION
Smart proxy TFTP plugin uses wget to download initrd, vmlinuz,
squash.img etc. It by default uses a connection/dns and read timeout of 10 seconds.

This commit enables one to the set the individual time outs via config
options. If these options are not set the code assumes the default 10s.