### PR TITLE
Fixes #24364 - non-ascii logs are readable now [CP 1.18]

### DIFF
--- a/lib/proxy/log_buffer/decorator.rb
+++ b/lib/proxy/log_buffer/decorator.rb
@@ -46,7 +46,7 @@ module Proxy::LogBuffer
           # we accept backtrace, exception and simple string
           backtrace = backtrace.is_a?(Exception) ? backtrace.backtrace : backtrace
           backtrace = backtrace.respond_to?(:join) ? backtrace.join("\n") : backtrace
-          rec = Proxy::LogBuffer::LogRecord.new(nil, severity, message, backtrace, request_id)
+          rec = Proxy::LogBuffer::LogRecord.new(nil, severity, message.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '?'), backtrace, request_id)
           @buffer.push(rec)
         end
       end

--- a/test/log_buffer/decorator_test.rb
+++ b/test/log_buffer/decorator_test.rb
@@ -45,7 +45,7 @@ class DecoratorTest < Test::Unit::TestCase
 
   def test_should_not_ignore_infos
     1.step(5) { |i| @decorator.info(i) }
-    assert_equal [1, 2, 3, 4, 5], @buffer.to_a.collect(&:message)
+    assert_equal ['1','2','3','4','5'], @buffer.to_a.collect(&:message)
   end
 
   def test_should_ignore_debugs
@@ -56,7 +56,7 @@ class DecoratorTest < Test::Unit::TestCase
   def test_should_not_ignore_debugs
     @logger.level = DEBUG
     1.step(5) { |i| @decorator.debug(i) }
-    assert_equal [1, 2, 3, 4, 5], @buffer.to_a.collect(&:message)
+    assert_equal ['1','2','3','4','5'], @buffer.to_a.collect(&:message)
   end
 
   def test_should_keep_request_id_in_buffer_when_available


### PR DESCRIPTION
(cherry picked from commit 4f09154e3ca164eea8dbbcbfc2ee803db4d8deab)

https://github.com/theforeman/smart-proxy/pull/596