### PR TITLE
Fixes #26329 - TFTP not needed active for HTTPBoot

### DIFF
--- a/modules/httpboot/httpboot_plugin.rb
+++ b/modules/httpboot/httpboot_plugin.rb
@@ -4,7 +4,6 @@ module Proxy::Httpboot
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
     plugin :httpboot, ::Proxy::VERSION
-    requires :tftp, ::Proxy::VERSION
 
     default_settings :root_dir => '/var/lib/tftpboot'
   end


### PR DESCRIPTION
I don'ŧ remember why I added this, I think I tought that TFTP is a separate plugin. Not needed.