### PR TITLE
Fixes #25244 - structured logging of exceptions

### DIFF
--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -107,14 +107,14 @@ module Proxy
     def load_ssl_private_key(path)
       OpenSSL::PKey::RSA.new(File.read(path))
     rescue Exception => e
-      logger.error "Unable to load private SSL key. Are the values correct in settings.yml and do permissions allow reading?: #{e}"
+      logger.error "Unable to load private SSL key. Are the values correct in settings.yml and do permissions allow reading?", e
       raise e
     end
 
     def load_ssl_certificate(path)
       OpenSSL::X509::Certificate.new(File.read(path))
     rescue Exception => e
-      logger.error "Unable to load SSL certificate. Are the values correct in settings.yml and do permissions allow reading?: #{e}"
+      logger.error "Unable to load SSL certificate. Are the values correct in settings.yml and do permissions allow reading?", e
       raise e
     end
 
@@ -184,7 +184,7 @@ module Proxy
       # do nothing. This is to prevent the exception handler below from catching SystemExit exceptions.
       raise
     rescue Exception => e
-      logger.error("Error during startup, terminating. #{e}", e.backtrace)
+      logger.error "Error during startup, terminating", e
       puts "Errors detected on startup, see log for details. Exiting: #{e}"
       exit(1)
     end

--- a/lib/proxy/kerberos.rb
+++ b/lib/proxy/kerberos.rb
@@ -9,7 +9,7 @@ module Proxy::Kerberos
     begin
       krb5.get_init_creds_keytab principal, keytab, nil, ccache
     rescue => e
-      logger.error "Failed to initialise credential cache from keytab: #{e}"
+      logger.error "Failed to initialise credential cache from keytab", e
       raise "Failed to initailize credentials cache from keytab: #{e}"
     end
     logger.debug "Kerberos credential cache initialised with principal: #{ccache.primary_principal}"

--- a/lib/proxy/log_buffer/decorator.rb
+++ b/lib/proxy/log_buffer/decorator.rb
@@ -41,7 +41,6 @@ module Proxy::LogBuffer
         return if message == ''
         # add to the logger first
         @logger.add(severity, message)
-        @logger.add(::Logger::Severity::DEBUG, backtrace) if backtrace
         # add add to the buffer
         if severity >= @logger.level
           # we accept backtrace, exception and simple string
@@ -51,6 +50,8 @@ module Proxy::LogBuffer
           @buffer.push(rec)
         end
       end
+      # exceptions are also sent to structured log if available
+      self.exception("Error details", backtrace) if backtrace && backtrace.is_a?(Exception)
     end
 
     def trace?

--- a/lib/proxy/plugin_initializer.rb
+++ b/lib/proxy/plugin_initializer.rb
@@ -100,9 +100,9 @@ class ::Proxy::PluginGroup
     fail_group_with_message("Disabling all modules in the group #{printable_module_names(member_names)} due to a failure in one of them: #{an_exception}", an_exception.backtrace)
   end
 
-  def fail_group_with_message(a_message, a_backtrace = nil)
+  def fail_group_with_message(a_message, an_exception = nil)
     set_group_state_to_failed
-    logger.error(a_message, a_backtrace)
+    logger.error(a_message, an_exception)
     members.each do |m|
       ::Proxy::LogBuffer::Buffer.instance.failed_module(m.plugin_name, a_message)
     end
@@ -210,7 +210,7 @@ module ::Proxy::LegacyRuntimeConfigurationLoader
     plugin.class_eval(&plugin.after_activation_blk)
     logger.info("Successfully initialized '#{plugin.plugin_name}'")
   rescue Exception => e
-    logger.error("Couldn't enable '#{plugin.plugin_name}': #{e}", e.backtrace)
+    logger.error "Couldn't enable '#{plugin.plugin_name}'", e
     ::Proxy::LogBuffer::Buffer.instance.failed_module(plugin.plugin_name, e.message)
   end
 end
@@ -221,7 +221,7 @@ module ::Proxy::DefaultRuntimeConfigurationLoader
     start_services(plugin.services, di_container)
     logger.info("Successfully initialized '#{plugin.plugin_name}'")
   rescue Exception => e
-    logger.error("Couldn't enable '#{plugin.plugin_name}': #{e}", e.backtrace)
+    logger.error "Couldn't enable '#{plugin.plugin_name}'", e
     ::Proxy::LogBuffer::Buffer.instance.failed_module(plugin.plugin_name, e.message)
     raise e
   end

--- a/lib/proxy/util.rb
+++ b/lib/proxy/util.rb
@@ -27,7 +27,7 @@ module Proxy::Util
               logger.debug "[#{pid}] #{line}"
             end
             stderr.each do |line|
-              logger.error "[#{pid}] #{line}"
+              logger.warn "[#{pid}] #{line}"
             end
             # In Ruby 1.8, popen3 always reports an error code of 0 in $?.
             # In Ruby >= 1.9, call thr.value to wait for a Process::Status object.
@@ -100,7 +100,7 @@ module Proxy::Util
       end
       Process.wait(c.pid)
     rescue Exception => e
-      logger.error("Exception '#{e}' when executing '#{cmd}'")
+      logger.error "Error when executing '#{cmd}'", e
       return false
     end
     logger.warn("Non-null exit code when executing '#{cmd}'") if $?.exitstatus != 0

--- a/modules/dhcp_common/free_ips.rb
+++ b/modules/dhcp_common/free_ips.rb
@@ -75,7 +75,7 @@ module Proxy::DHCP
             return possible_ip
           end
         rescue Exception => e
-          logger.error("Exception when pinging #{possible_ip}. Skipping the address.", e)
+          logger.error "Exception when pinging #{possible_ip}. Skipping the address.", e
         end
       end
 

--- a/modules/dhcp_libvirt/dhcp_libvirt_main.rb
+++ b/modules/dhcp_libvirt/dhcp_libvirt_main.rb
@@ -13,7 +13,8 @@ module Proxy::DHCP::Libvirt
       libvirt_network.add_dhcp_record record
       record
     rescue ::Libvirt::Error => e
-      logger.error msg = "Error adding DHCP record: #{e}"
+      msg = "Error adding DHCP record"
+      logger.error msg, e
       raise Proxy::DHCP::Error, msg
     end
 
@@ -21,7 +22,8 @@ module Proxy::DHCP::Libvirt
       # libvirt only supports one subnet per network
       libvirt_network.del_dhcp_record record
     rescue ::Libvirt::Error => e
-      logger.error msg = "Error removing DHCP record: #{e}"
+      msg = "Error removing DHCP record"
+      logger.error msg, e
       raise Proxy::DHCP::Error, msg
     end
   end

--- a/modules/dhcp_libvirt/subnet_service_initializer.rb
+++ b/modules/dhcp_libvirt/subnet_service_initializer.rb
@@ -37,7 +37,8 @@ module Proxy::DHCP::Libvirt
       raise Proxy::DHCP::Error("Only one subnet is supported") if ret_val.size > 1
       ret_val
     rescue Exception => e
-      logger.error msg = "Unable to parse subnets XML: #{e}"
+      msg = "Unable to parse subnets XML"
+      logger.error msg, e
       logger.debug xml if defined?(xml)
       raise Proxy::DHCP::Error, msg
     end
@@ -57,7 +58,8 @@ module Proxy::DHCP::Libvirt
       end
       to_ret
     rescue Exception => e
-      logger.error msg = "Unable to parse reservations XML: #{e}"
+      msg = "Unable to parse reservations XML"
+      logger.error msg, e
       logger.debug xml if defined?(xml)
       raise Proxy::DHCP::Error, msg
     end

--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -60,9 +60,9 @@ module Proxy::Dns::Dnscmd
 
     def report msg, response, error_only
       if response.grep(/completed successfully/).empty?
-        logger.error "Dnscmd failed:\n" + response.join("\n")
-        msg.sub! /Removed/,    "remove"
-        msg.sub! /Added/,      "add"
+        logger.error "Command dnscmd failed:\n" + response.join("\n")
+        msg.sub!(/Removed/, "remove")
+        msg.sub!(/Added/, "add")
         msg  = "Failed to #{msg}"
         raise Proxy::Dns::Error.new(msg) unless response.grep(/DNS_ERROR_NAME_DOES_NOT_EXIST/).any? && msg == "Failed to EnumRecords"
       else
@@ -71,7 +71,7 @@ module Proxy::Dns::Dnscmd
     rescue Proxy::Dns::Error
       raise
     rescue
-      logger.error "Dnscmd failed:\n" + (response.is_a?(Array) ? response.join("\n") : "Response was not an array! #{response}")
+      logger.error "Command dnscmd failed:\n" + (response.is_a?(Array) ? response.join("\n") : "Response was not an array! #{response}")
       raise Proxy::Dns::Error.new("Unknown error while processing '#{msg}'")
     end
 

--- a/modules/dns_libvirt/dns_libvirt_main.rb
+++ b/modules/dns_libvirt/dns_libvirt_main.rb
@@ -16,7 +16,8 @@ module Proxy::Dns::Libvirt
     def create_a_record(fqdn, ip)
       libvirt_network.add_dns_a_record fqdn, ip
     rescue ::Libvirt::Error => e
-      logger.error msg = "Error adding DNS A record: #{e}"
+      msg = "Error adding DNS A record"
+      logger.error msg, e
       raise Proxy::Dns::Error, msg
     end
     alias :create_aaaa_record :create_a_record
@@ -28,7 +29,8 @@ module Proxy::Dns::Libvirt
     def remove_a_record(fqdn)
       libvirt_network.del_dns_a_record fqdn, find_ip_for_host(fqdn)
     rescue ::Libvirt::Error => e
-      logger.error msg = "Error adding DNS A record: #{e}"
+      msg = "Error adding DNS A record"
+      logger.error msg, e
       raise Proxy::Dns::Error, msg
     end
     alias :remove_aaaa_record :remove_a_record
@@ -46,7 +48,8 @@ module Proxy::Dns::Libvirt
           end
         end
       rescue Exception => e
-        logger.error msg = "Unable to retrieve IP for #{host}: #{e}"
+        msg = "Unable to retrieve IP for #{host}"
+        logger.error msg, e
         logger.debug xml if defined?(xml)
         raise Proxy::Dns::Error, msg
       end

--- a/modules/puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever.rb
+++ b/modules/puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever.rb
@@ -81,7 +81,7 @@ class Proxy::PuppetApi::V3EnvironmentClassesApiClassesRetriever
         response, etag = @puppet_api.new(puppet_url, ssl_ca, ssl_cert, ssl_key).list_classes(environment, etag, MAX_PUPPETAPI_TIMEOUT)
       rescue Exception => e
         @m.synchronize { @futures_cache[environment] = nil }
-        logger.error("Error while retrieving puppet classes for '%s' environment" % [environment], e)
+        logger.error "Error while retrieving puppet classes for '%s' environment" % [environment], e
         raise e
       end
 

--- a/test/log_buffer/decorator_test.rb
+++ b/test/log_buffer/decorator_test.rb
@@ -10,6 +10,7 @@ class DecoratorTest < Test::Unit::TestCase
 
   DEBUG = ::Logger::Severity::DEBUG
   INFO = ::Logger::Severity::INFO
+  WARNING = ::Logger::Severity::WARN
   ERR = ::Logger::Severity::ERROR
   FATAL = ::Logger::Severity::FATAL
 
@@ -39,7 +40,7 @@ class DecoratorTest < Test::Unit::TestCase
   def test_should_pass_and_log_exception
     e = Exception.new('exception')
     @logger.expects(:add).with(DEBUG, "message")
-    @logger.expects(:add).with(DEBUG, e)
+    @decorator.expects(:exception).with("Error details", e)
     @decorator.debug("message", e)
   end
 


### PR DESCRIPTION
Proxy now supports configuring against system journal (via `:logfile: JOURNALD`). This patch refactors `error` calls, previously it was accepting bactrace as a simple string putting it into log on single line. This was unreadable.

With this patch, exceptions are passed into the `error` call as objects. Backtrace is correctly parsed via `exception.backtrace` and put as an extra warning log line with structured fields.

To test, configure proxy with journald and misconfigure a module so it fails to initialize it, exception will be thrown into logs as text and also if you do `journalctl -e -o verbose` three fields named `EXCEPTION` should be logged.