### PR TITLE
Fixes #26986 - reordered authorization checkers

### DIFF
--- a/lib/proxy/helpers.rb
+++ b/lib/proxy/helpers.rb
@@ -72,8 +72,10 @@ module Proxy::Helpers
     begin
       dns = Resolv.new
       fqdn = dns.getname(ip)
+    rescue Resolv::ResolvTimeout => e
+      log_halt 403, "timeout while resolving hostname for ip address #{ip}: #{e.message}"
     rescue Resolv::ResolvError => e
-      log_halt 403, "unable to resolve hostname for ip address #{ip}\n\n#{e.message}"
+      log_halt 403, "unable to resolve hostname for ip address #{ip}: #{e.message}"
     end
 
     unless forward_verify
@@ -81,8 +83,10 @@ module Proxy::Helpers
     else
       begin
         forward = dns.getaddresses(fqdn)
+      rescue Resolv::ResolvTimeout => e
+        log_halt 403, "timeout while resolving hostname for ip address #{ip}: #{e.message}"
       rescue Resolv::ResolvError => e
-        log_halt 403, "could not forward verify the remote hostname - #{fqdn} (#{ip})\n\n#{e.message}"
+        log_halt 403, "could not forward verify the remote hostname - #{fqdn} (#{ip}): #{e.message}"
       end
 
       if forward.include?(ip)

--- a/lib/sinatra/authorization.rb
+++ b/lib/sinatra/authorization.rb
@@ -30,7 +30,7 @@ module Sinatra
         # HTTP: test the reverse DNS entry of the remote IP
         trusted_hosts = Proxy::SETTINGS.trusted_hosts
         if trusted_hosts
-          logger.debug "verifying remote client #{request.env['REMOTE_ADDR']} against trusted_hosts #{trusted_hosts}"
+          logger.debug "authorize via trusted hosts: #{request.env['REMOTE_ADDR']} against trusted_hosts #{trusted_hosts}"
 
           if [ 'yes', 'on', 1 ].include? request.env['HTTPS'].to_s
             fqdn = https_cert_cn
@@ -51,14 +51,15 @@ module Sinatra
             log_halt 403, "No client SSL certificate supplied"
           end
         else
-          logger.debug('require_ssl_client_verification: skipping, non-HTTPS request')
+          logger.debug('authorize via ssl client: skipped')
         end
       end
 
       # Common set of authorization methods used in foreman-proxy
       def do_authorize_any
-        do_authorize_with_trusted_hosts
+        # keep the more likely auth methods first
         do_authorize_with_ssl_client
+        do_authorize_with_trusted_hosts
       end
     end
 

--- a/modules/dhcp_common/isc/omapi_provider.rb
+++ b/modules/dhcp_common/isc/omapi_provider.rb
@@ -200,7 +200,7 @@ module Proxy::DHCP::CommonISC
         ns = ip2hex validate_ip(server)
       rescue
         begin
-          ns = ip2hex Resolv.new.getaddress(server)
+          ns = ip2hex resolver.getaddress(Resolv.new)
         rescue
           logger.warn "Failed to resolve IP address for #{server}"
           ns = "\\\"#{server}\\\""


### PR DESCRIPTION
In trusted hosts authorization we do DNS reverse lookup. We do trusted hosts first and then SSL cert verify, we should do the other way around as SSL is more common on production deployments. Also, we do not set any DNS resolution timeout, therefore it defaults to 60/90 seconds on most systems which slows every single request.