### PR TITLE
Anonymise organisation specific server references in tests/dhcp

### DIFF
--- a/test/dhcp/isc_omapi_provider_test.rb
+++ b/test/dhcp/isc_omapi_provider_test.rb
@@ -105,10 +105,10 @@ class IscOmapiProviderTest < Test::Unit::TestCase
     assert_equal [
       %q{option SUNW.JumpStart-server \"192.168.122.24:/Solaris/jumpstart\";},
       %q{option SUNW.install-path \"/Solaris/install/Solaris_5.10_sparc_hw0811\";},
-      %q{option SUNW.install-server-hostname \"itgsyddev807.macbank\";},
+      %q{option SUNW.install-server-hostname \"someserver.somedomain\";},
       %q{option SUNW.install-server-ip-address 192.168.122.24;},
       %q{option SUNW.root-path-name \"/Solaris/install/Solaris_5.10_sparc_hw0811/Solaris_10/Tools/Boot\";},
-      %q{option SUNW.root-server-hostname \"itgsyddev807.macbank\";},
+      %q{option SUNW.root-server-hostname \"someserver.somedomain\";},
       %q{option SUNW.root-server-ip-address 192.168.122.24;},
       %q{option SUNW.sysid-config-file-server \"192.168.122.24:/Solaris/jumpstart/sysidcfg/sysidcfg_primary\";},
       %q{vendor-option-space SUNW;}

--- a/test/dhcp/sparc_attrs.rb
+++ b/test/dhcp/sparc_attrs.rb
@@ -1,7 +1,7 @@
 module SparcAttrs
   def sparc_attrs
     {
-        "hostname"=>"itgsyddev910.macbank",
+        "hostname"=>"someserver.somedomain",
         "mac"=>"00:21:28:6d:62:e8",
         "ip"=>"192.168.122.11",
         "network"=>"192.168.122.0",
@@ -11,8 +11,8 @@ module SparcAttrs
         "<SPARC-Enterprise-T5120>sysid_server_path"=>"192.168.122.24:/Solaris/jumpstart/sysidcfg/sysidcfg_primary",
         "<SPARC-Enterprise-T5120>install_server_ip"=>"192.168.122.24",
         "<SPARC-Enterprise-T5120>jumpstart_server_path"=>"192.168.122.24:/Solaris/jumpstart",
-        "<SPARC-Enterprise-T5120>install_server_name"=>"itgsyddev807.macbank",
-        "<SPARC-Enterprise-T5120>root_server_hostname"=>"itgsyddev807.macbank",
+        "<SPARC-Enterprise-T5120>install_server_name"=>"someserver.somedomain",
+        "<SPARC-Enterprise-T5120>root_server_hostname"=>"someserver.somedomain",
         "<SPARC-Enterprise-T5120>root_server_ip"=>"192.168.122.24",
         "<SPARC-Enterprise-T5120>install_path"=>"/Solaris/install/Solaris_5.10_sparc_hw0811"
     }


### PR DESCRIPTION
There are server organisation specific server references in these files and I have anonymised them. Sorry for any noise created during the commit process. 