### PR TITLE
fixes #23399 - Fix puppet kick instructions

### DIFF
--- a/config/settings.d/puppet_proxy_puppetrun.yml.example
+++ b/config/settings.d/puppet_proxy_puppetrun.yml.example
@@ -3,14 +3,12 @@
 # User for execution of puppetrun commands
 #
 # sudo permission needs to be added to ensure
-# smart-proxy can execute 'sudo' command
+# smart-proxy can execute 'sudo' command.
+# Make these changes in /etc/sudoers.d/foreman-proxy
 #
+# For Puppet 3:
 # Defaults:foreman-proxy !requiretty
-# foreman-proxy ALL=(peadmin) NOPASSWD: /opt/puppet/bin/puppet *',
+# foreman-proxy ALL=(puppet) NOPASSWD: /usr/bin/puppet kick *
 #
-# or
 #
-# Defaults:foreman-proxy !requiretty
-# foreman-proxy ALL=(peadmin) NOPASSWD: /opt/puppet/bin/puppetrun *',
-#
-#:user: peadmin
+#:user: puppet


### PR DESCRIPTION
Changes must be made in the sudo file, not in the YAML file where the
 instructions are found.
I think  "'," at end of line is not required.
As puppetrun was in Puppet 2.7 and puppet kick is not supported in
Puppet 4, lets only mention Puppet 3 example here.