### PR TITLE
remove has_rdoc from gemspec

### DIFF
--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -11,7 +11,6 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib", "modules"]
   s.test_files = Dir.glob("{test}/**/*test.rb")
   s.license = 'GPL-3.0'
-  s.has_rdoc = true
   s.extra_rdoc_files = ["README.md"]
   s.add_dependency 'json'
   s.add_dependency 'rack', '>= 1.1'


### PR DESCRIPTION
```
NOTE: Gem::Specification#has_rdoc= is deprecated with no replacement. It will be removed on or after 2018-12-01.
Gem::Specification#has_rdoc= called from /usr/local/share/foreman-proxy/smart_proxy.gemspec:14.
```