### PR TITLE
Fixes #23353 - included DHCP files default directory

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,3 +14,4 @@ gem 'concurrent-ruby', '~> 1.0', require: 'concurrent'
 Dir["#{File.dirname(__FILE__)}/bundler.d/*.rb"].each do |bundle|
   self.instance_eval(Bundler.read_file(bundle))
 end
+

--- a/modules/dhcp_common/isc/configuration_parser.rb
+++ b/modules/dhcp_common/isc/configuration_parser.rb
@@ -427,11 +427,15 @@ module Proxy
         end
 
         def parse_file(a_path)
+          if defined? @@config_path
+            a_path = File.absolute_path(a_path, @@config_path)
+          end
           File.open(a_path, 'r:ASCII-8BIT') {|f| conf.parse!(f.read, a_path)}
         end
 
         # returns all_subnets, all_hosts, root_group
         def subnets_hosts_and_leases(conf_as_string, filename)
+          @@config_path = File.dirname(filename)
           parsed = conf.parse!(conf_as_string, filename)
           start_visiting_parse_tree_nodes(parsed)
         end

--- a/test/dhcp/conf_parser_test.rb
+++ b/test/dhcp/conf_parser_test.rb
@@ -476,10 +476,12 @@ OFMULTILNE_LEASE
   end
 
   def test_include_relative
-    included = Proxy::DHCP::CommonISC::ConfigurationParser.new.subnets_hosts_and_leases(File.read('test/fixtures/dhcp/dhcp_include_relative_testcase1.conf'), 'test/fixtures/dhcp/dhcp_include_relative_testcase1.conf').flatten
+    included = Proxy::DHCP::CommonISC::ConfigurationParser.new.subnets_hosts_and_leases(File.read('test/fixtures/dhcp/dhcp_include_relative_testcase1.conf'), 
+                                                                                        'test/fixtures/dhcp/dhcp_include_relative_testcase1.conf').flatten
     assert_equal ['test.example.com'],
                  included.select {|node| node.class == Proxy::DHCP::CommonISC::ConfigurationParser::Host}.map(&:name)
-    included = Proxy::DHCP::CommonISC::ConfigurationParser.new.subnets_hosts_and_leases(File.read('test/fixtures/dhcp/dhcp_include_relative_testcase2.conf'), 'test/fixtures/dhcp/dhcp_include_relative_testcase2.conf').flatten
+    included = Proxy::DHCP::CommonISC::ConfigurationParser.new.subnets_hosts_and_leases(File.read('test/fixtures/dhcp/dhcp_include_relative_testcase2.conf'),
+                                                                                        'test/fixtures/dhcp/dhcp_include_relative_testcase2.conf').flatten
     assert_equal ['test.example.com'],
                  included.select {|node| node.class == Proxy::DHCP::CommonISC::ConfigurationParser::Host}.map(&:name)
   end

--- a/test/dhcp/conf_parser_test.rb
+++ b/test/dhcp/conf_parser_test.rb
@@ -475,6 +475,15 @@ OFMULTILNE_LEASE
                  included.select {|node| node.class == Proxy::DHCP::CommonISC::ConfigurationParser::HostNode}.map(&:fqdn)
   end
 
+  def test_include_relative
+    included = Proxy::DHCP::CommonISC::ConfigurationParser.new.subnets_hosts_and_leases(File.read('test/fixtures/dhcp/dhcp_include_relative_testcase1.conf'), 'test/fixtures/dhcp/dhcp_include_relative_testcase1.conf').flatten
+    assert_equal ['test.example.com'],
+                 included.select {|node| node.class == Proxy::DHCP::CommonISC::ConfigurationParser::Host}.map(&:name)
+    included = Proxy::DHCP::CommonISC::ConfigurationParser.new.subnets_hosts_and_leases(File.read('test/fixtures/dhcp/dhcp_include_relative_testcase2.conf'), 'test/fixtures/dhcp/dhcp_include_relative_testcase2.conf').flatten
+    assert_equal ['test.example.com'],
+                 included.select {|node| node.class == Proxy::DHCP::CommonISC::ConfigurationParser::Host}.map(&:name)
+  end
+
   def test_include_in_shared_network
     included =
       Proxy::DHCP::CommonISC::ConfigurationParser.new.conf.parse!('shared-network "testing" {include "test/fixtures/dhcp/dhcp_subnets.conf";}')

--- a/test/fixtures/dhcp/dhcp_include_relative_testcase1.conf
+++ b/test/fixtures/dhcp/dhcp_include_relative_testcase1.conf
@@ -1,0 +1,3 @@
+# Test that the ISC DHCP config file parser includes files without an absolute or more specific relative path
+# If none is given, the file to be included will be looked up in the directory where the dhcp configuration file is located
+include "dhcp_subnets.conf";

--- a/test/fixtures/dhcp/dhcp_include_relative_testcase2.conf
+++ b/test/fixtures/dhcp/dhcp_include_relative_testcase2.conf
@@ -1,0 +1,3 @@
+# Test that the ISC DHCP config file parser includes files without an absolute or more specific relative path
+# If none is given, the file to be included will be looked up in the directory where the dhcp configuration file is located
+include "../dhcp/dhcp_subnets.conf";


### PR DESCRIPTION
Hi All,

sorry for the long delay in coming back to you about this topic.
Lukas, thank you very much for the comments and recommendations about the previous pull request.

Please find attached the changes to the files as recommended by Lukas.

There is one exception and I need your support / discuss this with you:
Using an instance variable (@config_path) instead of a class variable (@@config_path) in   modules/dhcp_common/isc/configuration_parser.rb doesn't work

It seems as the parser framework uses different class instances when doing the parsing.
Thus when using instance variable @config_path the tests fail with 
  => 479:     included = Proxy::DHCP::CommonISC::ConfigurationParser.new.subnets_hosts_and_leases(File.read('test/fixtures/dhcp/dhcp_include_relative_testcase1.conf'), 'test/fixtures/dhcp/dhcp_include_relative_testcase1.conf').flatten
... (omitted) ...
Error: test_include_relative(Proxy::DHCP::CommonISC::ConfigurationParserTest): Errno::ENOENT: No such file or directory @ rb_sysopen - dhcp_subnets.conf

So i left the class variable in the code.
Please let me know, if this is acceptable or if there is an alternate approach better suitable.


Thanks
Sven