### PR TITLE
Fixes #23166 - MAC DHCP CRUD not case sensitive

### DIFF
--- a/modules/dhcp/dhcp_api.rb
+++ b/modules/dhcp/dhcp_api.rb
@@ -76,13 +76,15 @@ class Proxy::DhcpApi < ::Sinatra::Base
 
   # returns a record for a mac address
   get "/:network/mac/:mac_address" do
+    param_network = params[:network]
+    param_mac = params[:mac_address].downcase unless params[:mac_address].nil?
     begin
       content_type :json
-      record = server.find_record_by_mac(params[:network], params[:mac_address])
-      log_halt 404, "No DHCP record for MAC #{params[:network]}/#{params[:mac_address]} found" unless record
+      record = server.find_record_by_mac(param_network, param_mac)
+      log_halt 404, "No DHCP record for MAC #{param_network}/#{param_mac} found" unless record
       record.to_json
     rescue ::Proxy::DHCP::SubnetNotFound
-      log_halt 404, "Subnet #{params[:network]} could not found"
+      log_halt 404, "Subnet #{param_network} could not found"
     rescue => e
       log_halt 400, e
     end
@@ -135,7 +137,7 @@ class Proxy::DhcpApi < ::Sinatra::Base
   # delete a record for a mac address from a network
   delete "/:network/mac/:mac_address" do
     begin
-      server.del_record_by_mac(params[:network], params[:mac_address])
+      server.del_record_by_mac(params[:network], params[:mac_address].nil? ? nil : params[:mac_address].downcase)
       nil
     rescue ::Proxy::DHCP::SubnetNotFound # rubocop:disable Lint/HandleExceptions
       # no need to do anything

--- a/test/dhcp/dhcp_api_test.rb
+++ b/test/dhcp/dhcp_api_test.rb
@@ -212,6 +212,24 @@ class DhcpApiTest < Test::Unit::TestCase
     assert_equal expected, JSON.parse(last_response.body)
   end
 
+  def test_get_record_by_mac_uppercase
+    @server.expects(:find_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee").returns(@reservations.first)
+
+    get "/192.168.122.0/mac/00:11:BB:CC:DD:EE"
+
+    assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
+    expected = {
+      "deleteable" => true,
+      "type"       => "reservation",
+      "hostname"   =>"test.example.com",
+      "ip"         =>"192.168.122.1",
+      "mac"        =>"00:11:bb:cc:dd:ee",
+      "name"       => 'test.example.com',
+      "subnet"     =>"192.168.122.0/255.255.255.0" # NOTE: 'subnet' attribute isn't being used by foreman, which adds a 'network' attribute instead
+    }
+    assert_equal expected, JSON.parse(last_response.body)
+  end
+
   def test_get_record_by_mac_for_nonexistent_mac
     @server.expects(:find_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee").returns(nil)
     get "/192.168.122.0/mac/00:11:bb:cc:dd:ee"
@@ -301,6 +319,13 @@ class DhcpApiTest < Test::Unit::TestCase
   def test_delete_records_by_mac
     @server.expects(:del_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee")
     delete "/192.168.122.0/mac/00:11:bb:cc:dd:ee"
+    assert_equal 200, last_response.status
+    assert_empty last_response.body
+  end
+
+  def test_delete_records_by_mac_uppercase
+    @server.expects(:del_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee")
+    delete "/192.168.122.0/mac/00:11:BB:CC:DD:EE"
     assert_equal 200, last_response.status
     assert_empty last_response.body
   end


### PR DESCRIPTION
Problem for Hyper-V DHCP as reported by our user.

Now, the question is - shall I also do the same for our deprecated endpoints? It looks like a bug, maybe.