### PR TITLE
Fixes #23236 - fix for choria puppetrun on ubuntu

### DIFF
--- a/modules/puppet_proxy_mcollective/mcollective_main.rb
+++ b/modules/puppet_proxy_mcollective/mcollective_main.rb
@@ -21,7 +21,7 @@ class Proxy::PuppetMCollective::Runner < Proxy::Puppet::Runner
     # Defaults:foreman-proxy !requiretty
     # foreman-proxy ALL=(peadmin) NOPASSWD: /opt/puppet/bin/mco *',
     if user
-      cmd.push("-u", user)
+      cmd.push("-Hu", user)
     end
 
     mco_path = which("mco", ["/opt/puppet/bin", "/opt/puppetlabs/bin"])

--- a/test/puppet/mcollective_test.rb
+++ b/test/puppet/mcollective_test.rb
@@ -20,7 +20,7 @@ class MCollectiveTest < Test::Unit::TestCase
     @mcollective = Proxy::PuppetMCollective::Runner.new("peadmin")
     @mcollective.stubs(:which).with("sudo", anything).returns("/usr/bin/sudo")
     @mcollective.stubs(:which).with("mco", anything).returns("/usr/bin/mco")
-    @mcollective.expects(:shell_command).with(["/usr/bin/sudo", "-u", "peadmin", "/usr/bin/mco", "puppet", "runonce", "-I", "host1", "host2"]).returns(true)
+    @mcollective.expects(:shell_command).with(["/usr/bin/sudo", "-Hu", "peadmin", "/usr/bin/mco", "puppet", "runonce", "-I", "host1", "host2"]).returns(true)
     assert @mcollective.run(["host1", "host2"])
   end
 


### PR DESCRIPTION
Choria's (https://github.com/choria-io/mcollective-choria)
mcollective ssl auth plugin looks for authentication keys
in the running user's home directory.

When executed via `sudo -u` '~' is expanded to
the running user's home directory rather than
the impersonated user causing an authentication error.

e.g.
```
sysadmin@puppet:/$ sudo -u foreman-proxy mco find

The find application failed to run, use -v for full 
error backtrace details: No such file or directory 
@ rb_sysopen - 
~/.puppetlabs/etc/puppet/ssl/certs/foreman-proxy.mcollective.pem
```
