### PR TITLE
Fixes #23031 - parse server duid's with nested double quotes [CP 1.17]

### DIFF
--- a/modules/dhcp_common/isc/configuration_parser.rb
+++ b/modules/dhcp_common/isc/configuration_parser.rb
@@ -244,7 +244,8 @@ module Proxy
           llt = seq_(word('llt') | word('LLT'), SPACE.join(anything).odd._?)
           ll = seq_(word('ll') | word('LL'), SPACE.join(anything).odd._?)
           en = seq_(word('en') | word('EN'), prim(:int32), literal)
-          seq_(keyword,  literal | HEX | en | llt | ll | prim(:int32), EOSTMT) {|_, duid, _| KeyValueNode[:server_duid, duid.respond_to?(:flatten) ? duid.flatten : duid]}
+          duid_literal = /"([^"]|\")*"/.r
+          seq_(keyword, duid_literal | HEX | en | llt | ll | prim(:int32), EOSTMT) {|_, duid, _| KeyValueNode[:server_duid, duid.respond_to?(:flatten) ? duid.flatten : duid]}
         end
 
         def filename

--- a/test/dhcp/conf_parser_test.rb
+++ b/test/dhcp/conf_parser_test.rb
@@ -438,6 +438,8 @@ OFMULTILNE_LEASE
 
   def test_server_duid_parser
     assert_equal [Proxy::DHCP::CommonISC::ConfigurationParser::KeyValueNode[:server_duid, '"\000\001\000\001\"L{\010RT\000A\377\305"']],
+                  Proxy::DHCP::CommonISC::ConfigurationParser.new.conf.parse!('server-duid "\000\001\000\001\"L{\010RT\000A\377\305";')
+    assert_equal [Proxy::DHCP::CommonISC::ConfigurationParser::KeyValueNode[:server_duid, '"\000\001\000\001\"L{\010RT\000A\377\305"']],
                  Proxy::DHCP::CommonISC::ConfigurationParser.new.conf.parse!('server-duid "\000\001\000\001\"L{\010RT\000A\377\305";')
     assert_equal [Proxy::DHCP::CommonISC::ConfigurationParser::KeyValueNode[:server_duid, '"\000\001\000\001!:}\221RT\000^\244\022"']],
                  Proxy::DHCP::CommonISC::ConfigurationParser.new.conf.parse!('server-duid "\000\001\000\001!:}\221RT\000^\244\022";')


### PR DESCRIPTION
Manual backport of https://github.com/theforeman/smart-proxy/pull/571 into 1.17