### PR TITLE
Fixes #25769 - dhcp conf parser option code fixed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ bundler.d/*.local.rb
 pkg/
 test/tmp/*
 /tmp/
+/vendor

--- a/modules/dhcp_common/isc/configuration_parser.rb
+++ b/modules/dhcp_common/isc/configuration_parser.rb
@@ -269,10 +269,12 @@ module Proxy
         def option
           Rsec::Fail.reset
           keyword_option = word('option').fail 'keyword_option'
+          keyword_code = /code \d+/.r 'keyword_code'
           keyword_supersede = word('supersede').fail 'keyword_supersede'
           option_name = /[\w\.-]+/.r
-          seq_(keyword_option | keyword_supersede, option_name, '='.r._?, option_values, EOSTMT) {|maybe_supersede, name, _, values, _| OptionNode[maybe_supersede == 'supersede', name, values]} |
-              vendor_option_space | filename | next_server
+          seq_(keyword_option | keyword_supersede, option_name, keyword_code._?, '='.r._?, LFT_BRACKET._?, option_values, RGT_BRACKET._?, EOSTMT) do |maybe_supersede, name, _, _, _, values, _, _|
+            OptionNode[maybe_supersede == 'supersede', name, values]
+          end | vendor_option_space | filename | next_server
         end
 
         def set

--- a/test/dhcp/dhcp_isc_subnet_service_initialization_test.rb
+++ b/test/dhcp/dhcp_isc_subnet_service_initialization_test.rb
@@ -11,8 +11,24 @@ class DhcpIscSubnetServiceInitializationTest < Test::Unit::TestCase
   DHCPD_CONFIG =<<END
 # This is a comment.
 
+omapi-port 7911;
+default-lease-time 43200;
+max-lease-time 86400;
+ddns-update-style none;
+option domain-name "some.example.com";
+option domain-name-servers 192.168.121.101;
+option ntp-servers none;
+allow booting;
+allow bootp;
+option fqdn.no-client-update on;
+option fqdn.rcode2 255;
+option pxegrub code 150 = text ;
+
+option voip-tftp-server code 150 = { ip-address };
+
 subnet 192.168.122.0 netmask 255.255.255.0 {
   option interface-mtu 9000;
+  option voip-tftp-server 1.2.3.4;
   option routers 192.168.122.250; # This is an inline comment
   next-server 192.168.122.251;
 }


### PR DESCRIPTION
Fixed parser to understand "code 123 = { something };"

    option voip-tftp-server code 150 = { ip-address };

Also added statements from Foreman default dhcpd.conf managed by puppet.