### PR TITLE
Fixes #25942 - Fix ::TimeoutError is deprecated message

### DIFF
--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -47,7 +47,7 @@ module Proxy::Dns::Dnscmd
           response  = std_out.readlines
           response += std_err.readlines
         end
-      rescue TimeoutError
+      rescue Timeout::Error
         raise Proxy::Dns::Error.new("dnscmd did not respond within #{tsecs} seconds")
       ensure
         std_in.close  unless std_in.nil?


### PR DESCRIPTION
It seems Timeout::Error should be used instead and we actually use it in
other places.