### PR TITLE
Fixes #22651 - extend dhcpd config parser support for "include"'s

### DIFF
--- a/modules/dhcp_common/isc/configuration_parser.rb
+++ b/modules/dhcp_common/isc/configuration_parser.rb
@@ -336,7 +336,7 @@ module Proxy
           keyword = word('shared-network').fail 'keyword_shared_network'
           seq_(keyword,
                SPACE.join(LITERAL | FQDN).odd, LFT_BRACKET,
-               SPACE.join(option | host | lazy {subnet} | lazy {group} | pool | COMMENT | deleted | ignored_declaration | ignored_block).odd,
+               SPACE.join(include_file | option | host | lazy {subnet} | lazy {group} | pool | COMMENT | deleted | ignored_declaration | ignored_block).odd,
                RGT_BRACKET).cached {|_, name, _, statements, _| GroupNode[name.first, statements]}
         end
 

--- a/test/dhcp/conf_parser_test.rb
+++ b/test/dhcp/conf_parser_test.rb
@@ -470,4 +470,14 @@ OFMULTILNE_LEASE
     assert_equal ['test.example.com'],
                  included.select {|node| node.class == Proxy::DHCP::CommonISC::ConfigurationParser::HostNode}.map(&:fqdn)
   end
+
+  def test_include_in_shared_network
+    included =
+      Proxy::DHCP::CommonISC::ConfigurationParser.new.conf.parse!('shared-network "testing" {include "test/fixtures/dhcp/dhcp_subnets.conf";}')
+    assert_equal 1, included.size
+    assert_equal ['192.168.122.0', '192.168.123.0', '192.168.124.0', '192.168.1.0'],
+                 included.first.options_and_settings.flatten.select {|node| node.class == Proxy::DHCP::CommonISC::ConfigurationParser::IpV4SubnetNode}.map(&:subnet_address)
+    assert_equal ['test.example.com'],
+                 included.first.options_and_settings.flatten.select {|node| node.class == Proxy::DHCP::CommonISC::ConfigurationParser::HostNode}.map(&:fqdn)
+  end
 end


### PR DESCRIPTION
"include" statements inside "shared_network" blocks are supported now.