### PR TITLE
Fixes #25293 - Puma support for smart proxy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bundler.d/*.local.rb
 pkg/
 test/tmp/*
 /tmp/
+ssl/

--- a/bundler.d/puma.rb
+++ b/bundler.d/puma.rb
@@ -1,0 +1,11 @@
+group :puma do
+  if RUBY_VERSION < '2.3'
+    # Important!
+    # The last actual version that supports v2.0.0 up to v2.2.0 is 3.10.0
+    # Puma version 3.11.0 changed the usage of socket to a feature that is not
+    # supported by Ruby 2.2.0 and lower, and it causes a crash on TLS!
+    gem 'puma', '3.10.0', :require => 'puma'
+  else
+    gem 'puma', '~>3.12', :require => 'puma'
+  end
+end

--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -58,6 +58,11 @@
 # default values for https_port is 8443
 #:https_port: 8443
 
+# http server type configuration
+# A string that indicates the server type (possible values: 'webrick', 'puma').
+# Default value is 'webrick'
+#:http_server_type: 'puma'
+
 # Log configuration
 # Uncomment and modify if you want to change the location of the log file or use STDOUT or SYSLOG values
 #:log_file: /var/log/foreman-proxy/proxy.log

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -2,6 +2,7 @@ module ::Proxy::Settings
   class Global < ::OpenStruct
     DEFAULT_SETTINGS = {
       :settings_directory => Pathname.new(__FILE__).join("..","..","..","..","config","settings.d").expand_path.to_s,
+      :http_server_type => :webrick,
       :https_port => 8443,
       :log_file => "/var/log/foreman-proxy/proxy.log",
       :log_level => "INFO",

--- a/lib/proxy/signal_handler.rb
+++ b/lib/proxy/signal_handler.rb
@@ -3,11 +3,11 @@ require 'proxy/log'
 class Proxy::SignalHandler
   include ::Proxy::Log
 
-  def self.install_traps
+  def self.install_traps(servers)
     handler = new
     handler.install_ttin_trap unless RUBY_PLATFORM =~ /mingw/
-    handler.install_int_trap
-    handler.install_term_trap
+    handler.install_int_trap(servers)
+    handler.install_term_trap(servers)
     handler.install_usr1_trap unless RUBY_PLATFORM =~ /mingw/
   end
 
@@ -25,12 +25,22 @@ class Proxy::SignalHandler
     end
   end
 
-  def install_int_trap
-    trap(:INT) { exit(0) }
+  def install_int_trap(servers)
+    trap(:INT) do
+      servers.each do |server|
+        server.shutdown
+      end
+      exit(0)
+    end
   end
 
-  def install_term_trap
-    trap(:TERM) { exit(0) }
+  def install_term_trap(servers)
+    trap(:TERM) do
+      servers.each do |server|
+        server.shutdown
+      end
+      exit(0)
+    end
   end
 
   def install_usr1_trap

--- a/test/launcher_test.rb
+++ b/test/launcher_test.rb
@@ -40,10 +40,10 @@ class LauncherTest < Test::Unit::TestCase
     FileUtils.rm_f @launcher.pid_path
   end
 
-  def test_install_webrick_callback
+  def test_install_http_server_callback
     app1 = {app: 1}
     app2 = {app: 2}
-    @launcher.install_webrick_callback!(app1, nil, app2)
+    @launcher.install_http_server_callback!(app1, nil, app2)
     @launcher.expects(:launched).never
     app1[:StartCallback].call
     @launcher.expects(:launched).with([app1, app2])

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,7 +43,12 @@ module Proxy::IntegrationTestCase
     @t = Thread.new do
       launcher = Proxy::Launcher.new(@settings)
       app = launcher.public_send("#{protocol}_app", port, plugins)
-      launcher.webrick_server(app.merge(AccessLog: [Logger.new('/dev/null')]), ['localhost'], port).start
+      case @settings.http_server_type
+      when :webrick
+        launcher.add_webrick_server(app.merge(AccessLog: [Logger.new('/dev/null')]), ['localhost'], port).start
+      when :puma
+        launcher.add_puma_server(app.merge(AccessLog: [Logger.new('/dev/null')]), ['localhost'], port).start
+      end
     end
     Timeout::timeout(2) do
       sleep(0.1) until can_connect?('localhost', @settings.send("#{protocol}_port"))


### PR DESCRIPTION
Work in progress (still did not test it or wrote any tests for it), loading puma (or) webrick as an HTTP Server.

Started earlier today to work on it, most of it done, but not all :) 