### PR TITLE
fixes #23917 - convert tls version to string

### DIFF
--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -74,7 +74,7 @@ module Proxy
 
       if Proxy::SETTINGS.tls_disabled_versions
         Proxy::SETTINGS.tls_disabled_versions.each do |version|
-          constant = OpenSSL::SSL.const_get("OP_NO_TLSv#{version.gsub(/\./, '_')}") rescue nil
+          constant = OpenSSL::SSL.const_get("OP_NO_TLSv#{version.to_s.gsub(/\./, '_')}") rescue nil
 
           if constant
             logger.info "TLSv#{version} will be disabled."


### PR DESCRIPTION
If someone specifies settings in YAML like this:

```yaml
tls_disabled_versions:
  - 1.1
```

Ruby will interpret it as a float.  Currently, it must be quoted.
@inecas [added a to_s to the dynflow smart proxy plugin](https://github.com/theforeman/smart_proxy_dynflow/pull/43#pullrequestreview-92019342) to fix this,
this commit makes smart proxy behavior the same.

