### PR TITLE
Fixes #27047, #27048 - Proxy::Dns::Record deprecations

### DIFF
--- a/modules/dns_common/dns_common.rb
+++ b/modules/dns_common/dns_common.rb
@@ -96,18 +96,6 @@ module Proxy::Dns
       raise(Proxy::Dns::Error, "Deletion of #{type} not implemented")
     end
 
-    def dns_find(key)
-      logger.warn(%q{Proxy::Dns::Record#dns_find has been deprecated and will be removed in future versions of Smart-Proxy.
-                      Please use ::Proxy::Dns::Record#get_name or ::Proxy::Dns::Record#get_address instead.})
-      if key =~ /\.in-addr\.arpa$/ || key =~ /\.ip6\.arpa$/
-        get_name(key)
-      else
-        resolver.getaddress(key).to_s
-      end
-    rescue Resolv::ResolvError
-      false
-    end
-
     def get_name(a_ptr)
       get_resource_as_string(a_ptr, Resolv::DNS::Resource::IN::PTR, :name)
     end
@@ -169,11 +157,6 @@ module Proxy::Dns
     end
 
     def ptr_record_conflicts(content, name)
-      if name.match(Resolv::IPv4::Regex) || name.match(Resolv::IPv6::Regex)
-        logger.warn(%q{Proxy::Dns::Record#ptr_record_conflicts with a non-ptr record parameter has been deprecated and will be removed in future versions of Smart-Proxy.
-                      Please use ::Proxy::Dns::Record#ptr_record_conflicts('101.212.58.216.in-addr.arpa') format instead.})
-        name = IPAddr.new(name).reverse
-      end
       record_conflicts_name(name, Resolv::DNS::Resource::IN::PTR, content)
     end
 

--- a/modules/dns_common/dns_common.rb
+++ b/modules/dns_common/dns_common.rb
@@ -97,36 +97,44 @@ module Proxy::Dns
     end
 
     def get_name(a_ptr)
+      logger.warn('Deprecated: Proxy::Dns::Record#get_name is deprecated and will be removed in 1.24')
       get_resource_as_string(a_ptr, Resolv::DNS::Resource::IN::PTR, :name)
     end
 
     def get_name!(a_ptr)
+      logger.warn('Deprecated: Proxy::Dns::Record#get_name! is deprecated and will be removed in 1.24')
       get_resource_as_string!(a_ptr, Resolv::DNS::Resource::IN::PTR, :name)
     end
 
     def get_ipv4_address!(fqdn)
+      logger.warn('Deprecated: Proxy::Dns::Record#get_ipv4_address! is deprecated and will be removed in 1.24')
       get_resource_as_string!(fqdn, Resolv::DNS::Resource::IN::A, :address)
     end
 
     def get_ipv4_address(fqdn)
+      logger.warn('Deprecated: Proxy::Dns::Record#get_ipv4_address is deprecated and will be removed in 1.24')
       get_resource_as_string(fqdn, Resolv::DNS::Resource::IN::A, :address)
     end
 
     def get_ipv6_address!(fqdn)
+      logger.warn('Deprecated: Proxy::Dns::Record#get_ipv6_address! is deprecated and will be removed in 1.24')
       get_resource_as_string!(fqdn, Resolv::DNS::Resource::IN::AAAA, :address)
     end
 
     def get_ipv6_address(fqdn)
+      logger.warn('Deprecated: Proxy::Dns::Record#get_ipv6_address is deprecated and will be removed in 1.24')
       get_resource_as_string(fqdn, Resolv::DNS::Resource::IN::AAAA, :address)
     end
 
     def get_resource_as_string(value, resource_type, attr)
+      logger.warn('Deprecated: Proxy::Dns::Record#get_resource_as_string is deprecated and will be removed in 1.24')
       resolver.getresource(value, resource_type).send(attr).to_s
     rescue Resolv::ResolvError
       false
     end
 
     def get_resource_as_string!(value, resource_type, attr)
+      logger.warn('Deprecated: Proxy::Dns::Record#get_resource_as_string! is deprecated and will be removed in 1.24')
       resolver.getresource(value, resource_type).send(attr).to_s
     rescue Resolv::ResolvError
       raise Proxy::Dns::NotFound.new("Cannot find DNS entry for #{value}")
@@ -161,6 +169,7 @@ module Proxy::Dns
     end
 
     def to_ipaddress ip
+      logger.warn('Deprecated: Proxy::Dns::Record#to_ipaddress is deprecated and will be removed in 1.24')
       IPAddr.new(ip) rescue false
     end
 

--- a/test/dns_common/record_test.rb
+++ b/test/dns_common/record_test.rb
@@ -6,21 +6,6 @@ class DnsRecordTest < Test::Unit::TestCase
     @record = Proxy::Dns::Record.new
   end
 
-  def test_dns_find_with_ip_parameter
-    @record.expects(:get_name).with('2.0.13.127.in-addr.arpa').returns('not_existing.example.com')
-    assert_equal 'not_existing.example.com', @record.dns_find('2.0.13.127.in-addr.arpa')
-  end
-
-  def test_dns_find_with_ipv6_parameter
-    @record.expects(:get_name).with('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa').returns('not_existing.example.com')
-    assert_equal 'not_existing.example.com', @record.dns_find('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa')
-  end
-
-  def test_dns_find_with_fqdn_parameter
-    Resolv::DNS.any_instance.expects(:getaddress).with('some.host').returns(Resolv::IPv4.create('127.13.0.2'))
-    assert_equal '127.13.0.2', Proxy::Dns::Record.new.dns_find('some.host')
-  end
-
   def test_get_name_with_sideeffect_for_ipv4
     @record.expects(:get_resource_as_string!).with('2.0.13.127.in-addr.arpa', Resolv::DNS::Resource::IN::PTR, :name).returns('not_existing.example.com')
     assert 'not_existing.example.com', @record.get_name!('2.0.13.127.in-addr.arpa')
@@ -81,11 +66,6 @@ class DnsRecordTest < Test::Unit::TestCase
     assert_false @record.get_resource_as_string('some.host', Resolv::DNS::Resource::IN::A, :address)
   end
 
-  def test_dns_find_key_not_found
-    Resolv::DNS.any_instance.expects(:getaddress).with('another.host').raises(Resolv::ResolvError.new('DNS result has no information'))
-    assert !Proxy::Dns::Record.new.dns_find('another.host')
-  end
-
   def test_ptr_to_ip_ipv4
     assert_equal('192.168.33.30', Proxy::Dns::Record.new.ptr_to_ip('30.33.168.192.in-addr.arpa'))
   end
@@ -128,22 +108,6 @@ class DnsRecordTest < Test::Unit::TestCase
   def test_aaaa_record_conflicts_but_nothing_todo
     Resolv::DNS.any_instance.expects(:getresources).with('some.host',  Resolv::DNS::Resource::IN::AAAA).returns(ips('2001:DB8:DEEF::1'))
     assert_equal 0, Proxy::Dns::Record.new.aaaa_record_conflicts('some.host', '2001:DB8:DEEF::1')
-  end
-
-  def test_old_ptr_record_conflicts_no_conflict
-    Resolv::DNS.any_instance.expects(:getresources).with('33.33.168.192.in-addr.arpa',  Resolv::DNS::Resource::IN::PTR).returns([])
-    assert_equal -1, Proxy::Dns::Record.new.ptr_record_conflicts('some.host', '192.168.33.33')
-  end
-
-  def test_old_ptr_record_conflicts_has_conflict
-    Resolv::DNS.any_instance.expects(:getresources).with('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa',
-                                                         Resolv::DNS::Resource::IN::PTR).returns([Resolv::DNS::Resource::IN::PTR.new('some.host')])
-    assert_equal 1, Proxy::Dns::Record.new.ptr_record_conflicts('another.host', '2001:db8:deef::1')
-  end
-
-  def test_old_ptr_record_conflicts_but_nothing_todo
-    Resolv::DNS.any_instance.expects(:getresources).with('33.33.168.192.in-addr.arpa',  Resolv::DNS::Resource::IN::PTR).returns([Resolv::DNS::Resource::IN::PTR.new('some.host')])
-    assert_equal 0, Proxy::Dns::Record.new.ptr_record_conflicts('some.host', '192.168.33.33')
   end
 
   def test_ptr_record_conflicts_no_conflict


### PR DESCRIPTION
78da2d1ef03ac150812226946ac1ec546838624c (1.14) deprecated dns_find. bfbdeeb90e344ee8b0c9950f85b159035d9cbfbe (1.16) deprecated passing IPs to ptr_record_conflicts in 1.16. There was no clear deprecation timeline, but sufficient time has passed to remove them. I've manually verified the DNS plugins under theforeman organization and I'm not aware of other implementations.

The various methods to get DNS records are are unused since bfbdeeb90e344ee8b0c9950f85b159035d9cbfbe (1.16) and can be removed to clean up the API. Since they weren't formally deprecated and part of the API to subclasses (though unused) they're deprecated first to be removed in 1.24.