### PR TITLE
Fixes #26322 - Expose the puppet URL settings

### DIFF
--- a/modules/puppet_proxy_puppet_api/puppet_proxy_puppet_api_plugin.rb
+++ b/modules/puppet_proxy_puppet_api/puppet_proxy_puppet_api_plugin.rb
@@ -10,6 +10,7 @@ module Proxy::PuppetApi
     load_dependency_injection_wirings ::Proxy::PuppetApi::PluginConfiguration
 
     validate :puppet_url, :url => true
+    expose_setting :puppet_url
     validate_readable :puppet_ssl_ca, :puppet_ssl_cert, :puppet_ssl_key
 
     start_services :class_cache_initializer

--- a/modules/puppetca_http_api/puppetca_http_api_plugin.rb
+++ b/modules/puppetca_http_api/puppetca_http_api_plugin.rb
@@ -12,6 +12,7 @@ module ::Proxy
         requires :puppetca, ::Proxy::VERSION
 
         validate :puppet_url, :url => true
+        expose_setting :puppet_url
         validate_readable :puppet_ssl_ca, :puppet_ssl_cert, :puppet_ssl_key
 
         load_classes ::Proxy::PuppetCa::PuppetcaHttpApi::PluginConfiguration

--- a/test/plugins/plugin_initializer_test.rb
+++ b/test/plugins/plugin_initializer_test.rb
@@ -47,7 +47,7 @@ class PluginInitializerTest < Test::Unit::TestCase
          {:name => :plugin_2, :version => '1.0', :class => TestPlugin2, :state => :running, :http_enabled => true, :https_enabled => true,
           :settings => {}, :capabilities => []},
          {:name => :plugin_3, :version => '1.0', :class => TestPlugin3, :state => :running, :http_enabled => true, :https_enabled => true,
-          :settings => {"use_provider" => :plugin_4}, :capabilities => []},
+          :settings => {:use_provider => :plugin_4}, :capabilities => []},
          # :http_enabled and :https_enabled are not defined for providers
          {:name => :plugin_4, :version => '1.0', :class => TestPlugin4, :state => :running, :http_enabled => nil, :https_enabled => nil,
             :settings => nil, :capabilities => nil},

--- a/test/puppet/integration_test.rb
+++ b/test/puppet/integration_test.rb
@@ -35,7 +35,7 @@ class PuppetApiFeaturesTest < Test::Unit::TestCase
       assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:puppet])
       assert_equal([], mod['capabilities'])
 
-      expected_settings = {'use_provider' => ['puppet_proxy_puppet_api']}
+      expected_settings = {'use_provider' => ['puppet_proxy_puppet_api'], 'puppet_url' => 'https://puppet.example.com:8140'}
       assert_equal(expected_settings, mod['settings'])
     ensure
       ssl_ca.unlink

--- a/test/puppetca_http_api/integration_test.rb
+++ b/test/puppetca_http_api/integration_test.rb
@@ -37,7 +37,7 @@ class PuppetcaApiFeaturesTest < Test::Unit::TestCase
       assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:puppetca])
       assert_equal([], mod['capabilities'])
 
-      expected_settings = {'use_provider' => ['puppetca_hostname_whitelisting', 'puppetca_http_api']}
+      expected_settings = {'use_provider' => ['puppetca_hostname_whitelisting', 'puppetca_http_api'], 'puppet_url' => 'https://puppet.example.com:8140'}
       assert_equal(expected_settings, mod['settings'])
     ensure
       ssl_ca.unlink


### PR DESCRIPTION
This allows the Foreman to serve the correct hostname to clients. This is important when the Puppet URL is different from the Proxy URL.