### PR TITLE
Refs #21605 - remove rubocop metrics

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,9 +23,8 @@ Style/StringLiterals:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
-Metrics/ClassLength:
-  Exclude:
-    - 'test/**/*'
+Metrics:
+  Enabled: false
 
 Lint/AmbiguousRegexpLiteral:
   Enabled: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -236,49 +236,6 @@ Lint/RescueWithoutErrorClass:
 Lint/ScriptPermission:
   Enabled: false
 
-# Offense count: 224
-Metrics/AbcSize:
-  Max: 56
-
-# Offense count: 7
-# Configuration parameters: CountComments, ExcludedMethods.
-Metrics/BlockLength:
-  Max: 37
-
-# Offense count: 17
-# Configuration parameters: CountComments.
-Metrics/ClassLength:
-  Max: 368
-
-# Offense count: 30
-Metrics/CyclomaticComplexity:
-  Max: 25
-
-# Offense count: 2335
-# Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
-# URISchemes: http, https
-Metrics/LineLength:
-  Max: 201
-
-# Offense count: 168
-# Configuration parameters: CountComments.
-Metrics/MethodLength:
-  Max: 52
-
-# Offense count: 3
-# Configuration parameters: CountComments.
-Metrics/ModuleLength:
-  Max: 133
-
-# Offense count: 5
-# Configuration parameters: CountKeywordArgs.
-Metrics/ParameterLists:
-  Max: 8
-
-# Offense count: 25
-Metrics/PerceivedComplexity:
-  Max: 16
-
 # Offense count: 2
 Naming/ConstantName:
   Enabled: false

--- a/lib/proxy/pluggable.rb
+++ b/lib/proxy/pluggable.rb
@@ -1,5 +1,4 @@
 require 'ostruct'
-# rubocop:disable Metrics/ModuleLength
 module Proxy::Pluggable
   attr_reader :plugin_name, :version, :after_activation_blk
 

--- a/modules/puppet_proxy_legacy/puppet_config_environments_retriever.rb
+++ b/modules/puppet_proxy_legacy/puppet_config_environments_retriever.rb
@@ -11,9 +11,6 @@ class Proxy::PuppetLegacy::PuppetConfigEnvironmentsRetriever < Proxy::Puppet::En
     @puppet_configuration.get
   end
 
-  # rubocop:disable Metrics/PerceivedComplexity
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
   def all
     if !conf.has_key?(:main) || !conf.has_key?(:master)
       raise Exception, "Puppet configuration at #{@puppet_config_file_path} is missing 'main' and/or 'master' sections."

--- a/test/puppetca_http_api/ca_v1_api_request_test.rb
+++ b/test/puppetca_http_api/ca_v1_api_request_test.rb
@@ -52,7 +52,6 @@ class CaApiv1RequestTest < Test::Unit::TestCase
     stub_request(:get, 'https://puppet:8140/puppet-ca/v1/certificate_statuses/foreman').
       to_return(:status => 200, :body => fixture('ca_search.json'))
 
-    # rubocop:disable Metrics/LineLength
     expected = [
       {
         'dns_alt_names' => ['DNS:puppet', 'DNS:puppet.example.com'],

--- a/test/puppetca_http_api/puppetca_http_impl_test.rb
+++ b/test/puppetca_http_api/puppetca_http_impl_test.rb
@@ -8,7 +8,6 @@ class PuppetCaHttpImplTest < Test::Unit::TestCase
     def sign(certname); end
     def clean(certname); end
 
-    # rubocop:disable Metrics/LineLength
     def search(key = 'foreman')
       [
         {
@@ -30,7 +29,6 @@ class PuppetCaHttpImplTest < Test::Unit::TestCase
   end
 
   class FakeCaApiV1Request63 < FakeCaApiV1Request
-    # rubocop:disable Metrics/LineLength
     def search(key = 'foreman')
       [
         {


### PR DESCRIPTION
I broke Rubocop in the last patch, Jenkins was red and I executed it locally but I was too fast hitting that button.

Anyway, I propose to remove all metrics. This should not be job for Rubocop but rather for a human (reviewer). We are only loosing time by dancing around the "todo" file.