### PR TITLE
add support for srv dns records

### DIFF
--- a/modules/dns/dns_api.rb
+++ b/modules/dns/dns_api.rb
@@ -17,7 +17,7 @@ module Proxy::Dns
       log_halt(400, "'create' requires fqdn, value, and type parameters") if fqdn.nil? || value.nil? || type.nil?
 
       begin
-        validate_dns_name!(fqdn)
+        validate_dns_name!(fqdn, type)
 
         case type
         when 'A'
@@ -27,11 +27,14 @@ module Proxy::Dns
           ip = IPAddr.new(value, Socket::AF_INET6).to_s
           server.create_aaaa_record(fqdn, ip)
         when 'CNAME'
-          validate_dns_name!(value)
+          validate_dns_name!(value, type)
           server.create_cname_record(fqdn, value)
         when 'PTR'
           validate_reverse_dns_name!(value)
           server.create_ptr_record(fqdn, value)
+        when 'SRV'
+          validate_srv_value!(value)
+          server.create_srv_record(fqdn, value)
         else
           log_halt(400, "unrecognized 'type' parameter: #{type}")
         end
@@ -51,7 +54,7 @@ module Proxy::Dns
       end
 
       begin
-        validate_dns_name!(name)
+        validate_dns_name!(name, type)
 
         case type
         when 'A'
@@ -63,6 +66,8 @@ module Proxy::Dns
         when 'PTR'
           validate_reverse_dns_name!(name)
           server.remove_ptr_record(name)
+        when 'SRV'
+          server.remove_srv_record(name)
         else
           log_halt(400, "unrecognized 'type' parameter: #{type}")
         end
@@ -73,12 +78,34 @@ module Proxy::Dns
       end
     end
 
-    def validate_dns_name!(name)
-      raise Proxy::Dns::Error.new("Invalid DNS name #{name}") unless name =~ /^([a-zA-Z0-9]([-a-zA-Z0-9]+)?\.?)+$/
+    def validate_srv_value!(value)
+      parts = value.split(' ')
+      priority,weight,port,target = parts
+      validate_dns_name!(target, 'SRV')
+      unless parts.size == 4 &&
+        (0..65_535).cover?(Integer(priority)) &&
+        (0..65_535).cover?(Integer(weight)) &&
+        (1..65_535).cover?(Integer(port))
+          raise
+      end
+    rescue ArgumentError, RuntimeError # if any of the three tests on integer above fails or the condition was not met
+      raise Proxy::Dns::Error.new("Invalid DNS SRV value #{value}")
+    end
+
+    def validate_srv_name!(name)
+      raise Proxy::Dns::Error.new("Invalid DNS srv name #{name}") unless name =~ /^([a-zA-Z0-9_]([-a-zA-Z0-9_]+)?\.?)+$/
+    end
+
+    def validate_dns_name!(name, type=nil)
+      if type == 'SRV'
+        validate_srv_name!(name)
+      else
+        raise Proxy::Dns::Error.new("Invalid DNS name #{name}") unless name =~ /^([a-zA-Z0-9]([-a-zA-Z0-9]+)?\.?)+$/
+      end
     end
 
     def validate_reverse_dns_name!(name)
-      validate_dns_name!(name)
+      validate_dns_name!(name, 'PTR')
       raise Proxy::Dns::Error.new("Invalid reverse DNS #{name}") unless name =~ /\.(in-addr|ip6)\.arpa$/
     end
   end

--- a/modules/dns_common/dns_common.rb
+++ b/modules/dns_common/dns_common.rb
@@ -20,6 +20,10 @@ module Proxy::Dns
       Resolv::DNS.new(:nameserver => @server)
     end
 
+    def create_srv_record(service, value)
+      do_create(service, value, 'SRV')
+    end
+
     def create_a_record(fqdn, ip)
       case a_record_conflicts(fqdn, ip) #returns -1, 0, 1
         when 1 then
@@ -70,6 +74,10 @@ module Proxy::Dns
 
     def remove_a_record(fqdn)
       do_remove(fqdn, "A")
+    end
+
+    def remove_srv_record(fqdn)
+      do_remove(fqdn, 'SRV')
     end
 
     def remove_aaaa_record(fqdn)

--- a/test/dns_common/record_test.rb
+++ b/test/dns_common/record_test.rb
@@ -172,6 +172,12 @@ class DnsRecordTest < Test::Unit::TestCase
     assert_equal false, Proxy::Dns::Record.new.to_ipaddress('some.host')
   end
 
+  def test_create_srv_record
+    Proxy::Dns::Record.any_instance.expects(:do_create).with('_sip._tcp.example.com.','10 60 5060 bigbox.example.com.', 'SRV')
+
+    assert_nil Proxy::Dns::Record.new.create_srv_record('_sip._tcp.example.com.', '10 60 5060 bigbox.example.com.')
+  end
+
   def test_create_a_record
     Proxy::Dns::Record.any_instance.expects(:a_record_conflicts).returns(-1)
     Proxy::Dns::Record.any_instance.expects(:do_create).with('some.host', '192.168.33.22', 'A')


### PR DESCRIPTION
Here are original changes made by @pronix from #577 + fixes suggested by @witlessbird. Except I didn't change API tests to unit tests - I didn't understand how it should look like in the end. Do you mean to just test methods that validate records? Because we have no separate validator there.