### PR TITLE
Fixes #24631 - httpboot module

### DIFF
--- a/config/settings.d/httpboot.yml.example
+++ b/config/settings.d/httpboot.yml.example
@@ -1,0 +1,10 @@
+---
+# Enable publishing of a given directory under /EFI and /httpboot paths.
+# Directory listing is not possible, symlinks are followed but not outside
+# of the root directory specified in this file.
+
+# Enables the module, make sure to enable TFTP module as well to allow
+# configuration files deployment.
+:enabled: false
+
+#:root_dir: /var/lib/tftpboot

--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -50,7 +50,7 @@ module Proxy
         :DoNotListen => true,
         :Port => http_port, # only being used to correctly log http port being used
         :Logger => ::Proxy::LogBuffer::Decorator.instance,
-        :ServerSoftware => '',
+        :ServerSoftware => "foreman-proxy/#{Proxy::VERSION}",
         :daemonize => false
       }
     end
@@ -91,7 +91,7 @@ module Proxy
         :DoNotListen => true,
         :Port => https_port, # only being used to correctly log https port being used
         :Logger => ::Proxy::LogBuffer::Decorator.instance,
-        :ServerSoftware => '',
+        :ServerSoftware => "foreman-proxy/#{Proxy::VERSION}",
         :SSLEnable => true,
         :SSLVerifyClient => OpenSSL::SSL::VERIFY_PEER,
         :SSLPrivateKey => load_ssl_private_key(settings.ssl_private_key),

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -80,6 +80,7 @@ module Proxy
   require 'realm/realm'
   require 'realm_freeipa/realm_freeipa'
   require 'logs/logs'
+  require 'httpboot/httpboot'
 
   def self.version
     {:version => VERSION}

--- a/modules/httpboot/http_config.ru
+++ b/modules/httpboot/http_config.ru
@@ -1,0 +1,9 @@
+require 'httpboot/httpboot_api'
+
+map "/EFI" do
+  run Proxy::HttpbootApi
+end
+
+map "/httpboot" do
+  run Proxy::HttpbootApi
+end

--- a/modules/httpboot/httpboot.rb
+++ b/modules/httpboot/httpboot.rb
@@ -1,0 +1,1 @@
+require 'httpboot/httpboot_plugin'

--- a/modules/httpboot/httpboot_api.rb
+++ b/modules/httpboot/httpboot_api.rb
@@ -1,0 +1,15 @@
+class Proxy::HttpbootApi < Sinatra::Base
+  helpers ::Proxy::Helpers
+
+  get "/*" do
+    file = Pathname.new(params[:splat].first).cleanpath
+    root = Pathname.new(Proxy::Httpboot::Plugin.settings.root_dir).expand_path.cleanpath
+    joined_path = File.join(root, file)
+    log_halt(404, "Not found") unless File.exist?(joined_path)
+    real_file = Pathname.new(joined_path).realpath
+    log_halt(403, "Invalid or empty path") unless real_file.fnmatch?("#{root}/**")
+    log_halt(403, "Directory listing not allowed") if File.directory?(real_file)
+    log_halt(503, "Not a regular file") unless File.file?(real_file)
+    send_file real_file
+  end
+end

--- a/modules/httpboot/httpboot_plugin.rb
+++ b/modules/httpboot/httpboot_plugin.rb
@@ -1,0 +1,11 @@
+module Proxy::Httpboot
+  class Plugin < ::Proxy::Plugin
+    http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
+    https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
+
+    plugin :httpboot, ::Proxy::VERSION
+    requires :tftp, ::Proxy::VERSION
+
+    default_settings :root_dir => '/var/lib/tftpboot'
+  end
+end

--- a/test/httpboot/httpboot_api_test.rb
+++ b/test/httpboot/httpboot_api_test.rb
@@ -1,0 +1,68 @@
+require 'test_helper'
+require 'tempfile'
+require 'httpboot/httpboot_plugin'
+require 'httpboot/httpboot_api'
+
+ENV['RACK_ENV'] = 'test'
+
+class HttpbootApiTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Proxy::HttpbootApi.new
+  end
+
+  def setup
+    @tempdir = Dir.mktmpdir 'httpboot-test'
+    FileUtils.touch "#{@tempdir}/valid_file"
+    Dir.mkdir "#{@tempdir}/valid_dir"
+    FileUtils.ln_s "#{@tempdir}/valid_file", "#{@tempdir}/valid_symlink"
+    FileUtils.ln_s "#{@tempdir}/does_not_exist", "#{@tempdir}/invalid_symlink"
+    Proxy::Httpboot::Plugin.load_test_settings(root_dir: @tempdir)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tempdir) if @tempdir =~ /httpboot-test/
+  end
+
+  def test_valid_file
+    result = get "/valid_file"
+    assert_equal 200, last_response.status
+    assert_equal '', result.body
+  end
+
+  def test_valid_dir
+    result = get "/valid_dir"
+    assert_equal 403, last_response.status
+    assert_equal 'Directory listing not allowed', result.body
+  end
+
+  def test_valid_symlink
+    result = get "/valid_symlink"
+    assert_equal 200, last_response.status
+    assert_equal '', result.body
+  end
+
+  def test_invalid_symlink
+    result = get "/invalid_symlink"
+    assert_equal 404, last_response.status
+    assert_equal 'Not found', result.body
+  end
+
+  def test_empty_path
+    result = get "/"
+    assert_equal 403, last_response.status
+    assert_equal 'Invalid or empty path', result.body
+  end
+
+  def test_dangerous_symlink
+    another_dir = Dir.mktmpdir 'httpboot-test2'
+    FileUtils.touch "#{another_dir}/secure_file"
+    FileUtils.ln_s "#{another_dir}/secure_file", "#{@tempdir}/dangerous_symlink"
+    result = get "/dangerous_symlink"
+    assert_equal 403, last_response.status
+    assert_equal 'Invalid or empty path', result.body
+  ensure
+    FileUtils.rm_rf(another_dir) if another_dir =~ /httpboot-test/
+  end
+end


### PR DESCRIPTION
New module for nicer UEFI HTTP BOOT implementation:

https://github.com/theforeman/foreman/pull/5950

Please pay extra attention to security during review. I tested with paths like `'/EFI/../../../etc/passwd'` or similar. Directory listing is not allowed. Symlinks *are* followed by design and they are followed even *outside* of TFTP directory. Not sure if this is a problem, we can limit that tho if needed.