### PR TITLE
[WIP] Introduce capabilities

### DIFF
--- a/lib/proxy/pluggable.rb
+++ b/lib/proxy/pluggable.rb
@@ -35,6 +35,10 @@ module Proxy::Pluggable
     @plugin_default_settings.merge!(a_hash)
   end
 
+  def expose_setting(setting)
+    exposed_settings << setting
+  end
+
   def initialize_after(*module_names)
     raise "#{plugin_name}: 'initialize_after' method has been removed."
   end
@@ -177,6 +181,10 @@ module Proxy::Pluggable
 
   def dependencies
     @dependencies ||= []
+  end
+
+  def exposed_settings
+    @exposed_settings ||= []
   end
 
   def bundler_group_name

--- a/lib/proxy/pluggable.rb
+++ b/lib/proxy/pluggable.rb
@@ -16,6 +16,10 @@ module Proxy::Pluggable
     @bundler_group_name = name
   end
 
+  def capability(capability)
+    capabilities << capability
+  end
+
   # relative to ::Proxy::SETTINGS.settings_directory
   def settings_file(apath = nil)
     if apath.nil?
@@ -165,6 +169,10 @@ module Proxy::Pluggable
 
   def loading_failed(message)
     raise ::Proxy::PluginLoadingAborted, message
+  end
+
+  def capabilities
+    @capabilities ||= []
   end
 
   def dependencies

--- a/lib/proxy/plugin_initializer.rb
+++ b/lib/proxy/plugin_initializer.rb
@@ -33,6 +33,11 @@ class ::Proxy::PluginGroup
     [members.map { |m| m.capabilities }.compact].flatten.uniq.sort
   end
 
+  def settings
+    exposed_settings = [members.map { |m| m.exposed_settings }.compact].flatten.uniq.sort
+    Hash[exposed_settings.map { |setting| [setting, @plugin.settings[setting]] }]
+  end
+
   def resolve_providers(all_plugins_and_providers)
     return if inactive?
     return unless @plugin.uses_provider?
@@ -193,6 +198,7 @@ class ::Proxy::PluginInitializer
       updated[:http_enabled] = group.http_enabled?
       updated[:https_enabled] = group.https_enabled?
       updated[:capabilities] = group.capabilities
+      updated[:settings] = group.settings
       group.providers.each do |group_member|
         updated = to_update.find {|loaded_plugin| loaded_plugin[:name] == group_member.plugin_name}
         updated[:di_container] = group.di_container

--- a/lib/proxy/plugin_initializer.rb
+++ b/lib/proxy/plugin_initializer.rb
@@ -29,6 +29,10 @@ class ::Proxy::PluginGroup
     @https_enabled
   end
 
+  def capabilities
+    [members.map { |m| m.capabilities }.compact].flatten.uniq.sort
+  end
+
   def resolve_providers(all_plugins_and_providers)
     return if inactive?
     return unless @plugin.uses_provider?
@@ -188,6 +192,7 @@ class ::Proxy::PluginInitializer
       updated[:state] = group.state
       updated[:http_enabled] = group.http_enabled?
       updated[:https_enabled] = group.https_enabled?
+      updated[:capabilities] = group.capabilities
       group.providers.each do |group_member|
         updated = to_update.find {|loaded_plugin| loaded_plugin[:name] == group_member.plugin_name}
         updated[:di_container] = group.di_container

--- a/modules/dns/dns_plugin.rb
+++ b/modules/dns/dns_plugin.rb
@@ -6,6 +6,11 @@ module Proxy::Dns
     uses_provider
     default_settings :use_provider => 'dns_nsupdate', :dns_ttl => 86_400
     plugin :dns, ::Proxy::VERSION
+    capability :TYPE_A
+    capability :TYPE_AAAA
+    capability :TYPE_CNAME
+    capability :TYPE_PTR
+    capability :TYPE_SRV
 
     load_classes ::Proxy::Dns::ConfigurationLoader
   end

--- a/modules/root/root_api.rb
+++ b/modules/root/root_api.rb
@@ -20,15 +20,10 @@ class Proxy::RootApi < Sinatra::Base
           p[:class].ancestors.include?(::Proxy::Plugin)
       end
       content_type :json
-      enabled_plugins.sort { |x, y| x[:name] <=> y[:name] }.map do |p|
-        {
-          'name' => p[:name],
-          'capabilities' => p[:capabilities],
-          'http_enabled' => p[:http_enabled],
-          'https_enabled' => p[:https_enabled],
-          'settings' => p[:settings],
-        }
-      end.to_json
+
+      attributes = %i[capabilities http_enabled https_enabled settings]
+
+      Hash[enabled_plugins.collect { |p| [p[:name], Hash[attributes.map { |a| [a, p[a]] }]] }].to_json
     rescue => e
       log_halt 400, e
     end

--- a/modules/root/root_api.rb
+++ b/modules/root/root_api.rb
@@ -26,6 +26,7 @@ class Proxy::RootApi < Sinatra::Base
           'capabilities' => p[:capabilities],
           'http_enabled' => p[:http_enabled],
           'https_enabled' => p[:https_enabled],
+          'settings' => p[:settings],
         }
       end.to_json
     rescue => e

--- a/modules/tftp/tftp_plugin.rb
+++ b/modules/tftp/tftp_plugin.rb
@@ -10,5 +10,6 @@ module Proxy::TFTP
                      :tftp_connect_timeout => 10,
                      :tftp_dns_timeout => 10
 
+    expose_setting :tftp_servername
   end
 end


### PR DESCRIPTION
This is still very early but I wanted some feedback before continuing too far.

The idea is that modules can have various capabilities. In the example code I added various DNS record types, but I want to expand this to managing domains themselves. Not every provider can actually do this due to various limitations, but some can. Foreman can query the capabilities and decide to expose functionalities or hide them rather than try-and-fail.