### PR TITLE
Fixes #2720 - nsupdate master zone update setting

### DIFF
--- a/config/settings.d/dns_nsupdate.yml.example
+++ b/config/settings.d/dns_nsupdate.yml.example
@@ -4,5 +4,8 @@
 #
 
 #:dns_key: /etc/rndc.key
-# use this setting if you are managing a dns server which is not localhost though this proxy
-#:dns_server: dns.domain.com
+
+# DNS server to talk to, usually localhost but can be an arbitrary (remote) host.
+# This can be also set to a blank value to let nsupdate to detect the master
+# server of a zone.
+#:dns_server: 127.0.0.1

--- a/lib/proxy/default_plugin_validators.rb
+++ b/lib/proxy/default_plugin_validators.rb
@@ -1,5 +1,9 @@
 class Proxy::DefaultPluginValidators
   def self.validators
-    {:file_readable => ::Proxy::PluginValidators::FileReadable, :presence => ::Proxy::PluginValidators::Presence}
+    {
+      :file_readable => ::Proxy::PluginValidators::FileReadable,
+      :presence => ::Proxy::PluginValidators::Presence,
+      :presence_allow_empty => ::Proxy::PluginValidators::PresenceAllowEmpty,
+    }
   end
 end

--- a/lib/proxy/plugin_initializer.rb
+++ b/lib/proxy/plugin_initializer.rb
@@ -338,7 +338,7 @@ module ::Proxy::DefaultSettingsLoader
   end
 
   def validate_settings(plugin, config)
-    result = execute_validators(plugin.plugin_default_settings.keys.map { |k| {:name => :presence, :setting => k} }, config)
+    result = execute_validators(plugin.plugin_default_settings.keys.map { |k| {:name => :presence_allow_empty, :setting => k} }, config)
     result + execute_validators(plugin.validations, config)
   end
 

--- a/lib/proxy/plugin_validators.rb
+++ b/lib/proxy/plugin_validators.rb
@@ -42,4 +42,11 @@ module ::Proxy::PluginValidators
       true
     end
   end
+
+  class PresenceAllowEmpty < Base
+    def validate!(settings)
+      raise ::Proxy::Error::ConfigurationError, "Parameter '#{@setting_name}' is expected to be present" if settings[@setting_name].nil?
+      true
+    end
+  end
 end

--- a/modules/dns_nsupdate/dns_nsupdate_main.rb
+++ b/modules/dns_nsupdate/dns_nsupdate_main.rb
@@ -39,8 +39,10 @@ module Proxy::Dns::Nsupdate
       nsupdate_cmd = "#{@nsupdate} #{nsupdate_args}"
       logger.debug "running #{nsupdate_cmd}"
       @om = IO.popen(nsupdate_cmd, "r+")
-      logger.debug "nsupdate: executed - server #{@server}"
-      @om.puts "server #{@server}"
+      unless @server.nil? || @server.empty?
+        logger.debug "nsupdate: executed - server #{@server}"
+        @om.puts "server #{@server}"
+      end
     end
 
     def nsupdate_disconnect

--- a/test/dns_nsupdate/dns_nsupdate_config_test.rb
+++ b/test/dns_nsupdate/dns_nsupdate_config_test.rb
@@ -13,6 +13,12 @@ class DnsNsupdateConfigTest < Test::Unit::TestCase
     assert_nil Proxy::Dns::Nsupdate::Plugin.settings.dns_key
   end
 
+  def test_nsupdate_emty_dnsserver_setting
+    Proxy::Dns::Nsupdate::Plugin.load_test_settings(dns_server: '')
+
+    assert_equal "", Proxy::Dns::Nsupdate::Plugin.settings.dns_server
+  end
+
   def test_nsupdate_gss_default_settings
     Proxy::Dns::NsupdateGSS::Plugin.load_test_settings({})
 

--- a/test/plugins/module_loader_test.rb
+++ b/test/plugins/module_loader_test.rb
@@ -66,8 +66,8 @@ class ModuleLoaderTest < Test::Unit::TestCase
   def test_presence_validators_called_on_each_of_default_settings
     loader = ::Proxy::DefaultModuleLoader.new(TestPluginWithDefaultValues, nil)
     results = loader.validate_settings(TestPluginWithDefaultValues, :default_1 => "one", :default_2 => "two")
-    assert results.include?(:class => ::Proxy::PluginValidators::Presence, :setting => :default_1, :args => nil, :predicate => nil)
-    assert results.include?(:class => ::Proxy::PluginValidators::Presence, :setting => :default_2, :args => nil, :predicate => nil)
+    assert results.include?(:class => ::Proxy::PluginValidators::PresenceAllowEmpty, :setting => :default_1, :args => nil, :predicate => nil)
+    assert results.include?(:class => ::Proxy::PluginValidators::PresenceAllowEmpty, :setting => :default_2, :args => nil, :predicate => nil)
   end
 
   class TestValidator < ::Proxy::PluginValidators::Base


### PR DESCRIPTION
This patch allows empty strings for default values. Before the patch, when you attempted to create an empty value for any setting which had a default value via

    default_settings :dns_server => 'localhost'

it led to error "Parameter dns_server is expected to have a non-empty value" and this was too strict.

Empty value for dns_server nsupdate setting now means that server is not set via nsupdate which leads to updating master server rather than specific one. See ticket description for more details.