### PR TITLE
Refs #25614 - improve and add DNS capabilities

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -113,3 +113,6 @@ Style/LineEndConcatenation:
 
 Style/ParallelAssignment:
   Enabled: false
+
+Metrics/LineLength:
+  Max: 250

--- a/lib/proxy/helpers.rb
+++ b/lib/proxy/helpers.rb
@@ -20,6 +20,7 @@ module Proxy::Helpers
     end
     content_type :json if request.accept?("application/json")
     logger.error message, exception
+    logger.exception(message, exception) if exception.is_a?(Exception)
     halt code, message
   end
 

--- a/lib/proxy/log.rb
+++ b/lib/proxy/log.rb
@@ -79,7 +79,7 @@ module Proxy
     def call(env)
       status = 500
       env['rack.logger'] = logger
-      logger.info { "Started #{env['REQUEST_METHOD']} #{env['PATH_INFO']} #{env['QUERY_STRING']}" }
+      logger.info { "Started #{env['REQUEST_METHOD']} #{env['REQUEST_PATH']} #{env['QUERY_STRING']}" }
       logger.trace { 'Headers: ' + env.select {|k,v| k.start_with? 'HTTP_'}.inspect }
       logger.trace { (body = env['rack.input'].read).empty? ? '' : 'Body: ' + body }
       before = Time.now.to_f

--- a/modules/dhcp/dhcp_plugin.rb
+++ b/modules/dhcp/dhcp_plugin.rb
@@ -4,6 +4,7 @@ class Proxy::DhcpPlugin < ::Proxy::Plugin
 
   uses_provider
   default_settings :use_provider => 'dhcp_isc', :server => '127.0.0.1', :subnets => []
+  expose_setting :use_provider
   plugin :dhcp, ::Proxy::VERSION
 
   load_classes ::Proxy::DHCP::ConfigurationLoader

--- a/modules/dns/dns_plugin.rb
+++ b/modules/dns/dns_plugin.rb
@@ -5,6 +5,7 @@ module Proxy::Dns
 
     uses_provider
     default_settings :use_provider => 'dns_nsupdate', :dns_ttl => 86_400
+    expose_setting :use_provider
     plugin :dns, ::Proxy::VERSION
 
     load_classes ::Proxy::Dns::ConfigurationLoader

--- a/modules/dns_dnscmd/dns_dnscmd_plugin.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_plugin.rb
@@ -6,6 +6,11 @@ module ::Proxy::Dns::Dnscmd
 
     requires :dns, ::Proxy::VERSION
 
+    capability "record_type_a"
+    capability "record_type_aaaa"
+    capability "record_type_cname"
+    capability "record_type_ptr"
+
     load_classes ::Proxy::Dns::Dnscmd::PluginConfiguration
     load_dependency_injection_wirings ::Proxy::Dns::Dnscmd::PluginConfiguration
   end

--- a/modules/dns_libvirt/dns_libvirt_plugin.rb
+++ b/modules/dns_libvirt/dns_libvirt_plugin.rb
@@ -6,6 +6,8 @@ module ::Proxy::Dns::Libvirt
 
     default_settings :url => "qemu:///system", :network => 'default'
 
+    capability "record_type_a"
+
     load_classes ::Proxy::Dns::Libvirt::PluginConfiguration
     load_dependency_injection_wirings ::Proxy::Dns::Libvirt::PluginConfiguration
   end

--- a/modules/dns_nsupdate/dns_nsupdate_plugin.rb
+++ b/modules/dns_nsupdate/dns_nsupdate_plugin.rb
@@ -8,6 +8,12 @@ module ::Proxy::Dns::Nsupdate
 
     validate_readable :dns_key
 
+    capability "record_type_a"
+    capability "record_type_aaaa"
+    capability "record_type_cname"
+    capability "record_type_ptr"
+    capability "record_type_srv"
+
     load_classes ::Proxy::Dns::Nsupdate::PluginConfiguration
     load_dependency_injection_wirings ::Proxy::Dns::Nsupdate::PluginConfiguration
   end

--- a/modules/puppetca/puppetca_plugin.rb
+++ b/modules/puppetca/puppetca_plugin.rb
@@ -5,6 +5,7 @@ module Proxy::PuppetCa
 
     uses_provider
     default_settings :use_provider => 'puppetca_hostname_whitelisting'
+    expose_setting :use_provider
 
     load_classes ::Proxy::PuppetCa::PluginConfiguration
     load_programmable_settings ::Proxy::PuppetCa::PluginConfiguration

--- a/modules/realm/realm_plugin.rb
+++ b/modules/realm/realm_plugin.rb
@@ -4,6 +4,7 @@ module Proxy::Realm
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
     default_settings :use_provider => 'realm_freeipa'
+    expose_setting :use_provider
 
     uses_provider
     load_classes ::Proxy::Realm::ConfigurationLoader

--- a/modules/root/root_v2_api.rb
+++ b/modules/root/root_v2_api.rb
@@ -15,8 +15,9 @@ class Proxy::RootV2Api < Sinatra::Base
       attributes = [:http_enabled, :https_enabled, :settings, :state]
 
       plugins = enabled_plugins.inject({}) do |hash, plugin|
-        result = Hash[attributes.map { |attribute| [attribute, plugin[attribute]] }]
-        result[:capabilities] = process_capabilities(plugin[:state], plugin[:capabilities])
+        result = Hash[attributes.map { |attribute| [attribute, plugin[attribute]] }.delete_if { |k, v| v.nil? || (v.instance_of?(Hash) && v.empty?) }]
+        capabilities = process_capabilities(plugin[:state], plugin[:capabilities])
+        result[:capabilities] = capabilities unless capabilities.empty?
         hash[plugin[:name]] = result
         hash
       end

--- a/test/puppetca_http_api/ca_v1_api_request_test.rb
+++ b/test/puppetca_http_api/ca_v1_api_request_test.rb
@@ -52,7 +52,6 @@ class CaApiv1RequestTest < Test::Unit::TestCase
     stub_request(:get, 'https://puppet:8140/puppet-ca/v1/certificate_statuses/foreman').
       to_return(:status => 200, :body => fixture('ca_search.json'))
 
-    # rubocop:disable Metrics/LineLength
     expected = [
       {
         'dns_alt_names' => ['DNS:puppet', 'DNS:puppet.example.com'],
@@ -72,7 +71,6 @@ class CaApiv1RequestTest < Test::Unit::TestCase
         'subject_alt_names' => ['DNS:puppet', 'DNS:puppet.example.com']
       }
     ]
-    # rubocop:enable Metrics/LineLength
 
     assert_equal expected, @client.search
   end

--- a/test/puppetca_http_api/puppetca_http_impl_test.rb
+++ b/test/puppetca_http_api/puppetca_http_impl_test.rb
@@ -8,7 +8,6 @@ class PuppetCaHttpImplTest < Test::Unit::TestCase
     def sign(certname); end
     def clean(certname); end
 
-    # rubocop:disable Metrics/LineLength
     def search(key = 'foreman')
       [
         {
@@ -26,11 +25,9 @@ class PuppetCaHttpImplTest < Test::Unit::TestCase
         }
       ]
     end
-  # rubocop:enable Metrics/LineLength
   end
 
   class FakeCaApiV1Request63 < FakeCaApiV1Request
-    # rubocop:disable Metrics/LineLength
     def search(key = 'foreman')
       [
         {


### PR DESCRIPTION
When I started working on DNS capabilities, I realized that the feature does not work as expected. It publishes capabilities from plugins but completely ignores caps from providers. Therefore I am proposing slight change in V2 features API to also publish it from providers.

This changes the API result a bit, now it includes bunch of providers which are registered as "uninitialized". My first idea was to simply hide them, but I think it might be quite useful showing them flagged with state set to "uninitialized" because if we decide to add this later, this will be again a breaking change since the client code must now parse actually "state" value and not rely on simple element presence.

For this reason, I am leaving the "uninitialized" providers in the response. But now the output is getting out of control, it's very long with tons of "null", empty arrays and hashes. Therefore I am proposing to compact the result to more human-readable form (deleting all empty/nil elements). While I agree with Ewoud that generally it is good to avoid checking for non-existing elements, I think for JSON API this is not the case as this applies more for coding.

The patch also exposes "use_provider" setting value where appropriate. This way the consumer can eventually create a "tree" of initialized dependencies easily.

Second part of the patch is actually adding capabilities to DNS providers in core. We have three DNS providers from which ISC (nsupdate) is the most capable and libvirt is the most limited (supports only A type of records). I propose for `handles_X` pattern because we might add another set of capabilities so the prefix clearly differentiate each group.