### PR TITLE
[WIP] Fixes #23211 - Token based PuppetCA autosigning

### DIFF
--- a/lib/proxy/request.rb
+++ b/lib/proxy/request.rb
@@ -20,6 +20,12 @@ module Proxy::HttpRequest
       req
     end
 
+    def create_delete(path, query={}, headers={})
+      req = Net::HTTP::Delete.new(uri(path).path + "/" + query[:id])
+      req = add_headers(req, headers)
+      req
+    end
+
     def uri(path)
       URI.join(@base_uri.to_s, path)
     end

--- a/modules/puppetca/dependency_injection.rb
+++ b/modules/puppetca/dependency_injection.rb
@@ -1,0 +1,8 @@
+module Proxy::PuppetCa
+  module DependencyInjection
+    include Proxy::DependencyInjection::Accessors
+    def container_instance
+      @container_instance ||= ::Proxy::Plugins.instance.find {|p| p[:name] == :puppetca }[:di_container]
+    end
+  end
+end

--- a/modules/puppetca/plugin_configuration.rb
+++ b/modules/puppetca/plugin_configuration.rb
@@ -1,0 +1,13 @@
+module ::Proxy::PuppetCa
+  class PluginConfiguration
+    def load_classes
+      require 'puppetca/puppetca_certmanager'
+      require 'puppetca/dependency_injection'
+      require 'puppetca/puppetca_api'
+    end
+
+    def load_dependency_injection_wirings(container_instance, settings)
+      container_instance.dependency :cert_manager, lambda { ::Proxy::PuppetCa::Certmanager.new }
+    end
+  end
+end

--- a/modules/puppetca/puppetca.rb
+++ b/modules/puppetca/puppetca.rb
@@ -1,3 +1,2 @@
+require 'puppetca/plugin_configuration'
 require 'puppetca/puppetca_plugin'
-
-module Proxy::PuppetCa; end

--- a/modules/puppetca/puppetca_csr.rb
+++ b/modules/puppetca/puppetca_csr.rb
@@ -1,0 +1,25 @@
+module Proxy::PuppetCa
+  class CSR
+    attr_reader :csr
+
+    def initialize(raw_csr)
+      @csr = OpenSSL::X509::Request.new(raw_csr)
+    end
+
+    def challenge_password
+      attribute = custom_attributes.detect do |attr|
+        ['challengePassword', '1.2.840.113549.1.9.7'].include?(attr[:oid])
+      end
+      attribute ? attribute[:value] : nil
+    end
+
+    def custom_attributes
+      @csr.attributes.map do |attr|
+        {
+          oid: attr.oid,
+          value: attr.value.value.first.value
+        }
+      end
+    end
+  end
+end

--- a/modules/puppetca/puppetca_plugin.rb
+++ b/modules/puppetca/puppetca_plugin.rb
@@ -3,8 +3,11 @@ module Proxy::PuppetCa
     http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
-    default_settings :ssldir => '/var/lib/puppet/ssl', :autosignfile => '/etc/puppet/autosign.conf'
+    default_settings :ssldir => '/var/lib/puppet/ssl', :sign_all => false
 
     plugin :puppetca, ::Proxy::VERSION
+
+    load_classes ::Proxy::PuppetCa::PluginConfiguration
+    load_dependency_injection_wirings ::Proxy::PuppetCa::PluginConfiguration
   end
 end

--- a/test/puppetca/puppetca_config_test.rb
+++ b/test/puppetca/puppetca_config_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
-require 'puppetca/puppetca_plugin'
+require 'puppetca/puppetca'
 
 class PuppetCAConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
     Proxy::PuppetCa::Plugin.load_test_settings({})
     assert_equal '/var/lib/puppet/ssl', Proxy::PuppetCa::Plugin.settings.ssldir
-    assert_equal '/etc/puppet/autosign.conf', Proxy::PuppetCa::Plugin.settings.autosignfile
+    assert_equal false, Proxy::PuppetCa::Plugin.settings.sign_all
   end
 end


### PR DESCRIPTION
Removes old autosigning endpoints and adds new ones
that take a incoming CSR from puppet, extract the token
and forward it to foreman for verfication.

See also PRs in [foreman-core](https://github.com/theforeman/foreman/pull/5465), [community-templates](https://github.com/theforeman/community-templates/pull/475), [puppet-foreman_proxy](https://github.com/theforeman/puppet-foreman_proxy/pull/425) & [puppet-puppet](https://github.com/theforeman/puppet-puppet/pull/591).

We would like to see some feedback early on while we are testing this thoroughly.