### PR TITLE
Refs #26979 - Remove left over require

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,10 +4,7 @@ gemspec
 
 if RUBY_VERSION < '2.2'
   gem 'sinatra', '< 2'
-  gem 'rack', '>= 1.1', '< 2.0.0'
-else
-  gem 'sinatra'
-  gem 'rack', '>= 1.1'
+  gem 'rack', '>= 1.3', '< 2.0.0'
 end
 gem 'concurrent-ruby', '~> 1.0', require: 'concurrent'
 

--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -1,7 +1,5 @@
 group :development do
   # To use debugger
-  gem "ruby-debug", :platforms => :ruby_18
-  gem "ruby-debug19", :platforms => :ruby_19
   gem 'single_test'
   gem 'pry'
 

--- a/lib/rack-patch.rb
+++ b/lib/rack-patch.rb
@@ -1,6 +1,0 @@
-class Rack::Server
-  def initialize(options = nil)
-    @options = options
-    @app = options[:app] if options && options[:app]
-  end
-end

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -6,7 +6,6 @@ require 'launcher'
 require 'fileutils'
 require 'pathname'
 require 'webrick/https'
-require 'daemon'
 
 require 'proxy/log'
 require 'proxy/settings'

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -32,7 +32,6 @@ Proxy::BundlerHelper.require_groups(:default)
 
 require 'json'
 require 'rack'
-require 'rack-patch' if Rack.release < "1.3"
 require 'sinatra'
 require 'sinatra/authorization'
 require 'sinatra/default_not_found_page'

--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.license = 'GPL-3.0'
   s.extra_rdoc_files = ["README.md"]
   s.add_dependency 'json'
-  s.add_dependency 'rack', '>= 1.1'
+  s.add_dependency 'rack', '>= 1.3'
   s.add_dependency 'sinatra'
   s.add_dependency 'logging'
   s.description = <<EOF


### PR DESCRIPTION
bf476d0ad900e36f25865592538942a4b91610ad removed lib/daemon.rb since it only contained Ruby 1.x compatibility but left the require causing it to fail to start up.