### PR TITLE
Refs #26642 - Correct path logging

### DIFF
--- a/lib/proxy/log.rb
+++ b/lib/proxy/log.rb
@@ -98,7 +98,7 @@ module Proxy
       logger.info do
         after = Time.now.to_f
         duration = (after - before) * 1000
-        "Finished #{env["REQUEST_METHOD"]} #{env["PATH_INFO"]} with #{status} (#{duration.round(2)} ms)"
+        "Finished #{env["REQUEST_METHOD"]} #{env["REQUEST_PATH"]} with #{status} (#{duration.round(2)} ms)"
       end
     end
   end


### PR DESCRIPTION
In 8546c29d0a9af9de7653b80e22a6afc7b7b5ef89 the 'Started' log line started to use REQUEST_PATH. This completes it by also logging the 'Finished' line with a matching path.