### PR TITLE
WIP - Grub2 HTTP BOOT Hack

### DIFF
--- a/modules/httpboot/http_config.ru
+++ b/modules/httpboot/http_config.ru
@@ -7,3 +7,11 @@ end
 map "/httpboot" do
   run Proxy::HttpbootApi
 end
+
+map "/grub2" do
+  run Proxy::HttpbootApi
+end
+
+map "/grub.cfg" do
+  run Proxy::HttpbootApi
+end

--- a/modules/httpboot/httpboot_api.rb
+++ b/modules/httpboot/httpboot_api.rb
@@ -4,7 +4,14 @@ class Proxy::HttpbootApi < Sinatra::Base
   get "/*" do
     file = Pathname.new(params[:splat].first).cleanpath
     root = Pathname.new(Proxy::Httpboot::Plugin.settings.root_dir).expand_path.cleanpath
-    joined_path = File.join(root, file)
+    # special handling for Grub2 (https://bugzilla.redhat.com/show_bug.cgi?id=1616395)
+    if env['REQUEST_PATH'] && env['REQUEST_PATH'].match(/^\/grub2\/.*/)
+      joined_path = File.join(root, env['REQUEST_PATH'])
+    elsif env['REQUEST_PATH'] && env['REQUEST_PATH'].match(/^\/(grub.cfg|grub.cfg-.*)/)
+      joined_path = File.join(root, 'grub2', env['REQUEST_PATH'])
+    else
+      joined_path = File.join(root, file)
+    end
     log_halt(404, "Not found") unless File.exist?(joined_path)
     real_file = Pathname.new(joined_path).realpath
     log_halt(403, "Invalid or empty path") unless real_file.fnmatch?("#{root}/**")

--- a/test/httpboot/httpboot_api_test.rb
+++ b/test/httpboot/httpboot_api_test.rb
@@ -16,6 +16,10 @@ class HttpbootApiTest < Test::Unit::TestCase
     @tempdir = Dir.mktmpdir 'httpboot-test'
     FileUtils.touch "#{@tempdir}/valid_file"
     Dir.mkdir "#{@tempdir}/valid_dir"
+    Dir.mkdir "#{@tempdir}/grub2"
+    FileUtils.touch "#{@tempdir}/grub2/valid_file"
+    FileUtils.touch "#{@tempdir}/grub2/grub.cfg"
+    FileUtils.touch "#{@tempdir}/grub2/grub.cfg-00-01-02-03-04-05-06"
     FileUtils.ln_s "#{@tempdir}/valid_file", "#{@tempdir}/valid_symlink"
     FileUtils.ln_s "#{@tempdir}/does_not_exist", "#{@tempdir}/invalid_symlink"
     Proxy::Httpboot::Plugin.load_test_settings(root_dir: @tempdir)
@@ -35,6 +39,27 @@ class HttpbootApiTest < Test::Unit::TestCase
     result = get "/valid_dir"
     assert_equal 403, last_response.status
     assert_equal 'Directory listing not allowed', result.body
+  end
+
+  def test_valid_file_in_grub2
+    env = { 'REQUEST_PATH' => "/grub2/valid_file" }
+    result = get "/irrelevant", {}, env
+    assert_equal 200, last_response.status
+    assert_equal '', result.body
+  end
+
+  def test_grubcfg_in_grub2
+    env = { 'REQUEST_PATH' => "/grub.cfg" }
+    result = get "/irrelevant", {}, env
+    assert_equal 200, last_response.status
+    assert_equal '', result.body
+  end
+
+  def test_grubcfg_with_mac_in_grub2
+    env = { 'REQUEST_PATH' => "/grub.cfg-00-01-02-03-04-05-06" }
+    result = get "/irrelevant", {}, env
+    assert_equal 200, last_response.status
+    assert_equal '', result.body
   end
 
   def test_valid_symlink


### PR DESCRIPTION
Grub 2 in RHEL 7 (grub2-efi-x64-2.02-0.76.el7.1.x86_64) is unable to boot relative paths via HTTP UEFI Boot due to bug https://bugzilla.redhat.com/show_bug.cgi?id=1616395

This is a hack attempt that makes it working partially, it's not finished because in the end it tries to load vmlinuz and initramdisk from root (/) and I would need to create regexp Sinatra mapping for something like `/\w+-vmlinuz` which I do not like at all.

However I am pusing this WIP branch for the record.