### PR TITLE
Fixes #25825 - fixed BMC SSH config names

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Currently Supported modules:
  * Puppet CA - Manage certificate signing, cleaning and autosign on a Puppet CA server
  * Realm - Manage host registration to a realm (e.g. FreeIPA)
  * TFTP - any UNIX based tftp server
+ * Facts - module to gather facts from facter (used only on discovered nodes)
+ * HTTPBoot - endpoint exposing a (TFTP) directory via HTTP(s) for UEFI HTTP booting
+ * Logs - log buffer of proxy logs for easier troubleshooting
+ * Templates - unattended Foreman endpoint proxy
 
 # Installation
 Read the [Smart Proxy Installation section](https://theforeman.org/manuals/latest/index.html#4.3.1SmartProxyInstallation) of the manual.

--- a/modules/bmc/ssh.rb
+++ b/modules/bmc/ssh.rb
@@ -10,10 +10,10 @@ module Proxy
         @host = host
         @ssh_user = Proxy::BMC::Plugin.settings.bmc_ssh_user || 'root'
         @ssh_key = Proxy::BMC::Plugin.settings.bmc_ssh_key
-        @poweron = Proxy::BMC::Plugin.settings.poweron || 'false'
-        @poweroff = Proxy::BMC::Plugin.settings.poweroff || 'shutdown +1'
-        @powerstatus = Proxy::BMC::Plugin.settings.powerstatus || 'true'
-        @powercycle = Proxy::BMC::Plugin.settings.powercycle || 'shutdown -r +1'
+        @poweron = Proxy::BMC::Plugin.settings.bmc_ssh_poweron || 'false'
+        @poweroff = Proxy::BMC::Plugin.settings.bmc_ssh_poweroff || 'shutdown +1'
+        @powerstatus = Proxy::BMC::Plugin.settings.bmc_ssh_powerstatus || 'true'
+        @powercycle = Proxy::BMC::Plugin.settings.bmc_ssh_powercycle || 'shutdown -r +1'
       end
 
       # call remote command and return bool

--- a/test/bmc/bmc_api_shell_test.rb
+++ b/test/bmc/bmc_api_shell_test.rb
@@ -19,7 +19,7 @@ class BmcApiShellTest < Test::Unit::TestCase
   end
 
   def test_api_shell_should_powercycle_with_shutdown
-    Proxy::BMC::Shell.any_instance.stubs(:powercycle).returns(true)
+    Proxy::BMC::Shell.any_instance.stubs(:bmc_ssh_powercycle).returns(true)
     args = { :bmc_provider => 'shell' }
     get "/#{host}/chassis/power/cycle", args
     @args = { :username => "user", :password => "pass", :bmc_provider => "ipmitool", :host => "host" }

--- a/test/bmc/bmc_api_ssh_test.rb
+++ b/test/bmc/bmc_api_ssh_test.rb
@@ -16,10 +16,10 @@ class BmcApiShellTest < Test::Unit::TestCase
     @host = "somehost"
     @args = { :bmc_provider => "ssh" }
     Proxy::BMC::Plugin.load_test_settings(
-      :poweron => 'echo poweron',
-      :poweroff => 'echo poweroff',
-      :powerstatus => 'echo powerstatus',
-      :powercycle => 'echo powercycle'
+      :bmc_ssh_poweron => 'echo poweron',
+      :bmc_ssh_poweroff => 'echo poweroff',
+      :bmc_ssh_powerstatus => 'echo powerstatus',
+      :bmc_ssh_powercycle => 'echo powercycle'
     )
   end
 


### PR DESCRIPTION
SSIA + typos in SSH BMC module example config