### PR TITLE
Fixes #27654 - expose http(s) port setting

### DIFF
--- a/modules/httpboot/httpboot.rb
+++ b/modules/httpboot/httpboot.rb
@@ -1,1 +1,2 @@
+require 'httpboot/httpboot_plugin_configuration'
 require 'httpboot/httpboot_plugin'

--- a/modules/httpboot/httpboot_plugin.rb
+++ b/modules/httpboot/httpboot_plugin.rb
@@ -4,7 +4,11 @@ module Proxy::Httpboot
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
     plugin :httpboot, ::Proxy::VERSION
+    load_programmable_settings ::Proxy::Httpboot::PluginConfiguration
 
     default_settings :root_dir => '/var/lib/tftpboot'
+
+    expose_setting :http_port
+    expose_setting :https_port
   end
 end

--- a/modules/httpboot/httpboot_plugin_configuration.rb
+++ b/modules/httpboot/httpboot_plugin_configuration.rb
@@ -1,0 +1,9 @@
+module ::Proxy::Httpboot
+  class PluginConfiguration
+    def load_programmable_settings(settings)
+      settings[:http_port] = Proxy::SETTINGS.http_port
+      settings[:https_port] = Proxy::SETTINGS.https_port
+      settings
+    end
+  end
+end

--- a/test/httpboot/httpboot_api_test.rb
+++ b/test/httpboot/httpboot_api_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 require 'tempfile'
+require 'httpboot/httpboot_plugin_configuration'
 require 'httpboot/httpboot_plugin'
 require 'httpboot/httpboot_api'
 

--- a/test/httpboot/integration_test.rb
+++ b/test/httpboot/integration_test.rb
@@ -1,6 +1,7 @@
 require 'test_helper'
 require 'json'
 require 'root/root_v2_api'
+require 'httpboot/httpboot_plugin_configuration'
 require 'httpboot/httpboot_plugin'
 
 class HttpbootApiFeaturesTest < Test::Unit::TestCase
@@ -23,6 +24,7 @@ class HttpbootApiFeaturesTest < Test::Unit::TestCase
     assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:httpboot])
     assert_equal([], mod['capabilities'])
 
-    assert_equal({}, mod['settings'])
+    expected_settings = {'http_port' => nil, 'https_port' => 8443}
+    assert_equal(expected_settings, mod['settings'])
   end
 end


### PR DESCRIPTION
This is needed for HTTP Boot functionality as Proxy is not running on the standard 80.