### PR TITLE
Fixes #27550 - grub2 native config files

### DIFF
--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -98,7 +98,7 @@ module Proxy::TFTP
       ["#{pxeconfig_dir}/grub.cfg"]
     end
     def pxeconfig_file mac
-      ["#{pxeconfig_dir}/grub.cfg-01-"+mac.tr(':','-').downcase]
+      ["#{pxeconfig_dir}/grub.cfg-01-"+mac.tr(':','-').downcase, "#{pxeconfig_dir}/grub.cfg-#{mac.downcase}"]
     end
   end
 

--- a/test/tftp/tftp_server_test.rb
+++ b/test/tftp/tftp_server_test.rb
@@ -113,7 +113,7 @@ class TftpPxegrub2ServerTest < Test::Unit::TestCase
 
   def setup_paths
     @subject = Proxy::TFTP::Pxegrub2.new
-    @pxe_config_files = ["grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff"]
+    @pxe_config_files = ["grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff", "grub2/grub.cfg-aa:bb:cc:dd:ee:ff"]
     @pxe_default_files = ["grub2/grub.cfg"]
   end
 end


### PR DESCRIPTION
See the RM issue for the reasoning. We already do this for PXELinux, this will vastly simplify how we load custom config files.