### PR TITLE
Fixes #27218: revamps regex for finding realm name

### DIFF
--- a/modules/realm_freeipa/ipa_config_parser.rb
+++ b/modules/realm_freeipa/ipa_config_parser.rb
@@ -40,11 +40,11 @@ module Proxy::FreeIPARealm
       parsed_uri, realm_name = nil
 
       io.readlines.each do |line|
-        if line =~ /xmlrpc_uri/
+        if line =~ /^\s*xmlrpc_uri\s*=\s*\S+/
           uri = line.split("=")[1].strip
           parsed_uri = URI.parse(uri)
           logger.debug "freeipa: uri is #{uri}"
-        elsif line =~ /realm/
+        elsif line =~ /^\s*realm\s*=\s*\S+/
           realm_name = line.split("=")[1].strip
           logger.debug "freeipa: realm #{realm_name}"
         end

--- a/test/realm/realm.conf
+++ b/test/realm/realm.conf
@@ -2,7 +2,7 @@
 basedn = dc=demo1,dc=freeipa,dc=org
 realm = DEMO1.FREEIPA.ORG
 domain = demo1.freeipa.org
-server = ipa.demo1.freeipa.org
+server = ipa-realm.demo1.freeipa.org
 host = lucid-nonsense
 xmlrpc_uri = https://ipa.demo1.freeipa.org/ipa/xml
 enable_ra = True


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1726380 -- When parsing /etc/ipa/default.conf to find the realm name, instead of matching any line containing 'realm' match only lines starting with 'realm' and containing an = sign followed by optional spaces and mandatory 1+ non-spaces.