### PR TITLE
Fixes #24553 - Fix PuppetCa migrations

### DIFF
--- a/extra/migrations/2018062000000_migrate_puppetca_settings.rb
+++ b/extra/migrations/2018062000000_migrate_puppetca_settings.rb
@@ -6,7 +6,11 @@ class MigratePuppetCaSettings < ::Proxy::Migration
                                        path('settings.d', 'puppetca_hostname_whitelisting.yml.example'))
 
     module_settings   = YAML.load_file(path(src_dir, 'settings.d', 'puppetca.yml'))
-    provider_settings = YAML.load_file(path(src_dir, 'settings.d', 'puppetca_hostname_whitelisting.yml'))
+    if File.exist?(path(src_dir, 'settings.d', 'puppetca_hostname_whitelisting.yml'))
+      provider_settings = YAML.load_file(path(src_dir, 'settings.d', 'puppetca_hostname_whitelisting.yml'))
+    else
+      provider_settings =  {}
+    end
 
     write_yaml(path(dst_dir, 'settings.d', 'puppetca_hostname_whitelisting.yml'),
                transform_provider_yaml(module_settings, provider_settings))


### PR DESCRIPTION
The PuppetCA migration failed when the `hostname_whitelisting` settings file did not exist. This fixes this so that the migration succeeds anyway.