### PR TITLE
Fixes #27509 - logging reopen USR1 handler fixed

### DIFF
--- a/lib/proxy/signal_handler.rb
+++ b/lib/proxy/signal_handler.rb
@@ -35,7 +35,7 @@ class Proxy::SignalHandler
 
   def install_usr1_trap
     trap(:USR1) do
-      ::Proxy::LogBuffer::Decorator.instance.roll_log
+      ::Proxy::LogBuffer::Decorator.instance.roll_log = true
     end
   end
 end

--- a/test/log_buffer/decorator_test.rb
+++ b/test/log_buffer/decorator_test.rb
@@ -71,31 +71,12 @@ class DecoratorTest < Test::Unit::TestCase
     ::Logging.mdc['request'] = nil
   end
 
-  def test_should_not_roll_log_if_stdout_is_used
-    ::Proxy::LoggerFactory.stubs(:logger).returns(::Logger.new("/dev/null"))
-    (d = DecoratorForTesting.new(@logger, "STDOUT", nil)).handle_log_rolling
-    assert_equal @logger, d.logger
-  end
-
-  def test_should_not_roll_log_if_syslog_is_used
-    ::Proxy::LoggerFactory.stubs(:logger).returns(::Logger.new("/dev/null"))
-    (d = DecoratorForTesting.new(@logger, "SYSLOG", nil)).handle_log_rolling
-    assert_equal @logger, d.logger
-  end
-
-  def test_should_roll_log_if_file_logger_is_used
-    ::Proxy::LoggerFactory.stubs(:logger).returns(::Logger.new("/dev/null"))
-    (d = DecoratorForTesting.new(@logger, "/dev/null", nil)).handle_log_rolling
-    assert_not_equal @logger, d.logger
-  end
-
   def test_should_roll_log_if_flag_is_set
     ::Proxy::LoggerFactory.stubs(:logger).returns(::Logger.new("/dev/null"))
     d = DecoratorForTesting.new(@logger, "/dev/null", @buffer)
 
-    d.roll_log
+    d.roll_log = true
     d.add(DEBUG)
-
-    assert_not_equal @logger, d.logger
+    refute d.roll_log
   end
 end


### PR DESCRIPTION
After refactoring to "logging" gem the file reopening was not implemented properly.