### PR TITLE
Fixes #25243 - option interface-mtu parsed correctly

### DIFF
--- a/modules/dhcp_common/subnet.rb
+++ b/modules/dhcp_common/subnet.rb
@@ -26,7 +26,7 @@ module Proxy::DHCP
       @options[:domain_name] = options[:domain_name] if options[:domain_name]
       @options[:domain_name_servers] = options[:domain_name_servers] if options[:domain_name_servers]
       @options[:ntp_servers] = options[:ntp_servers] if options[:ntp_servers]
-      @options[:interface_mtu] = options[:interface_mtu].to_i if options[:interface_mtu]
+      @options[:interface_mtu] = options[:interface_mtu].flatten.first.to_i if options[:interface_mtu]
       @options[:range] = options[:range] if options[:range] && options[:range][0] && options[:range][1] && validate_subnet_range!(options[:range][0], options[:range][1])
 
       @m = Monitor.new

--- a/test/dhcp/conf_parser_test.rb
+++ b/test/dhcp/conf_parser_test.rb
@@ -261,6 +261,7 @@ EOMULTILNE_SHARED_NETWORK
 
   MULTILINE_POOL =<<EOMULTILINE_POOL
     subnet 192.168.1.0 netmask 255.255.255.128 {
+      option interface-mtu 9000;
       pool {
         authoritative;
         range 192.168.1.1 192.168.1.100;
@@ -271,6 +272,7 @@ EOMULTILNE_SHARED_NETWORK
 EOMULTILINE_POOL
   def test_parse_multiline_pool
     assert_equal [Proxy::DHCP::CommonISC::ConfigurationParser::IpV4SubnetNode['192.168.1.0', '255.255.255.128', [
+      Proxy::DHCP::CommonISC::ConfigurationParser::OptionNode[false, 'interface-mtu', [['9000']]],
       Proxy::DHCP::CommonISC::ConfigurationParser::GroupNode['pool', [
         Proxy::DHCP::CommonISC::ConfigurationParser::IgnoredDeclaration[['authoritative']],
         Proxy::DHCP::CommonISC::ConfigurationParser::RangeNode['192.168.1.1', '192.168.1.100', false],

--- a/test/dhcp/dhcp_isc_subnet_service_initialization_test.rb
+++ b/test/dhcp/dhcp_isc_subnet_service_initialization_test.rb
@@ -12,6 +12,7 @@ class DhcpIscSubnetServiceInitializationTest < Test::Unit::TestCase
 # This is a comment.
 
 subnet 192.168.122.0 netmask 255.255.255.0 {
+  option interface-mtu 9000;
   option routers 192.168.122.250; # This is an inline comment
   next-server 192.168.122.251;
 }
@@ -73,6 +74,12 @@ END
     assert_equal "192.168.123.0", subnets[1].network
     assert_equal "192.168.124.0", subnets[2].network
     assert_equal "192.168.1.0", subnets[3].network
+  end
+
+  def test_interface_mtu_option
+    @initialization.load_configuration_file(DHCPD_CONFIG)
+    subnets =  @subnet_service.all_subnets
+    assert_equal 9000, subnets[0].options[:interface_mtu]
   end
 
   def test_managed_subnets_netmask


### PR DESCRIPTION
It was erroring out when this was present in a conf file:

```
subnet 10.0.0.0 netmask 255.255.255.0 {
    option interface-mtu 9000;
}
```