### PR TITLE
allow for PUPPET_VERSION to be set

### DIFF
--- a/bundler.d/puppet.rb
+++ b/bundler.d/puppet.rb
@@ -1,4 +1,4 @@
 group :puppet_proxy_legacy do
-  gem 'puppet', '< 6.0.0'
+  gem 'puppet', ENV.key?('PUPPET_VERSION') ? "~> #{ENV['PUPPET_VERSION']}" : '< 6.0.0'
   gem 'ruby-augeas', :require => 'augeas'
 end


### PR DESCRIPTION
this will help when testing smart-proxy against different puppet
versions