### PR TITLE
Fixes #22432 - Handle LITERAL in ignored_declaration

### DIFF
--- a/modules/dhcp_common/isc/configuration_parser.rb
+++ b/modules/dhcp_common/isc/configuration_parser.rb
@@ -185,7 +185,7 @@ module Proxy
         DOUBLE_QUOTE = '"'.r 'double quote'
 
         def ignored_declaration
-          seq_(SPACE.join(/[^\s{};#]+/).odd, EOSTMT | COMMENT) {|content, _| IgnoredDeclaration[content]}
+          seq_(SPACE.join(LITERAL | /[^\s{};#]+/.r).odd, EOSTMT | COMMENT) {|content, _| IgnoredDeclaration[content]}
         end
 
         def ignored_block


### PR DESCRIPTION
If an `ignored_declaration` is a literal string containing certain regex-matched characters (`\s{};#`), configuration parsing breaks, with spurious error messages. The code should handle `LITERAL` values in addition to the current regex.

In my case, my /var/lib/dhcp/dhcpd.leases file had the following content:

```
# The format of this file is documented in the dhcpd.leases(5) manual page.
# This lease file was written by isc-dhcp-4.2.5

server-duid "\000\001\000\001!\374\304\243\000PV\244\350{";

```

This LLT duid contains a '{' because the VM's MAC address contains a 0x7b octet ('{'). This causes parsing to break, and dhcp_isc to fail with the following (misleading) error:

```
E, [2018-01-25T10:53:42.891745 ] ERROR -- : Couldn't enable 'dhcp_isc':
in /var/lib/dhcpd/dhcpd.leases:6 at 1, expect token [ include_keyword ]

 ^
D, [2018-01-25T10:53:42.891791 ] DEBUG -- : ["/usr/share/gems/gems/rsec-0.4.2/lib/rsec/parser.rb:19:in `parse!'", "/usr/share/foreman-proxy/
modules/dhcp_common/isc/configuration_parser.rb:390:in `subnets_hosts_and_leases'", "/usr/share/foreman-proxy/modules/dhcp_common/isc/subnet
_service_initialization.rb:17:in `load_leases_file'", "/usr/share/foreman-proxy/modules/dhcp_isc/isc_state_changes_observer.rb:156:in `load_
leases_file'", "/usr/share/foreman-proxy/modules/dhcp_isc/isc_state_changes_observer.rb:130:in `block in do_start'", "/usr/share/foreman-pro
xy/modules/dhcp_common/subnet_service.rb:154:in `block in group_changes'", "/usr/share/ruby/monitor.rb:211:in `mon_synchronize'", "/usr/shar
e/foreman-proxy/modules/dhcp_common/subnet_service.rb:154:in `group_changes'", "/usr/share/foreman-proxy/modules/dhcp_isc/isc_state_changes_
observer.rb:128:in `do_start'", "/usr/share/foreman-proxy/modules/dhcp_isc/isc_state_changes_observer.rb:80:in `start'", "/usr/share/foreman
-proxy/modules/dhcp_isc/inotify_leases_file_observer.rb:42:in `start'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:235:in `bl
ock in start_services'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:233:in `each'", "/usr/share/foreman-proxy/lib/proxy/plugi
n_initializer.rb:233:in `start_services'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:218:in `configure_plugin'", "/usr/share
/foreman-proxy/lib/proxy/plugin_initializer.rb:89:in `block in configure'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:89:in
`each'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:89:in `configure'", "/usr/share/foreman-proxy/lib/proxy/plugin_initialize
r.rb:167:in `block in initialize_plugins'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:167:in `each'", "/usr/share/foreman-pr
oxy/lib/proxy/plugin_initializer.rb:167:in `initialize_plugins'", "/usr/share/foreman-proxy/lib/launcher.rb:153:in `launch'", "/usr/share/fo
reman-proxy/bin/smart-proxy:6:in `<main>'"]
E, [2018-01-25T10:53:42.891957 ] ERROR -- : Disabling all modules in the group ['dhcp_isc', 'dhcp'] due to a failure in one of them:
in /var/lib/dhcpd/dhcpd.leases:6 at 1, expect token [ include_keyword ]

 ^
D, [2018-01-25T10:53:42.891992 ] DEBUG -- : ["/usr/share/gems/gems/rsec-0.4.2/lib/rsec/parser.rb:19:in `parse!'", "/usr/share/foreman-proxy/
modules/dhcp_common/isc/configuration_parser.rb:390:in `subnets_hosts_and_leases'", "/usr/share/foreman-proxy/modules/dhcp_common/isc/subnet
_service_initialization.rb:17:in `load_leases_file'", "/usr/share/foreman-proxy/modules/dhcp_isc/isc_state_changes_observer.rb:156:in `load_
leases_file'", "/usr/share/foreman-proxy/modules/dhcp_isc/isc_state_changes_observer.rb:130:in `block in do_start'", "/usr/share/foreman-pro
xy/modules/dhcp_common/subnet_service.rb:154:in `block in group_changes'", "/usr/share/ruby/monitor.rb:211:in `mon_synchronize'", "/usr/shar
e/foreman-proxy/modules/dhcp_common/subnet_service.rb:154:in `group_changes'", "/usr/share/foreman-proxy/modules/dhcp_isc/isc_state_changes_
observer.rb:128:in `do_start'", "/usr/share/foreman-proxy/modules/dhcp_isc/isc_state_changes_observer.rb:80:in `start'", "/usr/share/foreman
-proxy/modules/dhcp_isc/inotify_leases_file_observer.rb:42:in `start'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:235:in `bl
ock in start_services'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:233:in `each'", "/usr/share/foreman-proxy/lib/proxy/plugi
n_initializer.rb:233:in `start_services'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:218:in `configure_plugin'", "/usr/share
/foreman-proxy/lib/proxy/plugin_initializer.rb:89:in `block in configure'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:89:in
`each'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:89:in `configure'", "/usr/share/foreman-proxy/lib/proxy/plugin_initialize
r.rb:167:in `block in initialize_plugins'", "/usr/share/foreman-proxy/lib/proxy/plugin_initializer.rb:167:in `each'", "/usr/share/foreman-pr
oxy/lib/proxy/plugin_initializer.rb:167:in `initialize_plugins'", "/usr/share/foreman-proxy/lib/launcher.rb:153:in `launch'", "/usr/share/fo
reman-proxy/bin/smart-proxy:6:in `<main>'"]
```

NOTE: I do not know this code well enough to know if this is really the correct fix, but it works for this case. YMMV.