### PR TITLE
Fixes #27557 - support EUI-48, 64 and InfiniBand MACs

### DIFF
--- a/modules/dhcp_common/isc/configuration_parser.rb
+++ b/modules/dhcp_common/isc/configuration_parser.rb
@@ -207,7 +207,9 @@ module Proxy
         EOSTMT = ';'.r 'end of statement'
         COMMA =  /\s*,\s*/.r 'comma'
         HEX = /([a-fA-F0-9][a-fA-F0-9]?:)+[a-fA-F0-9][a-fA-F0-9]?/.r
-        MAC_ADDRESS = /([a-fA-F0-9][a-fA-F0-9]?:){5}[a-fA-F0-9][a-fA-F0-9]?/.r 'mac address'
+        MAC_ADDRESS = /([a-fA-F0-9][a-fA-F0-9]?:){5}[a-fA-F0-9][a-fA-F0-9]?/.r 'EUI-48 mac address'
+        MAC64_ADDRESS = /([a-fA-F0-9][a-fA-F0-9]?:){7}[a-fA-F0-9][a-fA-F0-9]?/.r 'EUI-64 mac address'
+        MACIB_ADDRESS = /([a-fA-F0-9][a-fA-F0-9]?:){19}[a-fA-F0-9][a-fA-F0-9]?/.r 'infiniband mac address'
         IPV4_ADDRESS = /\d+\.\d+\.\d+\.\d+/.r 'ipv4 address'
         IPV4_ADDRESS_LIST = IPV4_ADDRESS.join(COMMA).even
         IPV6_ADDRESS = /[a-fA-F0-9:]+/.r 'ipv6 address'
@@ -289,7 +291,7 @@ module Proxy
           hardware_keyword = word('hardware').fail 'keyword_hardware'
           ethernet_keyword = word('ethernet').fail 'keyword_ethernet'
           token_ring_keyword = word('token-ring').fail 'keyword_token_ring'
-          seq_(hardware_keyword, ethernet_keyword | token_ring_keyword, MAC_ADDRESS, EOSTMT) {|_, type, address, _| HardwareNode[type, address]}
+          seq_(hardware_keyword, ethernet_keyword | token_ring_keyword, MACIB_ADDRESS | MAC64_ADDRESS | MAC_ADDRESS, EOSTMT) {|_, type, address, _| HardwareNode[type, address]}
         end
 
         def fixed_address

--- a/test/dhcp/conf_parser_test.rb
+++ b/test/dhcp/conf_parser_test.rb
@@ -356,6 +356,40 @@ EOMULTILINE_HOST
     ]]], Proxy::DHCP::CommonISC::ConfigurationParser.new.conf.parse!(MULTILINE_HOST)
   end
 
+  HOST_WITH_MAC64 =<<EOHOST_WITH_MAC64
+    host eui64 {
+      hardware ethernet 00:25:96:FF:FE:12:34:56;
+      fixed-address 192.168.1.1;
+      option routers 204.254.239.1;
+      filename "pxelinux.0";
+    }
+EOHOST_WITH_MAC64
+  def test_multiline_host_parser_with_mac64
+    assert_equal [Proxy::DHCP::CommonISC::ConfigurationParser::HostNode['eui64', [
+      Proxy::DHCP::CommonISC::ConfigurationParser::HardwareNode['ethernet', '00:25:96:FF:FE:12:34:56'],
+      Proxy::DHCP::CommonISC::ConfigurationParser::KeyValueNode[:fixed_address, '192.168.1.1'],
+      Proxy::DHCP::CommonISC::ConfigurationParser::OptionNode[false, 'routers', [['204.254.239.1']]],
+      Proxy::DHCP::CommonISC::ConfigurationParser::OptionNode[false, 'filename', [['"pxelinux.0"']]]
+    ]]], Proxy::DHCP::CommonISC::ConfigurationParser.new.conf.parse!(HOST_WITH_MAC64)
+  end
+
+  HOST_WITH_IBMAC =<<EOHOST_WITH_IBMAC
+    host infiniband {
+      hardware ethernet 80:00:02:08:fe:80:00:00:00:00:00:00:00:02:aa:bb:cc:dd:ee:ff;
+      fixed-address 192.168.1.1;
+      option routers 204.254.239.1;
+      filename "pxelinux.0";
+    }
+EOHOST_WITH_IBMAC
+  def test_multiline_host_parser_with_infiniband
+    assert_equal [Proxy::DHCP::CommonISC::ConfigurationParser::HostNode['infiniband', [
+      Proxy::DHCP::CommonISC::ConfigurationParser::HardwareNode['ethernet', '80:00:02:08:fe:80:00:00:00:00:00:00:00:02:aa:bb:cc:dd:ee:ff'],
+      Proxy::DHCP::CommonISC::ConfigurationParser::KeyValueNode[:fixed_address, '192.168.1.1'],
+      Proxy::DHCP::CommonISC::ConfigurationParser::OptionNode[false, 'routers', [['204.254.239.1']]],
+      Proxy::DHCP::CommonISC::ConfigurationParser::OptionNode[false, 'filename', [['"pxelinux.0"']]]
+    ]]], Proxy::DHCP::CommonISC::ConfigurationParser.new.conf.parse!(HOST_WITH_IBMAC)
+  end
+
   def test_lease_timestamp_parser
     assert_equal Proxy::DHCP::CommonISC::ConfigurationParser::KeyValueNode[:starts, Time.parse('2 2017/05/01 14:20:25 UTC')],
                  Proxy::DHCP::CommonISC::ConfigurationParser.new.lease_time_stamp.parse!('starts 2 2017/05/01 14:20:25;')

--- a/test/dhcp/isc_omapi_provider_test.rb
+++ b/test/dhcp/isc_omapi_provider_test.rb
@@ -43,34 +43,36 @@ class IscOmapiProviderTest < Test::Unit::TestCase
   end
 
   def test_om_add_record
-    omio = OMIO.new
-    @dhcp.stubs(:om).returns(omio)
-    @dhcp.expects(:om_connect)
-    @dhcp.expects(:om_disconnect)
+    ['01:02:03:04:05:06', '80:00:02:08:fe:80:00:00:00:00:00:00:00:02:aa:bb:cc:dd:ee:ff'].each do |mac_address|
+      omio = OMIO.new
+      @dhcp.stubs(:om).returns(omio)
+      @dhcp.expects(:om_connect)
+      @dhcp.expects(:om_disconnect)
 
-    @dhcp.expects(:solaris_options_statements).returns([])
-    @dhcp.expects(:ztp_options_statements).returns([])
-    @dhcp.expects(:poap_options_statements).returns([])
+      @dhcp.expects(:solaris_options_statements).returns([])
+      @dhcp.expects(:ztp_options_statements).returns([])
+      @dhcp.expects(:poap_options_statements).returns([])
 
-    record_to_add = Proxy::DHCP::Reservation.new('a-test-01',
-                                                 '192.168.42.100',
-                                                 '01:02:03:04:05:06',
-                                                 Proxy::DHCP::Subnet.new('192.168.42.0', '255.255.255.0'),
-                                                 :hostname => 'a-test',
-                                                 :filename => 'a_file',
-                                                 :nextServer => '192.168.42.10')
+      record_to_add = Proxy::DHCP::Reservation.new('a-test-01',
+                                                   '192.168.42.100',
+                                                   mac_address,
+                                                   Proxy::DHCP::Subnet.new('192.168.42.0', '255.255.255.0'),
+                                                   :hostname => 'a-test',
+                                                   :filename => 'a_file',
+                                                   :nextServer => '192.168.42.10')
 
-    @dhcp.om_add_record(record_to_add)
+      @dhcp.om_add_record(record_to_add)
 
-    expected_om_output = [
-      "set name = \"#{record_to_add.name}\"",
-      "set ip-address = #{record_to_add.ip}",
-      "set hardware-address = #{record_to_add.mac}",
-      "set hardware-type = 1",
-      "set statements = \"filename = \\\"#{record_to_add.options[:filename]}\\\"; next-server = c0:a8:2a:0a; option host-name = \\\"#{record_to_add.hostname}\\\";\"",
-      "create"
-    ]
-    assert_equal expected_om_output, omio.input_commands
+      expected_om_output = [
+        "set name = \"#{record_to_add.name}\"",
+        "set ip-address = #{record_to_add.ip}",
+        "set hardware-address = #{record_to_add.mac}",
+        "set hardware-type = 1",
+        "set statements = \"filename = \\\"#{record_to_add.options[:filename]}\\\"; next-server = c0:a8:2a:0a; option host-name = \\\"#{record_to_add.hostname}\\\";\"",
+        "create"
+      ]
+      assert_equal expected_om_output, omio.input_commands
+    end
   end
 
   def test_del_record


### PR DESCRIPTION
Our DHCP API does not seem to verify MAC address form which is good, so it is up to the DHCP providers to error out in case they don't support them. Looks like ISC DHCP does work fine with all the three, so I added some extra tests and fixed our parser so it recognize them properly.