### PR TITLE
[WIP] fixes #27022 - settings via env variables

### DIFF
--- a/lib/proxy/plugin_validators.rb
+++ b/lib/proxy/plugin_validators.rb
@@ -8,7 +8,7 @@ module ::Proxy::PluginValidators
     end
 
     def required_setting?
-      @plugin.plugin_default_settings.has_key?(@setting_name)
+      @plugin.plugin_default_settings.has_key?(@setting_name) && !@plugin.plugin_default_settings[@setting_name].nil?
     end
 
     def evaluate_predicate(settings)

--- a/lib/proxy/settings.rb
+++ b/lib/proxy/settings.rb
@@ -10,15 +10,16 @@ module Proxy::Settings
   def self.initialize_global_settings(settings_path = nil, argv = ARGV)
     global = ::Proxy::Settings::Global.new(YAML.load(File.read(settings_path || SETTINGS_PATH)))
     global.apply_argv(argv)
+    global.apply_env(ENV)
     global
   end
 
   def self.load_plugin_settings(defaults, settings_file, settings_directory = nil)
     settings = {}
     begin
-      settings = YAML.load(File.read(File.join(settings_directory || ::Proxy::SETTINGS.settings_directory, settings_file))) || {}
+      settings = read_settings_file(settings_file, settings_directory)
     rescue Errno::ENOENT
-      logger.warn("Couldn't find settings file #{settings_directory || ::Proxy::SETTINGS.settings_directory}/#{settings_file}. Using default settings.")
+      logger.warn("Couldn't find settings file #{File.join(settings_directory || ::Proxy::SETTINGS.settings_directory, settings_file)}. Using default settings.")
     end
     ::Proxy::Settings::Plugin.new(defaults, settings)
   end

--- a/lib/proxy/settings_from_env.rb
+++ b/lib/proxy/settings_from_env.rb
@@ -1,0 +1,39 @@
+module Proxy::SettingsFromEnv
+  def self.guess_setting_type(value)
+    case value
+    when Array
+      :list
+    when TrueClass, FalseClass
+      :boolean
+    when Float
+      :float
+    when Integer
+      :integer
+    when Symbol
+      :symbol
+    else
+      :string
+    end
+  end
+
+  def self.cast_value(type, value)
+    case type
+    when :integer
+      value.to_i
+    when :float
+      value.to_f
+    when :boolean
+      !%w[0 false].include?(value.strip.downcase)
+    when :list
+      value.split(/[ ,]/)
+    when :dict
+      Hash[value.split(/[&,]/).map { |kv| kv.split('=') }]
+    when :symbol
+      value.to_sym
+    when :string
+      value
+    else
+      raise "Unsupported type #{type} for setting."
+    end
+  end
+end

--- a/modules/bmc/bmc_plugin.rb
+++ b/modules/bmc/bmc_plugin.rb
@@ -2,7 +2,7 @@ module Proxy::BMC
   class Plugin < Proxy::Plugin
     http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
-  
+
     plugin :bmc, ::Proxy::VERSION
   end
 end

--- a/modules/puppetca_http_api/puppetca_http_api_plugin.rb
+++ b/modules/puppetca_http_api/puppetca_http_api_plugin.rb
@@ -6,7 +6,8 @@ module ::Proxy
       class Plugin < ::Proxy::Provider
         plugin :puppetca_http_api, ::Proxy::VERSION
 
-        default_settings :puppet_ssl_ca => '/etc/puppetlabs/puppet/ssl/certs/ca.pem'
+        default_settings :puppet_ssl_ca => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
+          :puppet_url => nil, :puppet_ssl_cert => nil, :puppet_ssl_key => nil
 
         load_validators :url => ::Proxy::Puppet::Validators::UrlValidator
         requires :puppetca, ::Proxy::VERSION

--- a/modules/root/root_module_loader.rb
+++ b/modules/root/root_module_loader.rb
@@ -5,7 +5,7 @@ class ::Proxy::RootPluginLoader < ::Proxy::DefaultModuleLoader
   end
 
   # no need to log setting for this module as they aren't user-configurable and never change
-  def log_used_settings(settings)
+  def log_used_settings(settings, settings_by_source = {})
     # noop
   end
 end

--- a/modules/templates/templates_plugin.rb
+++ b/modules/templates/templates_plugin.rb
@@ -5,6 +5,8 @@ module Proxy::Templates
 
     plugin :templates, ::Proxy::VERSION
 
+    default_settings :template_url => nil
+
     validate_presence :template_url
 
     after_activation do

--- a/test/global_settings_test.rb
+++ b/test/global_settings_test.rb
@@ -40,4 +40,14 @@ class GlobalSettingsTest < Test::Unit::TestCase
     settings.apply_argv(['--no-daemonize'])
     assert_equal false, settings.daemon
   end
+
+  def test_apply_env_settings
+    env = {
+      'FOREMAN_PROXY_HTTPS_PORT' => 123
+    }
+    settings = ::Proxy::Settings::Global.new(https_port: 456)
+    assert_equal 456, settings.https_port
+    settings.apply_env(env)
+    assert_equal 123, settings.https_port
+  end
 end

--- a/test/plugins/plugin_initializer_test.rb
+++ b/test/plugins/plugin_initializer_test.rb
@@ -14,11 +14,14 @@ class PluginInitializerTest < Test::Unit::TestCase
     capability(CAP_LAMBDA)
     capability(CAP_PROC)
     capability('foo')
-    default_settings :enabled => true, :foo => :bar, :secret => :password
+    default_settings :enabled => false, :foo => :baz, :secret => :password
     expose_setting(:foo)
   end
 
   def test_initialize_plugins
+    ENV['FOREMAN_PROXY_PLUGIN_6_ENABLED'] = 'true'
+    ENV['FOREMAN_PROXY_PLUGIN_6_FOO'] = 'bar'
+
     plugins = ::Proxy::Plugins.new
     plugins.update([{:name => :plugin_1, :version => '1.0', :class => TestPlugin1, :state => :uninitialized},
                     {:name => :plugin_2, :version => '1.0', :class => TestPlugin2, :state => :uninitialized},
@@ -55,5 +58,8 @@ class PluginInitializerTest < Test::Unit::TestCase
             :settings => {}, :capabilities => []},
          {:name => :plugin_6, :version => '1.0', :class => TestPlugin6, :state => :running, :http_enabled => true, :https_enabled => true,
             :settings=>{:foo=>:bar}, :capabilities => [CAP_LAMBDA, CAP_PROC, 'foo']}], loaded)
+
+    ENV.delete('FOREMAN_PROXY_PLUGIN_6_ENABLED')
+    ENV.delete('FOREMAN_PROXY_PLUGIN_6_FOO')
   end
 end


### PR DESCRIPTION
This is still a very early version of the patch.

@ekohl & @ohadlevy: I'm using the definition of the default settings to guess the type of a setting. Is it safe to assume that every setting has a default setting defined? Or would we need to extend the plugin dsl to define settings and their type?