### PR TITLE
Fixes #27032 - improve logging and timeout

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -79,3 +79,10 @@
 # which is about 500 kB request.
 #:log_buffer: 2000
 #:log_buffer_errors: 1000
+
+# DNS resolver timeout(s). This may be a single positive number
+# or an array of positive numbers representing timeouts in seconds.
+# If an array is specified, a DNS request will retry and wait for
+# each successive interval in the array until a successful response
+# is received. See Ruby Resolv#timeouts documentation for more info.
+#:dns_resolv_timeouts: [5, 8, 13]

--- a/lib/proxy/log.rb
+++ b/lib/proxy/log.rb
@@ -1,5 +1,6 @@
 require 'logging'
 require 'proxy/log_buffer/decorator'
+require 'proxy/time_utils'
 
 module Proxy
   module Log
@@ -74,13 +75,14 @@ module Proxy
 
   class LoggerMiddleware
     include Log
+    include ::Proxy::TimeUtils
 
     def initialize(app)
       @app = app
     end
 
     def call(env)
-      before = Time.now.to_f
+      before = time_monotonic
       status = 500
       env['rack.logger'] = logger
       logger.info { "Started #{env['REQUEST_METHOD']} #{env['REQUEST_PATH']} #{env['QUERY_STRING']}" }
@@ -99,7 +101,7 @@ module Proxy
       raise e
     ensure
       logger.info do
-        after = Time.now.to_f
+        after = time_monotonic
         duration = (after - before) * 1000
         "Finished #{env["REQUEST_METHOD"]} #{env["REQUEST_PATH"]} with #{status} (#{duration.round(2)} ms)"
       end

--- a/lib/proxy/logging_resolv.rb
+++ b/lib/proxy/logging_resolv.rb
@@ -1,0 +1,65 @@
+require 'resolv'
+require 'proxy/time_utils'
+require 'forwardable'
+
+# Decorator for Resolv and DNS::Resolv Ruby classes that performs
+# logging into the smart proxy logger.
+module Proxy
+  class LoggingResolv
+    include ::Proxy::Log
+    include ::Proxy::TimeUtils
+    extend Forwardable
+
+    def_delegators :@resolv, :each_address, :each_name
+
+    SLOW_DNS_QUERY_MS = 9000
+
+    def initialize(resolv)
+      @resolv = resolv
+    end
+
+    def resolver(override_nameserver = @server)
+      dns_resolv(:nameserver => override_nameserver)
+    end
+
+    def getresource(name, typeclass)
+      call_with_timing(:getresource, name, typeclass)
+    end
+
+    def getresources(name, typeclass)
+      call_with_timing(:getresources, name, typeclass)
+    end
+
+    def getname(name)
+      call_with_timing(:getname, name)
+    end
+
+    def getnames(name)
+      call_with_timing(:getnames, name)
+    end
+
+    def getaddress(name)
+      call_with_timing(:getaddress, name)
+    end
+
+    def getaddresses(name)
+      call_with_timing(:getaddresses, name)
+    end
+
+    private
+
+    def call_with_timing(method, *args)
+      result = nil
+      duration = time_spent_in_ms do
+        result = @resolv.send(method, *args)
+      end
+      if duration < SLOW_DNS_QUERY_MS
+        logger.debug "Finished DNS query #{method} for '#{args.first}' in #{duration.round(2)} ms"
+      else
+        logger.warn "Slow DNS query #{method} for #{args.inspect} took #{duration.round(2)} ms"
+        logger.debug "Resolver used: #{@resolv.inspect}"
+      end
+      result
+    end
+  end
+end

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -17,7 +17,8 @@ module ::Proxy::Settings
       :log_buffer => 2000,
       :log_buffer_errors => 1000,
       :ssl_disabled_ciphers => [],
-      :tls_disabled_versions => []
+      :tls_disabled_versions => [],
+      :dns_resolv_timeouts => [5, 8, 13] # Ruby default is [5, 20, 40] which is a bit too much for us
     }
 
     HOW_TO_NORMALIZE = {

--- a/lib/proxy/time_utils.rb
+++ b/lib/proxy/time_utils.rb
@@ -1,0 +1,23 @@
+module Proxy::TimeUtils
+  # monotonic timers are only on Ruby 2.1+
+  if defined?(Process::CLOCK_MONOTONIC)
+    def time_monotonic
+      Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    end
+  else
+    def time_monotonic
+      Time.now.to_f
+    end
+  end
+
+  def time_spent_in_ms
+    before = time_monotonic
+    begin
+      yield
+    ensure
+      after = time_monotonic
+      duration = (after - before) * 1000
+    end
+    duration
+  end
+end

--- a/modules/dhcp_common/server.rb
+++ b/modules/dhcp_common/server.rb
@@ -4,6 +4,7 @@ require "dhcp_common/record/lease"
 require "dhcp_common/record/reservation"
 require 'dhcp_common/record/deleted_reservation'
 require 'dhcp_common/pingable'
+require 'proxy/logging_resolv'
 
 module Proxy::DHCP
   class Server
@@ -14,6 +15,8 @@ module Proxy::DHCP
     include Proxy::DHCP::Pingable
     include Proxy::Log
     include Proxy::Validations
+    include ::Proxy::TimeUtils
+    include ::Proxy::Helpers
 
     def initialize(name, managed_subnets, subnet_service, free_ips_service = nil)
       @name = name

--- a/modules/dns_common/dns_common.rb
+++ b/modules/dns_common/dns_common.rb
@@ -1,5 +1,6 @@
 require 'resolv'
 require 'ipaddr'
+require 'proxy/logging_resolv'
 
 module Proxy::Dns
   class Error < RuntimeError; end
@@ -8,16 +9,18 @@ module Proxy::Dns
 
   class Record
     include ::Proxy::Log
+    include ::Proxy::TimeUtils
+    include ::Proxy::Helpers
 
     attr_reader :server, :ttl
 
     def initialize(server = nil, ttl = nil)
       @server = server || "localhost"
-      @ttl    = ttl || "86400"
+      @ttl = ttl || "86400"
     end
 
-    def resolver
-      Resolv::DNS.new(:nameserver => @server)
+    def resolver(override_nameserver = @server)
+      dns_resolv(:nameserver => override_nameserver)
     end
 
     def create_srv_record(service, value)


### PR DESCRIPTION
Foreman proxy DNS module performs record resolve operating during create request, but there is not a single log line about it. It is worth adding also timing information because this can be cruical for finding why some DNS requests are slow.