### PR TITLE
Fixes #27088 - Handle capabilities for uninitialized plugins

### DIFF
--- a/modules/root/root_v2_api.rb
+++ b/modules/root/root_v2_api.rb
@@ -25,6 +25,7 @@ class Proxy::RootV2Api < Sinatra::Base
   end
 
   def process_capabilities(state, capabilities)
+    return [] if state == :uninitialized
     capabilities = capabilities.select { |cap| !cap.is_a?(Proc) || state == :running }
     capabilities = capabilities.map do |capability|
       capability.is_a?(Proc) ? capability.call : capability

--- a/test/bmc/integration_test.rb
+++ b/test/bmc/integration_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'json'
 require 'root/root_v2_api'
-require 'bmc/bmc'
+require 'bmc/bmc_plugin'
 require 'bmc/ipmi'
 
 class BmcApiFeaturesTest < Test::Unit::TestCase


### PR DESCRIPTION
For some reason, this test fails locally for me but not on Jenkins:

```
Error: test_features(BmcApiFeaturesTest): JSON::ParserError: 809: unexpected token at 'private method `select' called for nil:NilClass'
/home/lzap/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/json-2.5.1/lib/json/common.rb:216:in `parse'
/home/lzap/.rbenv/versions/2.7.2/lib/ruby/gems/2.7.0/gems/json-2.5.1/lib/json/common.rb:216:in `parse'
/home/lzap/work/smart-proxy/test/bmc/integration_test.rb:21:in `test_features'
     18:
     19:     get '/features'
     20:
  => 21:     response = JSON.parse(last_response.body)
     22:
     23:     mod = response['bmc']
     24:     refute_nil(mod)
```
