### PR TITLE
Fixes #26823 - NotPresent exception in PuppetcaPuppetCert

### DIFF
--- a/modules/puppetca/puppetca_api.rb
+++ b/modules/puppetca/puppetca_api.rb
@@ -55,7 +55,7 @@ module Proxy::PuppetCa
       certname = params[:certname]
       begin
         autosigner.disable(certname)
-      rescue Proxy::PuppetCa::NotPresent => e
+      rescue ::Proxy::PuppetCa::NotPresent => e
         log_halt 404, e.to_s
       rescue => e
         log_halt 406, "Failed to remove autosign for #{certname}: #{e}"
@@ -77,7 +77,7 @@ module Proxy::PuppetCa
         content_type :json
         certname = params[:certname]
         puppetca_impl.clean(certname)
-      rescue Proxy::PuppetCa::NotPresent => e
+      rescue ::Proxy::PuppetCa::NotPresent => e
         log_halt 404, e.to_s
       rescue => e
         log_halt 406, "Failed to remove certificate(s) for #{certname}: #{e}"

--- a/modules/puppetca_puppet_cert/puppetca_impl.rb
+++ b/modules/puppetca_puppet_cert/puppetca_impl.rb
@@ -145,7 +145,7 @@ module ::Proxy::PuppetCa::PuppetcaPuppetCert
         logger.debug "#{mode}ed puppet certificate for #{certname}"
       elsif response =~ /Could not find client certificate/ || $?.exitstatus == 24
         logger.debug "Attempt to remove nonexistent client certificate for #{certname}"
-        raise NotPresent, "Attempt to remove nonexistent client certificate for #{certname}"
+        raise ::Proxy::PuppetCa::NotPresent, "Attempt to remove nonexistent client certificate for #{certname}"
       else
         logger.warn "Failed to run puppetca: #{response}"
         raise "Execution of puppetca failed, check log files"


### PR DESCRIPTION
In eab6b899c63dfaeb9ae29f6b48d80950ec40bed0 the PuppetcaPuppetCert class was introduced. It created a regression by referring to the relative NotPresent which resulted in:

  uninitialized constant Proxy::PuppetCa::PuppetcaPuppetCert::PuppetcaImpl::NotPresent

By using the absolute class name, we get the correct Exception class.