### PR TITLE
Fixes #22435 - Switch to to_json for FreeIPA

### DIFF
--- a/modules/realm_freeipa/provider.rb
+++ b/modules/realm_freeipa/provider.rb
@@ -76,10 +76,10 @@ module Proxy::FreeIPARealm
         result = do_host_modify(hostname, setattr)
       end
 
-      JSON.pretty_generate(result["result"])
+      result['result'].to_json
     rescue => e
       if e.message =~ /no modifications/
-        JSON.pretty_generate("message" => "nothing to do")
+        JSON.pretty_generate({"message" => "nothing to do"})
       else
         raise
       end
@@ -118,7 +118,8 @@ module Proxy::FreeIPARealm
           raise
         end
       end
-      JSON.pretty_generate(result)
+
+      result.to_json
     end
 
     def self.ensure_utf(object)

--- a/test/realm/freeipa_provider_test.rb
+++ b/test/realm/freeipa_provider_test.rb
@@ -49,7 +49,7 @@ class FreeIPATest < Test::Unit::TestCase
   def test_delete
     ok_result = {:a => 'a'}
     @provider.expects(:ipa_call).with('host_del', ['a_host'], 'updatedns' => true).returns(ok_result)
-    assert_equal JSON.pretty_generate(ok_result), @provider.delete(@realm, 'a_host')
+    assert_equal ok_result.to_json, @provider.delete(@realm, 'a_host')
   end
 
   def test_delete_with_unrecognized_realm_raises_exception
@@ -123,7 +123,7 @@ class FreeIPATest < Test::Unit::TestCase
                    1 => unicode_string,
                    :key => unicode_string }, new_hash)
 
-    deserialized_hash = JSON.load(JSON.pretty_generate(new_hash))
+    deserialized_hash = JSON.load(new_hash.to_json)
     assert_equal({ unicode_string => { unicode_string => [ unicode_string, 'test'],
                                        'hello' => 'world' },
                    '1' => unicode_string,


### PR DESCRIPTION
On current Puppet 4, pretty_generate calls fail for types like string
and boolean. This is in part due to Puppet 4 requiring json_pure
~> 1.8.