### PR TITLE
Fixes #26962 - put session id into mdc too

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -73,7 +73,7 @@
 # Logging pattern for file-based loging
 #:file_logging_pattern: '%d %.8X{request} [%.1l] %m'
 # Logging pattern for syslog or journal loging
-#:system_logging_pattern: '%.8X{request} [%.1l] %m'
+#:system_logging_pattern: '%m'
 
 # Log buffer size and extra buffer size (for errors). Defaults to 3000 messages in total,
 # which is about 500 kB request.

--- a/lib/proxy/request_id_middleware.rb
+++ b/lib/proxy/request_id_middleware.rb
@@ -6,11 +6,8 @@ module Proxy
 
     def call(env)
       ::Logging.mdc['remote_ip'] = env['REMOTE_ADDR']
-      if env.has_key?('HTTP_X_REQUEST_ID')
-        ::Logging.mdc['request'] = env['HTTP_X_REQUEST_ID']
-      else
-        ::Logging.mdc['request'] = SecureRandom.uuid
-      end
+      ::Logging.mdc['request'] = env['HTTP_X_REQUEST_ID'] || SecureRandom.uuid
+      ::Logging.mdc['session'] = env['HTTP_X_SESSION_ID'] || SecureRandom.uuid
       status, header, body = @app.call(env)
       [status, header, ::Rack::BodyProxy.new(body) { ::Logging.mdc.clear }]
     end

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -8,7 +8,7 @@ module ::Proxy::Settings
       :file_rolling_size => 100,
       :file_rolling_age => 'weekly',
       :file_logging_pattern => '%d %.8X{request} [%.1l] %m',
-      :system_logging_pattern => '%.8X{request} [%.1l] %m',
+      :system_logging_pattern => '%m',
       :log_level => "INFO",
       :daemon => false,
       :daemon_pid => "/var/run/foreman-proxy/foreman-proxy.pid",


### PR DESCRIPTION
Proxy currently only sends request id to logs, session id can be useful too. One more improvement - logging pattern should only be the message, no logging level or request id because these are reported using structured fields.

Core required PR: https://github.com/theforeman/smart-proxy/pull/653