### PR TITLE
Fixes #25824 - BMC provider nil exception test fixed

### DIFF
--- a/test/bmc/bmc_api_test.rb
+++ b/test/bmc/bmc_api_test.rb
@@ -174,7 +174,7 @@ class BmcApiTest < Test::Unit::TestCase
   def test_api_recovers_from_nil_provider
     Proxy::BMC::Plugin.load_test_settings(:bmc_default_provider => nil)
     Proxy::BMC::IPMI.stubs(:providers_installed).returns(['freeipmi'])
-    test_args = { 'bmc_provider' => nil }
+    test_args = { 'bmc_provider' => '' }
     Proxy::BMC::IPMI.any_instance.stubs(:test).returns(true)
     get "/#{host}/test", test_args
     assert last_response.ok?, "Last response was not ok"


### PR DESCRIPTION
I am not aware it's possible to send `nil` via request parameters, therefore this test is not correct. This fails with recent Sinatra versions due to this change:

https://github.com/sinatra/sinatra/pull/1479#issuecomment-453034886