### PR TITLE
Fixes #27351 - don't use rolling appender by default

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -64,8 +64,8 @@
 # Uncomment and modify if you want to change the log level
 # WARN, DEBUG, ERROR, FATAL, INFO, UNKNOWN
 #:log_level: INFO
-# The maximum size of a log file before it's rolled (in MiB)
-#:file_rolling_size: 100
+# The maximum size of a log file before it's rolled (in MiB) or zero to use external log rotation (default)
+#:file_rolling_size: 0
 # The maximum age of a log file before it's rolled (in seconds). Also accepts 'daily', 'weekly', or 'monthly'.
 #:file_rolling_age: weekly
 # Number of log files to keep

--- a/lib/proxy/log.rb
+++ b/lib/proxy/log.rb
@@ -49,8 +49,11 @@ module Proxy
           keep = ::Proxy::SETTINGS.file_rolling_keep
           size = BASE_LOG_SIZE * ::Proxy::SETTINGS.file_rolling_size
           age = ::Proxy::SETTINGS.file_rolling_age
-          logger.add_appenders(Logging.appenders.rolling_file(
-            logger_name, layout: layout, filename: log_file, keep: keep, size: size, age: age, roll_by: 'date'))
+          if size > 0
+            logger.add_appenders(Logging.appenders.rolling_file(logger_name, layout: layout, filename: log_file, keep: keep, size: size, age: age, roll_by: 'date'))
+          else
+            logger.add_appenders(Logging.appenders.file(logger_name, layout: layout, filename: log_file))
+          end
         rescue ArgumentError => ae
           logger.add_appenders(Logging.appenders.stdout(logger_name, layout: layout))
           logger.warn "Log file #{log_file} cannot be opened. Falling back to STDOUT: #{ae}"

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -5,7 +5,7 @@ module ::Proxy::Settings
       :https_port => 8443,
       :log_file => "/var/log/foreman-proxy/proxy.log",
       :file_rolling_keep => 6,
-      :file_rolling_size => 100,
+      :file_rolling_size => 0,
       :file_rolling_age => 'weekly',
       :file_logging_pattern => '%d %.8X{request} [%.1l] %m',
       :system_logging_pattern => '%m',


### PR DESCRIPTION
It looks like TwP/logging gem's Rolling File implementation is not thread safe and it can be causing issues during reopens. Smart-proxy configures Rolling File appender and this can't be turned off. Default behavior is weekly rolling or by 100 MiB size, this patch changes it to use simple File appender and rely on logrotate which we configure by default anyway.

The implementation is based on dynflow where we do the very same approach when `file_rolling_size` is set to zero. So for consistency I'd prefer to take the same approach here. Also, installer change will be probably needed.