### PR TITLE
Fixes #22727: support for larger number of puppet environments

### DIFF
--- a/modules/puppet_proxy/puppet_api.rb
+++ b/modules/puppet_proxy/puppet_api.rb
@@ -27,6 +27,15 @@ class Proxy::Puppet::Api < ::Sinatra::Base
     end
   end
 
+  get "/environment_details" do
+    begin
+      content_type :json
+      class_retriever.environment_details().to_json
+    rescue Proxy::Puppet::NotReady => e
+      log_halt 503, e.message
+    end
+  end
+
   get "/environments/:environment" do
     content_type :json
     begin
@@ -45,10 +54,17 @@ class Proxy::Puppet::Api < ::Sinatra::Base
       class_retriever.classes_in_environment(params[:environment]).map{|k| {k.to_s => { :name => k.name, :module => k.module, :params => k.params} } }.to_json
     rescue Proxy::Puppet::EnvironmentNotFound
       log_halt 404, "Could not find environment '#{params[:environment]}'"
-    rescue Proxy::Puppet::TimeoutError => e
+    end
+  end
+
+  get "/environments/:environment/classes_counter" do
+    content_type :json
+    begin
+      class_retriever.count_classes_in_environment(params[:environment]).to_json
+    rescue Proxy::Puppet::EnvironmentNotFound
+      log_halt 404, "Could not find environment '#{params[:environment]}'"
+    rescue Proxy::Puppet::NotReady => e
       log_halt 503, e.message
-    rescue Exception => e
-      log_halt 406, "Failed to show puppet classes: #{e}"
     end
   end
 

--- a/modules/puppet_proxy_common/errors.rb
+++ b/modules/puppet_proxy_common/errors.rb
@@ -1,5 +1,6 @@
 module Proxy::Puppet
   class EnvironmentNotFound < StandardError; end
+  class NotReady < StandardError; end
   class DataError < StandardError; end
   class TimeoutError < StandardError; end
 end

--- a/modules/puppet_proxy_legacy/class_scanner_base.rb
+++ b/modules/puppet_proxy_legacy/class_scanner_base.rb
@@ -25,5 +25,9 @@ module Proxy::PuppetLegacy
     def classes_in_environment(an_environment)
       classes(environments_retriever.get(an_environment).paths)
     end
+
+    def class_count(environment)
+      0 # Not implemented
+    end
   end
 end

--- a/modules/puppet_proxy_puppet_api/lru_cache.rb
+++ b/modules/puppet_proxy_puppet_api/lru_cache.rb
@@ -1,0 +1,103 @@
+module ::Proxy::PuppetApi
+  class LinkedListNode
+    attr_accessor :left, :right, :key, :value
+    def initialize(key, value)
+      @value = value
+      @key = key
+    end
+  end
+
+  class LinkedList
+    attr_reader :head, :tail, :size
+
+    def initialize
+      @size = 0
+    end
+
+    def push(a_node)
+      return create_head(a_node) if empty?
+      add_node(a_node)
+    end
+
+    def pop
+      delete(tail)
+    end
+
+    def delete(a_node)
+      if empty?
+        @head = nil
+        @tail = nil
+      elsif @size == 1
+        @head = nil
+        @tail = nil
+        @size -= 1
+      elsif a_node.left.nil? # head
+        @head = a_node.right
+        @head.left = nil
+        @size -= 1
+      elsif a_node.right.nil? # tail
+        @tail = a_node.left
+        @tail.right = nil
+        @size -= 1
+      else
+        a_node.left.right = a_node.right
+        a_node.right.left = a_node.left
+        @size -= 1
+      end
+
+      a_node.left = nil unless a_node.nil?
+      a_node.right = nil unless a_node.nil?
+      a_node
+    end
+
+    def create_head(a_node)
+      @head = a_node
+      @tail = a_node
+      @size = 1
+    end
+
+    def add_node(a_node)
+      a_node.right = head
+      a_node.left = nil
+      head.left = a_node
+      @head = a_node
+      @size += 1
+    end
+
+    def empty?
+      @size == 0
+    end
+  end
+
+  class LRUCache
+    def initialize(capacity)
+      @capacity = capacity
+      @cache = {}
+      @lru = LinkedList.new
+    end
+
+    def []=(key, value)
+      if @lru.size == @capacity
+        tail = @lru.pop
+        @cache.delete(tail.key)
+      end
+
+      old_node = @cache[key]
+      @lru.delete(old_node) if old_node
+      new_node = LinkedListNode.new(key, value)
+      @lru.push(new_node)
+      @cache[key] = new_node
+      value
+    end
+
+    def [](key)
+      node = @cache[key]
+      return nil if node.nil?
+
+      @lru.delete(node)
+      @lru.push(node)
+
+      node.value
+    end
+  end
+end

--- a/modules/puppet_proxy_puppet_api/plugin_configuration.rb
+++ b/modules/puppet_proxy_puppet_api/plugin_configuration.rb
@@ -16,33 +16,43 @@ module ::Proxy::PuppetApi
       require 'puppet_proxy_puppet_api/v3_api_request'
       require 'puppet_proxy_puppet_api/v3_environments_retriever'
       require 'puppet_proxy_puppet_api/v3_classes_retriever'
+      require 'puppet_proxy_puppet_api/lru_cache'
       require 'puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever'
     end
 
     def load_dependency_injection_wirings(container_instance, settings)
+      container_instance.dependency :environment_classes_api_v3,
+                                    (lambda do
+                                      ::Proxy::PuppetApi::EnvironmentClassesApiv3.new(
+                                          settings[:puppet_url],
+                                          settings[:puppet_ssl_ca],
+                                          settings[:puppet_ssl_cert],
+                                          settings[:puppet_ssl_key])
+                                    end)
+
       container_instance.dependency :environment_retriever_impl,
                                     lambda {::Proxy::PuppetApi::V3EnvironmentsRetriever.new(settings[:puppet_url], settings[:puppet_ssl_ca], settings[:puppet_ssl_cert], settings[:puppet_ssl_key])}
 
       if Gem::Version.new(settings[:puppet_version].to_s) < Gem::Version.new("4.4")
         container_instance.dependency :class_retriever_impl,
                                       lambda {::Proxy::PuppetApi::V3ClassesRetriever.new(settings[:puppet_url], settings[:puppet_ssl_ca], settings[:puppet_ssl_cert], settings[:puppet_ssl_key])}
-        container_instance.dependency :class_cache_initializer, lambda {Proxy::PuppetApi::NoopClassesCacheInitializer.new}
       else
+        container_instance.singleton_dependency :environment_classes_counter,
+                                                (lambda do
+                                                  ::Proxy::PuppetApi::EnvironmentClassesCounter.new(
+                                                      container_instance.get_dependency(:environment_classes_api_v3),
+                                                      container_instance.get_dependency(:environment_retriever_impl),
+                                                      settings[:classes_counter_update_frequency],
+                                                      settings[:classes_counter_timeout_interval])
+                                                end)
         container_instance.singleton_dependency :class_retriever_impl,
                                                 (lambda do
                                                   ::Proxy::PuppetApi::V3EnvironmentClassesApiClassesRetriever.new(
-                                                    settings[:puppet_url],
-                                                    settings[:puppet_ssl_ca],
-                                                    settings[:puppet_ssl_cert],
-                                                    settings[:puppet_ssl_key],
-                                                    settings[:api_timeout])
+                                                    container_instance.get_dependency(:environment_classes_api_v3),
+                                                    settings[:api_timeout],
+                                                    container_instance.get_dependency(:environment_classes_counter),
+                                                    settings[:max_number_of_cached_environments])
                                                 end)
-        container_instance.dependency :class_cache_initializer,
-                                      (lambda do
-                                        Proxy::PuppetApi::EnvironmentClassesCacheInitializer.new(
-                                          container_instance.get_dependency(:class_retriever_impl),
-                                          container_instance.get_dependency(:environment_retriever_impl))
-                                      end)
       end
     end
   end

--- a/modules/puppet_proxy_puppet_api/puppet_proxy_puppet_api_plugin.rb
+++ b/modules/puppet_proxy_puppet_api/puppet_proxy_puppet_api_plugin.rb
@@ -1,6 +1,8 @@
 module Proxy::PuppetApi
   class Plugin < Proxy::Provider
-    default_settings :puppet_ssl_ca => '/var/lib/puppet/ssl/certs/ca.pem', :api_timeout => 30
+    default_settings :puppet_ssl_ca => '/var/lib/puppet/ssl/certs/ca.pem', :api_timeout => 30,
+                     :classes_counter_update_frequency => 60 * 60, :classes_counter_timeout_interval => 10 * 60,
+                     :max_number_of_cached_environments => 100
 
     plugin :puppet_proxy_puppet_api, ::Proxy::VERSION
 
@@ -12,6 +14,6 @@ module Proxy::PuppetApi
     validate :puppet_url, :url => true
     validate_readable :puppet_ssl_ca, :puppet_ssl_cert, :puppet_ssl_key
 
-    start_services :class_cache_initializer
+    start_services :environment_classes_counter
   end
 end

--- a/modules/puppet_proxy_puppet_api/v3_classes_retriever.rb
+++ b/modules/puppet_proxy_puppet_api/v3_classes_retriever.rb
@@ -25,11 +25,8 @@ class Proxy::PuppetApi::V3ClassesRetriever
     raise Proxy::Puppet::EnvironmentNotFound.new(e.response_body) if e.status_code.to_s == '400' && e.response_body.include?("Could not find environment")
     raise e
   end
-end
 
-# A dummy noop service
-class Proxy::PuppetApi::NoopClassesCacheInitializer
-  def start_service
-    # nothing to do, we don't cache classes in this implementation
+  def class_count(environment)
+    0 #Not implemented
   end
 end

--- a/modules/puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever.rb
+++ b/modules/puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever.rb
@@ -1,127 +1,202 @@
 require 'concurrent'
 
-class Proxy::PuppetApi::V3EnvironmentClassesApiClassesRetriever
-  include ::Proxy::Log
-
+module Proxy::PuppetApi
   DEFAULT_CLIENT_TIMEOUT = 15
   MAX_PUPPETAPI_TIMEOUT = 300
+  MAX_RETRIES = 3
+  RETRY_DELAY = 60
 
-  attr_reader :puppet_url, :ssl_ca, :ssl_cert, :ssl_key, :api_timeout
+  class V3EnvironmentClassesApiClassesRetriever
+    include ::Proxy::Log
 
-  def initialize(puppet_url, puppet_ssl_ca, puppet_ssl_cert, puppet_ssl_key, api_timeout, api = nil)
-    @etag_cache = {}
-    @classes_cache = {}
-    @futures_cache = {}
-    @ssl_ca = puppet_ssl_ca
-    @ssl_cert = puppet_ssl_cert
-    @ssl_key = puppet_ssl_key
-    @puppet_url = puppet_url
-    @api_timeout = api_timeout
-    @m = Monitor.new
-    @puppet_api = api || Proxy::PuppetApi::EnvironmentClassesApiv3
-  end
+    attr_reader :api_timeout, :puppet_api, :environment_classes_counter
 
-  def classes_in_environment(environment)
-    legacy_classes_format(get_classes(environment))
-  end
+    def initialize(api, api_timeout, environment_classes_counter, max_number_of_cached_environments)
+      @etag_cache = {}
+      @classes_cache = ::Proxy::PuppetApi::LRUCache.new(max_number_of_cached_environments)
+      @futures_cache = {}
+      @api_timeout = api_timeout
+      @m = Monitor.new
+      @puppet_api = api
+      @environment_classes_counter = environment_classes_counter
+    end
 
-  def classes_and_errors_in_environment(environment)
-    classes_and_errors(get_classes(environment))
-  end
+    def classes_in_environment(environment)
+      legacy_classes_format(get_classes(environment))
+    end
 
-  def classes_and_errors(response)
-    response['files'].map do |current|
-      classes = (current['classes'] || []).map do |clazz|
-        parameters = clazz['params'].map do |parameter|
-          if parameter['default_source'].is_a?(String) && parameter['default_source'].start_with?('$')
-            to_return = parameter.dup
-            to_return['default_source'] = "${#{parameter['default_source'].slice(1..-1)}}"
-            to_return
-          else
-            parameter
+    def classes_and_errors_in_environment(environment)
+      classes_and_errors(get_classes(environment))
+    end
+
+    def environment_details
+      environment_classes_counter.count_all_classes
+    end
+
+    def count_classes_in_environment(environment)
+      environment_classes_counter.count_classes_in_environment(environment)
+    end
+
+    def classes_and_errors(response)
+      response['files'].map do |current|
+        classes = (current['classes'] || []).map do |clazz|
+          parameters = clazz['params'].map do |parameter|
+            if parameter['default_source'].is_a?(String) && parameter['default_source'].start_with?('$')
+              to_return = parameter.dup
+              to_return['default_source'] = "${#{parameter['default_source'].slice(1..-1)}}"
+              to_return
+            else
+              parameter
+            end
+          end
+          {'name' => clazz['name'], 'params' => parameters}
+        end
+        current.has_key?('error') ? current : {'path' => current['path'], 'classes' => classes}
+      end
+    end
+
+    def legacy_classes_format(response)
+      response['files'].map do |current|
+        (current['classes'] || []).map do |manifest| # current['classes'] is nil for 'error' entities
+          parameters = manifest['params'].inject({}) do |all, parameter|
+            parameter_value = parameter['default_literal'] || parameter['default_source']
+            all[parameter['name']] = (parameter_value.is_a?(String) && parameter_value.start_with?('$')) ? "${#{parameter_value.slice(1..-1)}}" : parameter_value
+            all
+          end
+          ::Proxy::Puppet::PuppetClass.new(manifest['name'], parameters)
+        end
+      end.flatten
+    end
+
+    def get_classes(environment)
+      future = async_get_classes(environment)
+      cache_used = @m.synchronize { !!@etag_cache[environment] } #etags are only available when classes cache is enabled
+      client_timeout = cache_used ? DEFAULT_CLIENT_TIMEOUT : api_timeout
+      logger.warn("Puppet server classes cache is disabled, classes retrieval can be slow.") unless cache_used
+
+      future.value!(client_timeout)
+
+      raise ::Proxy::Puppet::TimeoutError, "Puppet is taking too long to respond, please try again later." if future.pending?
+      future.value
+    end
+
+    def async_get_classes(environment)
+      etag, classes, existing_future = @m.synchronize { [@etag_cache[environment], @classes_cache[environment], @futures_cache[environment]] }
+      return existing_future unless existing_future.nil?
+
+      future = Concurrent::Promise.new do
+        begin
+          response, etag = puppet_api.list_classes(environment, etag, MAX_PUPPETAPI_TIMEOUT)
+        rescue Exception => e
+          @m.synchronize { @futures_cache[environment] = nil }
+          logger.error("Error while retrieving puppet classes for '%s' environment" % [environment], e)
+          raise e
+        end
+
+        if response == Proxy::PuppetApi::EnvironmentClassesApiv3::NOT_MODIFIED
+          @m.synchronize { @futures_cache[environment] = nil }
+          classes
+        else
+          @m.synchronize do
+            @futures_cache[environment] = nil
+            @etag_cache[environment] = etag
+            @classes_cache[environment] = response
           end
         end
-        {'name' => clazz['name'], 'params' => parameters}
       end
-      current.has_key?('error') ? current : {'path' => current['path'], 'classes' => classes}
+      @m.synchronize { @futures_cache[environment] = future }
+
+      future.execute
     end
   end
 
-  def legacy_classes_format(response)
-    response['files'].map do |current|
-      (current['classes'] || []).map do |manifest| # current['classes'] is nil for 'error' entities
-        parameters = manifest['params'].inject({}) do |all, parameter|
-          parameter_value = parameter['default_literal'] || parameter['default_source']
-          all[parameter['name']] = (parameter_value.is_a?(String) && parameter_value.start_with?('$')) ? "${#{parameter_value.slice(1..-1)}}" : parameter_value
-          all
-        end
-        ::Proxy::Puppet::PuppetClass.new(manifest['name'], parameters)
+  class EnvironmentClassesCounter
+    include ::Proxy::Log
+    attr_reader :environment_classes, :environments_retriever, :etag_cache,
+                :update_frequency, :timeout_interval, :m
+
+    def initialize(environment_classes_api, environments_retriever, update_frequency, timeout_interval)
+      @environment_classes = environment_classes_api
+      @environments_retriever = environments_retriever
+      @etag_cache = Hash.new([0, nil]) # environment to [count, etag] tuple
+      @update_frequency = update_frequency
+      @timeout_interval = timeout_interval
+      @m = Monitor.new
+    end
+
+    def count_classes_in_environment(an_environment)
+      class_count, _ = m.synchronize do
+        raise Proxy::Puppet::NotReady, "Initial class counters cache initialization in progress" if @first_pass_in_progress
+        raise Proxy::Puppet::EnvironmentNotFound.new unless etag_cache.has_key?(an_environment)
+        etag_cache[an_environment]
       end
-    end.flatten
-  end
+      class_count
+    end
 
-  def get_classes(environment)
-    future = async_get_classes(environment)
-    cache_used = @m.synchronize { !!@etag_cache[environment] } #etags are only available when classes cache is enabled
-    client_timeout = cache_used ? DEFAULT_CLIENT_TIMEOUT : api_timeout
-    logger.warn("Puppet server classes cache is disabled, classes retrieval can be slow.") unless cache_used
-
-    future.value!(client_timeout)
-
-    raise ::Proxy::Puppet::TimeoutError, "Puppet is taking too long to respond, please try again later." if future.pending?
-    future.value
-  end
-
-  def async_get_classes(environment)
-    etag, classes, existing_future = @m.synchronize { [@etag_cache[environment], @classes_cache[environment], @futures_cache[environment]] }
-    return existing_future unless existing_future.nil?
-
-    future = Concurrent::Promise.new do
-      begin
-        response, etag = @puppet_api.new(puppet_url, ssl_ca, ssl_cert, ssl_key).list_classes(environment, etag, MAX_PUPPETAPI_TIMEOUT)
-      rescue Exception => e
-        @m.synchronize { @futures_cache[environment] = nil }
-        logger.error("Error while retrieving puppet classes for '%s' environment" % [environment], e)
-        raise e
-      end
-
-      if response == Proxy::PuppetApi::EnvironmentClassesApiv3::NOT_MODIFIED
-        @m.synchronize { @futures_cache[environment] = nil }
-        classes
-      else
-        @m.synchronize do
-          @futures_cache[environment] = nil
-          @etag_cache[environment] = etag
-          @classes_cache[environment] = response
-        end
+    def count_all_classes
+      m.synchronize do
+        raise Proxy::Puppet::NotReady, "Initial class counters cache initialization in progress" if @first_pass_in_progress
+        etag_cache.inject({}) {|all, current| all.update(current.first => {:class_count => current.last[0]})}
       end
     end
-    @m.synchronize { @futures_cache[environment] = future }
 
-    future.execute
-  end
-end
+    def update_class_counts(attempt_number = 0, next_launch = 0)
+      next_timer_task_launch = Time.now.to_i + update_frequency
+      logger.debug("Updating puppet class counts cache")
+      all_environments = environments_retriever.all.map(&:name)
+      updated_class_counts = all_environments.inject({}) do |all, environment|
+        count, etag = m.synchronize { etag_cache[environment] }
+        response, new_etag = environment_classes.list_classes(environment, etag, MAX_PUPPETAPI_TIMEOUT)
+        if response == Proxy::PuppetApi::EnvironmentClassesApiv3::NOT_MODIFIED
+          all.update(environment => [count, etag])
+        else
+          all.update(environment => [count_classes_in_response(response), new_etag])
+        end
+        all
+      end
+      m.synchronize { @etag_cache = updated_class_counts; @first_pass_in_progress = false }
+      logger.debug("Finished updating puppet class counts cache")
+    rescue Exception => e
+      logger.error("Error while updating puppet class counts: ", e)
+      if e.kind_of?(SystemCallError) || (e.kind_of?(::Proxy::Error::HttpError) && e.status_code >= "500")
+        retry_class_counts_update(attempt_number, next_timer_task_launch)
+      end
+    end
 
-class Proxy::PuppetApi::EnvironmentClassesCacheInitializer
-  include ::Proxy::Log
+    def retry_class_counts_update(attempt_number, next_timer_task_launch)
+      if attempt_number > 2 || Time.now.to_i + launch_delay(attempt_number + 1) >= next_timer_task_launch
+        logger.error("Giving up on class count update retries")
+        return
+      end
 
-  def initialize(classes_retriever, environments_retriever)
-    @environments = environments_retriever
-    @classes = classes_retriever
-  end
+      Concurrent::ScheduledTask.new(launch_delay(attempt_number + 1)) do
+        logger.debug("Retrying class count updates")
+        update_class_counts(attempt_number + 1, next_timer_task_launch)
+      end.execute
+    end
 
-  def start
-    logger.info("Started puppet class cache initialization")
-    Concurrent::Promise.new { @environments.all }
-                       .then do |environments|
-                         environments.map(&:name).map do |environment|
-                           logger.debug("Initializing puppet class cache for '#{environment}' environment")
-                           @classes.async_get_classes(environment)
-                         end
-                       end
-                       .flat_map { |futures| Concurrent::Promise.all?(*futures) }
-                       .then { logger.info("Finished puppet class cache initialization") }
-                       .on_error { logger.warning("Failed to initialize puppet class cache, deferring initialization. Is puppetserver running?") }
-                       .execute
+    def launch_delay(attempt_number)
+      (attempt_number + 1) * RETRY_DELAY
+    end
+
+    def count_classes_in_response(list_classes_response)
+      list_classes_response['files'].inject(0) do |all, current|
+        all + (current['classes'] || []).size
+      end
+    end
+
+    def start
+      @m.synchronize { @first_pass_in_progress = true }
+      @timer_task = Concurrent::TimerTask.new(:execution_interval => update_frequency,
+                                              :timeout_interval => timeout_interval,
+                                              :run_now => true) do
+        update_class_counts
+      end
+      @timer_task.execute
+    end
+
+    def stop
+      @timer_task.shutdown unless @timer_task.nil?
+    end
   end
 end

--- a/test/puppet/environment_classes_counter_test.rb
+++ b/test/puppet/environment_classes_counter_test.rb
@@ -1,0 +1,95 @@
+require 'test_helper'
+require 'puppet_proxy_common/api_request'
+require 'puppet_proxy_puppet_api/v3_api_request'
+require 'puppet_proxy_common/errors'
+require 'puppet_proxy_common/puppet_class'
+require 'puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever'
+
+class EnvironmentClassesCounterTest < Test::Unit::TestCase
+  class CounterForTesting < Proxy::PuppetApi::EnvironmentClassesCounter
+    attr_accessor :etag_cache, :first_pass_in_progress, :total_number_of_classes
+  end
+
+  def setup
+    @environment_classes_api = Object.new
+    @environments_retriever = Object.new
+    @counter = CounterForTesting.new(@environment_classes_api, @environments_retriever, 10, 10)
+  end
+
+  def test_class_count
+    @counter.etag_cache['testing'] = [100, '12345']
+    assert_equal 100, @counter.count_classes_in_environment('testing')
+  end
+
+  def test_class_count_should_raise_exception_for_nonexistent_environment
+    assert_raises(Proxy::Puppet::EnvironmentNotFound) do
+      @counter.count_classes_in_environment('nonexistent')
+    end
+  end
+
+  def test_class_count_should_raise_an_exception_if_initial_cache_update_in_progress
+    @counter.first_pass_in_progress = true
+    assert_raises(Proxy::Puppet::NotReady) do
+      @counter.count_classes_in_environment('testing')
+    end
+  end
+
+  def test_all_classes_count
+    @counter.etag_cache = {'testing' => [100, '12345'], 'testing-2' => [200, '12345']}
+    assert_equal({'testing' => {:class_count => 100}, 'testing-2' => {:class_count => 200}}, @counter.count_all_classes)
+  end
+
+  def test_all_classes_count_should_raise_exception_if_initial_cache_update_in_progress
+    @counter.first_pass_in_progress = true
+    assert_raises(Proxy::Puppet::NotReady) do
+      @counter.count_all_classes
+    end
+  end
+
+  ENVIRONMENT_CLASSES_RESPONSE =<<EOL
+{
+  "files": [
+    {
+      "classes": [{"name": "dns::config", "params": []}],
+      "path": "/manifests/config.pp"
+    },
+    {
+      "classes": [{"name": "dns::install", "params": []}],
+      "path": "/manifests/install.pp"
+    },
+    {
+      "error": "Syntax error at '=>' at /manifests/witherror.pp:20:19",
+      "path": "/manifests/witherror.pp"
+    }],
+  "name": "test_environment"
+}
+EOL
+  def test_update_class_counts
+    environment_name = 'test_environment'
+    @environments_retriever.expects(:all).returns(
+        [Proxy::Puppet::Environment.new(environment_name, 'test_path_1')])
+    @environment_classes_api.expects(:list_classes).with(environment_name, nil, Proxy::PuppetApi::MAX_PUPPETAPI_TIMEOUT).
+      returns([JSON.load(ENVIRONMENT_CLASSES_RESPONSE), 42])
+    @counter.update_class_counts
+
+    assert_equal 2, @counter.count_classes_in_environment(environment_name)
+    _, etag = @counter.etag_cache[environment_name]
+    assert_equal 42, etag
+    assert_equal({'test_environment' => {:class_count => 2}}, @counter.count_all_classes)
+  end
+
+  def test_update_class_counts_when_etag_did_not_change
+    environment_name = 'test_environment'
+    @counter.etag_cache[environment_name] = [100, 42]
+    @environments_retriever.expects(:all).
+      returns([Proxy::Puppet::Environment.new(environment_name, 'test_path_1')])
+    @environment_classes_api.expects(:list_classes).with(environment_name, 42, Proxy::PuppetApi::MAX_PUPPETAPI_TIMEOUT).
+      returns(Proxy::PuppetApi::EnvironmentClassesApiv3::NOT_MODIFIED)
+    @counter.update_class_counts
+
+    assert_equal 100, @counter.count_classes_in_environment(environment_name)
+    _, etag = @counter.etag_cache[environment_name]
+    assert_equal 42, etag
+    assert_equal({'test_environment' => {:class_count => 100}}, @counter.count_all_classes)
+  end
+end

--- a/test/puppet/lru_cache_test.rb
+++ b/test/puppet/lru_cache_test.rb
@@ -1,0 +1,166 @@
+require 'test_helper'
+require 'puppet_proxy_puppet_api/lru_cache'
+
+class LRUCacheTest < Test::Unit::TestCase
+  class LRUCacheForTesting < ::Proxy::PuppetApi::LRUCache
+    attr_accessor :lru, :cache
+  end
+
+  def setup
+    @cache = LRUCacheForTesting.new(3)
+    @ll = @cache.lru
+  end
+
+  def test_empty_linked_list
+    assert @ll.empty?
+    assert_nil @ll.head
+    assert_nil @ll.tail
+  end
+
+  def test_add_the_first_element_to_linked_list
+    @ll.push(node = ::Proxy::PuppetApi::LinkedListNode.new(1, 1))
+
+    assert_equal 1, @ll.size
+    assert_equal node, @ll.head
+    assert_equal node, @ll.tail
+    assert_nil node.left
+    assert_nil node.right
+  end
+
+  def test_add_two_elements_to_linked_list
+    @ll.push(tail = ::Proxy::PuppetApi::LinkedListNode.new(1, 1))
+    @ll.push(head = ::Proxy::PuppetApi::LinkedListNode.new(2, 2))
+
+    assert_equal 2, @ll.size
+    assert_equal tail, @ll.tail
+    assert_equal head, @ll.head
+    assert_nil head.left
+    assert_equal tail, head.right
+    assert_nil tail.right
+    assert_equal head, tail.left
+  end
+
+  def test_add_three_elements_to_linked_list
+    @ll.push(tail = ::Proxy::PuppetApi::LinkedListNode.new(1, 1))
+    @ll.push(middle = ::Proxy::PuppetApi::LinkedListNode.new(2, 2))
+    @ll.push(head = ::Proxy::PuppetApi::LinkedListNode.new(3, 3))
+
+    assert_equal 3, @ll.size
+    assert_equal tail, @ll.tail
+    assert_equal head, @ll.head
+    assert_nil head.left
+    assert_equal middle, head.right
+    assert_nil tail.right
+    assert_equal middle, tail.left
+    assert_equal head, middle.left
+    assert_equal tail, middle.right
+  end
+
+  def test_remove_an_element_from_empty_linked_list
+    node = @ll.pop
+    assert_nil node
+    assert @ll.empty?
+    assert_nil @ll.head
+    assert_nil @ll.tail
+  end
+
+  def test_remove_the_only_element_from_linked_list
+    @ll.push(expected_node = ::Proxy::PuppetApi::LinkedListNode.new(1, 1))
+
+    node = @ll.pop
+    assert @ll.empty?
+    assert_nil @ll.head
+    assert_nil @ll.tail
+    assert_equal expected_node, node
+    assert_nil node.left
+    assert_nil node.right
+  end
+
+  def test_remove_head_from_linked_list
+    @ll.push(tail = ::Proxy::PuppetApi::LinkedListNode.new(1, 1))
+    @ll.push(middle = ::Proxy::PuppetApi::LinkedListNode.new(2, 2))
+    @ll.push(head = ::Proxy::PuppetApi::LinkedListNode.new(3, 3))
+    @ll.delete(head)
+
+    assert_equal 2, @ll.size
+    assert_equal middle, @ll.head
+    assert_equal tail, @ll.tail
+    assert_equal tail, middle.right
+    assert_nil middle.left
+    assert_equal middle, tail.left
+    assert_nil tail.right
+  end
+
+  def test_remove_tail_from_linked_list
+    @ll.push(tail = ::Proxy::PuppetApi::LinkedListNode.new(1, 1))
+    @ll.push(middle = ::Proxy::PuppetApi::LinkedListNode.new(2, 2))
+    @ll.push(head = ::Proxy::PuppetApi::LinkedListNode.new(3, 3))
+    @ll.delete(tail)
+
+    assert_equal 2, @ll.size
+    assert_equal middle, @ll.tail
+    assert_equal head, @ll.head
+    assert_equal head, middle.left
+    assert_nil middle.right
+    assert_equal middle, head.right
+    assert_nil head.left
+  end
+
+  def test_remove_middle_element_from_linked_list
+    @ll.push(tail = ::Proxy::PuppetApi::LinkedListNode.new(1, 1))
+    @ll.push(middle = ::Proxy::PuppetApi::LinkedListNode.new(2, 2))
+    @ll.push(head = ::Proxy::PuppetApi::LinkedListNode.new(3, 3))
+    @ll.delete(middle)
+
+    assert_equal 2, @ll.size
+    assert_equal tail, @ll.tail
+    assert_equal head, @ll.head
+    assert_equal head, tail.left
+    assert_equal tail, head.right
+    assert_nil head.left
+    assert_nil tail.right
+  end
+
+  def test_add_a_new_element_to_cache
+    result = (@cache[1] = 1)
+
+    assert_equal 1, result
+    assert_equal 1, @cache.lru.size
+    assert_equal 1, @cache.cache.size
+    assert_equal 1, @cache.cache[1].value
+  end
+
+  def test_replace_an_element_in_cache
+    @cache[1] = 1
+    result = (@cache[1] = 2)
+
+    assert_equal 2, result
+    assert_equal 1, @cache.lru.size
+    assert_equal 1, @cache.cache.size
+    assert_equal 2, @cache.cache[1].value
+  end
+
+  def test_adding_elements_to_cache_under_max_capacity
+    @cache[1] = 1
+    @cache[2] = 2
+
+    assert_equal 2, @cache.lru.size
+    assert_equal 2, @cache.cache.size
+    assert_equal 1, @cache.cache[1].value
+    assert_equal 2, @cache.cache[2].value
+  end
+
+  def test_should_remove_the_oldest_element_when_adding_element_to_cache_at_max_capacity
+    @cache[1] = 1
+    @cache[2] = 2
+    @cache[3] = 3
+    @cache[4] = 4
+
+    assert_equal 3, @cache.lru.size
+    assert_equal 3, @cache.cache.size
+    assert_nil @cache.cache[1]
+    assert_equal 2, @cache.cache[2].value
+    assert_equal 3, @cache.cache[3].value
+    assert_equal 4, @cache.cache[4].value
+  end
+end


### PR DESCRIPTION
- Puppet environments are no longer being cached on startup.
- Classes cache is now an LRU one with a configurable max
  number of environments to cache.
- Added a dedicated api point for per-environment class counts