### PR TITLE
Fixes #25432 - Support Huawei VRP

### DIFF
--- a/modules/dhcp_common/isc/omapi_provider.rb
+++ b/modules/dhcp_common/isc/omapi_provider.rb
@@ -159,6 +159,19 @@ module Proxy::DHCP::CommonISC
       statements
     end
 
+    def vendor_specific_ztp_statements(options)
+      statements = []
+      if options.has_key?(:ztp_vendor) 
+        case options[:ztp_vendor]
+          when "huawei"
+            if options.has_key?(:ztp_firmware)
+              statements << "option option-143 = \\\"vrpfile=#{options[:ztp_firmware][:core]};webfile=#{options[:ztp_firmware][:web]};\\\";"
+            end
+        end
+      end
+      statements
+    end
+
     # Quirk: Junos ZTP requires special DHCP options
     def ztp_options_statements(options)
       statements = []
@@ -167,6 +180,8 @@ module Proxy::DHCP::CommonISC
         opt150 = ip2hex validate_ip(options[:nextServer])
         statements << "option option-150 = #{opt150};"
         statements << "option FM_ZTP.config-file-name = \\\"#{options[:filename]}\\\";"
+
+        statements.concat(vendor_specific_ztp_statements(options))
       end
       statements
     end

--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -110,7 +110,7 @@ module Proxy::TFTP
       [pxeconfig_dir]
     end
     def pxeconfig_file mac
-      ["#{pxeconfig_dir}/"+mac.delete(':').upcase]
+      ["#{pxeconfig_dir}/"+mac.delete(':').upcase, "#{pxeconfig_dir}/"+mac.delete(':').upcase+".cfg"]
     end
   end
 

--- a/test/dhcp/isc_omapi_provider_test.rb
+++ b/test/dhcp/isc_omapi_provider_test.rb
@@ -118,6 +118,13 @@ class IscOmapiProviderTest < Test::Unit::TestCase
     assert_equal [], @dhcp.ztp_options_statements(:filename => 'foo.cfg')
     assert_equal ['option option-150 = c0:a8:7a:01;', 'option FM_ZTP.config-file-name = \\"ztp.cfg\\";'],
                  @dhcp.ztp_options_statements(:filename => 'ztp.cfg', :nextServer => '192.168.122.1')
+    assert_equal ['option option-150 = c0:a8:7a:01;', 'option FM_ZTP.config-file-name = \\"ztp.cfg\\";'],
+                 @dhcp.ztp_options_statements(:filename => 'ztp.cfg', :nextServer => '192.168.122.1', :ztp_vendor => 'junos')
+    assert_equal ['option option-150 = c0:a8:7a:01;', 'option FM_ZTP.config-file-name = \\"ztp.cfg\\";',
+                  'option option-143 = \\"vrpfile=firmware.cc;webfile=web.7z;\\";'],
+                 @dhcp.ztp_options_statements(:filename => 'ztp.cfg', :nextServer => '192.168.122.1',
+                                              :ztp_vendor => 'huawei', :ztp_firmware => { :core => 'firmware.cc',
+                                                                                          :web => 'web.7z'})
   end
 
   def test_poap_quirks

--- a/test/tftp/tftp_server_test.rb
+++ b/test/tftp/tftp_server_test.rb
@@ -136,7 +136,7 @@ class TftpZtpServerTest < Test::Unit::TestCase
 
   def setup_paths
     @subject = Proxy::TFTP::Ztp.new
-    @pxe_config_files = ["ztp.cfg/AABBCCDDEEFF"]
+    @pxe_config_files = ["ztp.cfg/AABBCCDDEEFF", "ztp.cfg/AABBCCDDEEFF.cfg"]
   end
 
   def test_create_default


### PR DESCRIPTION
Allow support for provisioning Huawei switches running VRP via ZTP mechanism
This code also allows to add additional switch manufactures whom can utilize ZTP