### PR TITLE
Fixes #21605 - more authorization options

### DIFF
--- a/test/sinatra/authorization_helpers_test.rb
+++ b/test/sinatra/authorization_helpers_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+require 'sinatra/base'
+
+class AuthorizationHelpersTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    TestApp.new
+  end
+
+  def test_http
+    get '/public'
+    assert last_response.ok?
+    get '/private'
+    assert last_response.ok?
+  end
+
+  def test_https
+    get '/public', {}, 'HTTPS' => 'yes'
+    assert last_response.ok?
+    get '/private', {}, 'HTTPS' => 'yes'
+    assert last_response.forbidden?
+  end
+
+  class TestApp < ::Sinatra::Base
+    include Sinatra::Authorization::Helpers
+
+    get '/public' do
+      'success'
+    end
+
+    get '/private' do
+      do_authorize_any
+      'success'
+    end
+  end
+end


### PR DESCRIPTION
Before this change, when using authorization helpers, one got all or
nothing, without any chance to use the authorization just of a subset of
the requests.

This patch introduces `Sinatra::Authorization::Helpers` that provide
`do_authorize*` methods that are not wrapped in the before block. so that
they their usage is more flexible.

There are at least 3 places I know of that would benefit from this change:

- https://github.com/theforeman/smart_proxy_dynflow/pull/28
- https://github.com/theforeman/smart_proxy_dynflow/pull/54
- https://github.com/theforeman/smart_proxy_remote_execution_ssh/pull/40