### PR TITLE
Fixes #26642 - logging post data fix

### DIFF
--- a/lib/proxy/helpers.rb
+++ b/lib/proxy/helpers.rb
@@ -20,6 +20,7 @@ module Proxy::Helpers
     end
     content_type :json if request.accept?("application/json")
     logger.error message, exception
+    logger.exception(message, exception) if exception.is_a?(Exception)
     halt code, message
   end
 


### PR DESCRIPTION
My work and Ivan's review in smart proxy dynflow core revealed nasty bug in our logging stack in smart proxy. This luckily only hits when FOREMAN_PROXY_TRACE env variable is set to true which is only for debugging purposes. Rack input (StringIO) is read however it is never rewinded back, therefore later on the data is empty therefore POST/PUT services do not work correctly. Additionally, time tracking code can lead to nil error during exceptions.