### PR TITLE
PuppetCA: Add Puppet-6 support

### DIFF
--- a/modules/puppetca/puppetca_puppet_cert.rb
+++ b/modules/puppetca/puppetca_puppet_cert.rb
@@ -203,6 +203,7 @@ module Proxy::PuppetCa
     end
 
     def puppetca mode, certname
+
       raise "Invalid mode #{mode}" unless mode =~ /^(clean|sign)$/
       certname.downcase!
 
@@ -218,6 +219,8 @@ module Proxy::PuppetCa
       response = `#{command} 2>&1`
       if $?.success?
         logger.debug "#{mode}ed puppet certificate for #{certname}"
+      elsif response =~ /Could not find files to clean/
+        logger.debug "PUPPET 6 CASE"
       elsif response =~ /Could not find client certificate/ || $?.exitstatus == 24
         logger.debug "Attempt to remove nonexistent client certificate for #{certname}"
         raise NotPresent, "Attempt to remove nonexistent client certificate for #{certname}"
@@ -225,6 +228,7 @@ module Proxy::PuppetCa
         logger.warn "Failed to run puppetca: #{response}"
         raise "Execution of puppetca failed, check log files"
       end
+
       $?.success?
     end
   end

--- a/modules/puppetca/puppetca_puppet_cert.rb
+++ b/modules/puppetca/puppetca_puppet_cert.rb
@@ -208,7 +208,7 @@ module Proxy::PuppetCa
 
       if to_bool(::Proxy::PuppetCa::Plugin.settings.puppet_6, false)
         find_puppetca_6
-        command = "#{@sudo} #{@puppetca} #{mode} --cername #{certname}"
+        command = "#{@sudo} #{@puppetca} #{mode} --certname #{certname}"
       else
         find_puppetca
         command = "#{@sudo} #{@puppetca} --#{mode} #{certname}"


### PR DESCRIPTION
fixes #25065

#### Motivation
with puppet-6 all commands like `puppet cert *` are depricateded. Instead one should use `puppetserver ca *` commands for certificates.

#### Possible Solution
This PR adding a "puppet6" functionality for Puppet-CA. It can be activated by defining `:puppet_6: true` parameter in `puppetca.yml` settings file of the proxy

Please review.

