### PR TITLE
Fixes #23799 - Refactor: Make PuppetCa pluggable

### DIFF
--- a/config/settings.d/puppetca.yml.example
+++ b/config/settings.d/puppetca.yml.example
@@ -2,7 +2,9 @@
 # Can be true, false, or http/https to enable just one of the protocols
 :enabled: false
 
+# valid providers:
+#   - puppetca_hostname_whitelisting (verify CSRs based on a hostname whitelist)
+#:use_provider: puppetca_hostname_whitelisting
 #:ssldir: /var/lib/puppet/ssl
-#:autosignfile: /etc/puppet/autosign.conf
 #:puppetca_use_sudo: true
 #:sudo_command: /usr/bin/sudo

--- a/config/settings.d/puppetca_hostname_whitelisting.yml.example
+++ b/config/settings.d/puppetca_hostname_whitelisting.yml.example
@@ -1,0 +1,6 @@
+---
+#
+# Configuration of the PuppetCA hostname_whitelisting provider
+#
+
+#:autosignfile: /etc/puppet/autosign.conf

--- a/extra/migrations/2018062000000_migrate_puppetca_settings.rb
+++ b/extra/migrations/2018062000000_migrate_puppetca_settings.rb
@@ -1,0 +1,33 @@
+require 'yaml'
+
+class MigratePuppetCaSettings < ::Proxy::Migration
+  def migrate
+    copy_original_configuration_except(path('settings.d', 'puppetca.yml'),
+                                       path('settings.d', 'puppetca_hostname_whitelisting.yml.example'))
+
+    module_settings   = YAML.load_file(path(src_dir, 'settings.d', 'puppetca.yml'))
+    provider_settings = YAML.load_file(path(src_dir, 'settings.d', 'puppetca_hostname_whitelisting.yml'))
+
+    write_yaml(path(dst_dir, 'settings.d', 'puppetca_hostname_whitelisting.yml'),
+               transform_provider_yaml(module_settings, provider_settings))
+    write_yaml(path(dst_dir, 'settings.d', 'puppetca.yml'), transform_puppetca_yaml(module_settings))
+  end
+
+  def transform_puppetca_yaml(input)
+    input.delete(:autosignfile)
+    input[:use_provider] = 'puppetca_hostname_whitelisting'
+    input
+  end
+
+  def transform_provider_yaml(module_settings, provider_settings)
+    provider_settings = {} unless provider_settings.is_a? Hash
+    provider_settings[:autosignfile] = module_settings[:autosignfile]
+    provider_settings
+  end
+
+  def write_yaml(filepath, yaml)
+    File.open(filepath, 'w') do |f|
+      f.write(yaml.to_yaml)
+    end
+  end
+end

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -67,6 +67,7 @@ module Proxy
   require 'dhcp_native_ms/dhcp_native_ms'
   require 'dhcp_libvirt/dhcp_libvirt'
   require 'puppetca/puppetca'
+  require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting'
   require 'puppet_proxy/puppet'
   require 'puppet_proxy_customrun/puppet_proxy_customrun'
   require 'puppet_proxy_legacy/puppet_proxy_legacy'

--- a/modules/puppetca/dependency_injection.rb
+++ b/modules/puppetca/dependency_injection.rb
@@ -1,0 +1,8 @@
+module Proxy::PuppetCa
+  module DependencyInjection
+    include Proxy::DependencyInjection::Accessors
+    def container_instance
+      @container_instance ||= ::Proxy::Plugins.instance.find {|p| p[:name] == :puppetca }[:di_container]
+    end
+  end
+end

--- a/modules/puppetca/plugin_configuration.rb
+++ b/modules/puppetca/plugin_configuration.rb
@@ -1,0 +1,13 @@
+module ::Proxy::PuppetCa
+  class PluginConfiguration
+    def load_classes
+      require 'puppetca/puppetca_puppet_cert'
+      require 'puppetca/dependency_injection'
+      require 'puppetca/puppetca_api'
+    end
+
+    def load_dependency_injection_wirings(container_instance, settings)
+      container_instance.dependency :puppet_cert, lambda { ::Proxy::PuppetCa::PuppetCert.new }
+    end
+  end
+end

--- a/modules/puppetca/puppetca.rb
+++ b/modules/puppetca/puppetca.rb
@@ -1,3 +1,2 @@
+require 'puppetca/plugin_configuration'
 require 'puppetca/puppetca_plugin'
-
-module Proxy::PuppetCa; end

--- a/modules/puppetca/puppetca_plugin.rb
+++ b/modules/puppetca/puppetca_plugin.rb
@@ -3,8 +3,13 @@ module Proxy::PuppetCa
     http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
-    default_settings :ssldir => '/var/lib/puppet/ssl', :autosignfile => '/etc/puppet/autosign.conf'
+    default_settings :ssldir => '/var/lib/puppet/ssl'
 
+    uses_provider
+    default_settings :use_provider => 'puppetca_hostname_whitelisting'
+
+    load_classes ::Proxy::PuppetCa::PluginConfiguration
+    load_dependency_injection_wirings ::Proxy::PuppetCa::PluginConfiguration
     plugin :puppetca, ::Proxy::VERSION
   end
 end

--- a/modules/puppetca/puppetca_puppet_cert.rb
+++ b/modules/puppetca/puppetca_puppet_cert.rb
@@ -2,65 +2,19 @@ require 'openssl'
 require 'set'
 
 module Proxy::PuppetCa
-  extend ::Proxy::Log
-  extend ::Proxy::Util
 
   class NotPresent < RuntimeError; end
 
-  class << self
+  class PuppetCert
+    include ::Proxy::Log
+    include ::Proxy::Util
+
     def sign certname
       puppetca("sign", certname)
     end
 
     def clean certname
       puppetca("clean", certname)
-    end
-
-    #remove certname from autosign if exists
-    def disable certname
-      raise "No such file #{autosign_file}" unless File.exist?(autosign_file)
-
-      found = false
-      entries = File.readlines(autosign_file).collect do |l|
-        if l.chomp != certname
-          l
-        else
-          found = true
-          nil
-        end
-      end.uniq.compact
-      if found
-        open(autosign_file, File::TRUNC|File::RDWR) do |autosign|
-          autosign.write entries.join
-        end
-        logger.debug "Removed #{certname} from autosign"
-      else
-        logger.debug "Attempt to remove nonexistent client autosign for #{certname}"
-        raise NotPresent, "Attempt to remove nonexistent client autosign for #{certname}"
-      end
-    end
-
-    # add certname to puppet autosign file
-    # parameter is certname to use
-    def autosign certname
-      FileUtils.touch(autosign_file) unless File.exist?(autosign_file)
-
-      open(autosign_file, File::RDWR) do |autosign|
-        # Check that we don't have that host already
-        found = autosign.readlines.find { |line| line.chomp == certname }
-        autosign.puts certname unless found
-      end
-      logger.debug "Added #{certname} to autosign"
-    end
-
-    # list of hosts which are now allowed to be installed via autosign
-    def autosign_list
-      return [] unless File.exist?(autosign_file)
-      File.read(autosign_file).split("\n").reject do |v|
-        v =~ /^\s*#.*|^$/ ## Remove comments and empty lines
-      end.map do |v|
-        v.chomp ## Strip trailing spaces
-      end
     end
 
     # list of all certificates and their state/fingerprint
@@ -127,10 +81,6 @@ module Proxy::PuppetCa
 
     def ssldir
       Proxy::PuppetCa::Plugin.settings.ssldir
-    end
-
-    def autosign_file
-      Proxy::PuppetCa::Plugin.settings.autosignfile
     end
 
     # parse the puppetca --list output

--- a/modules/puppetca_hostname_whitelisting/plugin_configuration.rb
+++ b/modules/puppetca_hostname_whitelisting/plugin_configuration.rb
@@ -1,0 +1,12 @@
+module ::Proxy::PuppetCa::HostnameWhitelisting
+  class PluginConfiguration
+    def load_classes
+      require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_autosigner'
+    end
+
+    def load_dependency_injection_wirings(container_instance, settings)
+      container_instance.dependency :autosigner, lambda { ::Proxy::PuppetCa::HostnameWhitelisting::Autosigner.new }
+    end
+  end
+end
+

--- a/modules/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting.rb
+++ b/modules/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting.rb
@@ -1,0 +1,2 @@
+require 'puppetca_hostname_whitelisting/plugin_configuration'
+require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_plugin'

--- a/modules/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_autosigner.rb
+++ b/modules/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_autosigner.rb
@@ -1,0 +1,57 @@
+module ::Proxy::PuppetCa::HostnameWhitelisting
+  class Autosigner
+    include ::Proxy::Log
+    include ::Proxy::Util
+
+    def autosign_file
+      Proxy::PuppetCa::HostnameWhitelisting::Plugin.settings.autosignfile
+    end
+
+    #remove certname from autosign if exists
+    def disable certname
+      raise "No such file #{autosign_file}" unless File.exist?(autosign_file)
+
+      found = false
+      entries = File.readlines(autosign_file).collect do |l|
+        if l.chomp != certname
+          l
+        else
+          found = true
+          nil
+        end
+      end.uniq.compact
+      if found
+        open(autosign_file, File::TRUNC|File::RDWR) do |autosign|
+          autosign.write entries.join
+        end
+        logger.debug "Removed #{certname} from autosign"
+      else
+        logger.debug "Attempt to remove nonexistent client autosign for #{certname}"
+        raise ::Proxy::PuppetCa::NotPresent, "Attempt to remove nonexistent client autosign for #{certname}"
+      end
+    end
+
+    # add certname to puppet autosign file
+    # parameter is certname to use
+    def autosign certname
+      FileUtils.touch(autosign_file) unless File.exist?(autosign_file)
+
+      open(autosign_file, File::RDWR) do |autosign|
+        # Check that we don't have that host already
+        found = autosign.readlines.find { |line| line.chomp == certname }
+        autosign.puts certname unless found
+      end
+      logger.debug "Added #{certname} to autosign"
+    end
+
+    # list of hosts which are now allowed to be installed via autosign
+    def autosign_list
+      return [] unless File.exist?(autosign_file)
+      File.read(autosign_file).split("\n").reject do |v|
+        v =~ /^\s*#.*|^$/ ## Remove comments and empty lines
+      end.map do |v|
+        v.chomp ## Strip trailing spaces
+      end
+    end
+  end
+end

--- a/modules/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_plugin.rb
+++ b/modules/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_plugin.rb
@@ -1,0 +1,11 @@
+module ::Proxy::PuppetCa::HostnameWhitelisting
+  class Plugin < ::Proxy::Provider
+    plugin :puppetca_hostname_whitelisting, ::Proxy::VERSION
+
+    requires :puppetca, ::Proxy::VERSION
+    default_settings :autosignfile => '/etc/puppet/autosign.conf'
+
+    load_classes ::Proxy::PuppetCa::HostnameWhitelisting::PluginConfiguration
+    load_dependency_injection_wirings ::Proxy::PuppetCa::HostnameWhitelisting::PluginConfiguration
+  end
+end

--- a/test/puppetca/puppetca_config_test.rb
+++ b/test/puppetca/puppetca_config_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
-require 'puppetca/puppetca_plugin'
+require 'puppetca/puppetca'
 
 class PuppetCAConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
     Proxy::PuppetCa::Plugin.load_test_settings({})
     assert_equal '/var/lib/puppet/ssl', Proxy::PuppetCa::Plugin.settings.ssldir
-    assert_equal '/etc/puppet/autosign.conf', Proxy::PuppetCa::Plugin.settings.autosignfile
+    assert_equal 'puppetca_hostname_whitelisting', Proxy::PuppetCa::Plugin.settings.use_provider
   end
 end

--- a/test/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_autosigner_test.rb
+++ b/test/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_autosigner_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+require 'tempfile'
+require 'fileutils'
+
+require 'puppetca/puppetca'
+require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting'
+require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_autosigner'
+
+class PuppetCaHostnameWhitelistingAutosignerTest < Test::Unit::TestCase
+  def setup
+    @file = Tempfile.new('autosign_test')
+    begin
+      ## Setup
+      FileUtils.cp './test/fixtures/autosign.conf', @file.path
+    rescue
+      @file.close
+      @file.unlink
+      @file = nil
+    end
+    @autosigner = Proxy::PuppetCa::HostnameWhitelisting::Autosigner.new
+    @autosigner.stubs(:autosign_file).returns(@file.path)
+  end
+
+  def test_should_list_autosign_entries
+    assert_equal @autosigner.autosign_list, ['foo.example.com', '*.bar.example.com']
+  end
+
+  def test_should_add_autosign_entry
+    content = []
+    begin
+      ## Execute
+      @autosigner.autosign 'foobar.example.com'
+      ## Read output
+      content = @file.read.split("\n")
+    ensure
+      @file.close
+      @file.unlink
+    end
+    assert_true content.include?('foobar.example.com')
+  end
+
+  def test_should_not_duplicate_autosign_entry
+    begin
+      before_content = @file.read
+      @file.seek(0)
+      ## Execute
+      @autosigner.autosign 'foo.example.com'
+      ## Read output
+      after_content = @file.read
+    ensure
+      @file.close
+      @file.unlink
+    end
+    assert_equal before_content, after_content
+  end
+
+  def test_should_remove_autosign_entry
+    begin
+      @autosigner.disable 'foo.example.com'
+      content = @file.read
+    ensure
+      @file.close
+      @file.unlink
+    end
+    assert_false content.split("\n").include?('foo.example.com')
+    assert_true content.end_with?("\n")
+  end
+end

--- a/test/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_config_test.rb
+++ b/test/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_config_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+require 'puppetca/puppetca'
+require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting'
+require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_plugin'
+
+class PuppetCaHostnameWhitelistingConfigTest < Test::Unit::TestCase
+  def test_omitted_settings_have_default_values
+    Proxy::PuppetCa::HostnameWhitelisting::Plugin.load_test_settings({})
+    assert_equal '/etc/puppet/autosign.conf', Proxy::PuppetCa::HostnameWhitelisting::Plugin.settings.autosignfile
+  end
+end


### PR DESCRIPTION
Since we are planning to offer alternative options for autosinging in the future (token based instead of hostname based) (see [redmine issue](http://projects.theforeman.org/issues/23211)) and want to allow users to choose their autosigning variant (primarily to allow compatibility with old versions, old foreman versions etc) we need to make the PuppetCA module pluggable, which means moving the autosinging functionality to a provider, which can then be swapped using the SmartProxy settings. We also want to clean up the module a bit and use dependency injections etc. The common logic for listing/signing/cleaning certificates (not autosign-entries) that uses the `puppet cert` command will remain in the puppetca-module.

This is btw an alternative approach to https://github.com/theforeman/smart-proxy/pull/576 which should allow for backwards compatibility and a compatible API between the autosigning variants.