### PR TITLE
Fixes #24016 - Allow building a tarball without bundle

### DIFF
--- a/Rakefile.dist
+++ b/Rakefile.dist
@@ -1,4 +1,5 @@
 require 'rake/clean'
+load 'tasks/pkg.rake'
 
 BUILDDIR = File.expand_path(ENV['BUILDDIR'] || '_build')
 PREFIX = ENV['PREFIX'] || '/usr/local'

--- a/tasks/pkg.rake
+++ b/tasks/pkg.rake
@@ -5,8 +5,12 @@ namespace :pkg do
   task :generate_source do
     File.exist?('pkg') || FileUtils.mkdir('pkg')
     ref = ENV['ref'] || 'HEAD'
+    name = 'foreman-proxy'
     version = `git show #{ref}:VERSION`.chomp.chomp('-develop')
     raise "can't find VERSION from #{ref}" if version.empty?
-    `git archive --prefix=foreman-proxy-#{version}/ #{ref} | bzip2 -9 > pkg/foreman-proxy-#{version}.tar.bz2`
+    filename = "pkg/#{name}-#{version}.tar.bz2"
+    `git archive --prefix=#{name}-#{version}/ #{ref} | bzip2 -9 > #{filename}`
+    raise 'Failed to generate the source archive' if $? != 0
+    puts filename
   end
 end


### PR DESCRIPTION
This allows generation of the source tarball without the whole bundle installed. It also prints the generated filename.