### PR TITLE
Refs #27654 - port is nil for disabled endpoints

### DIFF
--- a/modules/httpboot/httpboot.rb
+++ b/modules/httpboot/httpboot.rb
@@ -1,2 +1,1 @@
-require 'httpboot/httpboot_plugin_configuration'
 require 'httpboot/httpboot_plugin'

--- a/modules/httpboot/httpboot_plugin.rb
+++ b/modules/httpboot/httpboot_plugin.rb
@@ -4,11 +4,16 @@ module Proxy::Httpboot
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
     plugin :httpboot, ::Proxy::VERSION
-    load_programmable_settings ::Proxy::Httpboot::PluginConfiguration
 
     default_settings :root_dir => '/var/lib/tftpboot'
 
     expose_setting :http_port
     expose_setting :https_port
+
+    after_activation do
+      plugin = ::Proxy::Plugins.instance.find{|p| p[:name] == :httpboot}
+      settings[:http_port] = plugin[:http_enabled] ? Proxy::SETTINGS.http_port : nil
+      settings[:https_port] = plugin[:https_enabled] ? Proxy::SETTINGS.https_port : nil
+    end
   end
 end

--- a/modules/httpboot/httpboot_plugin_configuration.rb
+++ b/modules/httpboot/httpboot_plugin_configuration.rb
@@ -1,9 +1,0 @@
-module ::Proxy::Httpboot
-  class PluginConfiguration
-    def load_programmable_settings(settings)
-      settings[:http_port] = Proxy::SETTINGS.http_port
-      settings[:https_port] = Proxy::SETTINGS.https_port
-      settings
-    end
-  end
-end

--- a/test/httpboot/httpboot_api_test.rb
+++ b/test/httpboot/httpboot_api_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 require 'tempfile'
-require 'httpboot/httpboot_plugin_configuration'
 require 'httpboot/httpboot_plugin'
 require 'httpboot/httpboot_api'
 

--- a/test/httpboot/integration_test.rb
+++ b/test/httpboot/integration_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 require 'json'
 require 'root/root_v2_api'
-require 'httpboot/httpboot_plugin_configuration'
 require 'httpboot/httpboot_plugin'
 
 class HttpbootApiFeaturesTest < Test::Unit::TestCase
@@ -13,7 +12,7 @@ class HttpbootApiFeaturesTest < Test::Unit::TestCase
   end
 
   def test_features
-    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('httpboot.yml').returns(enabled: true, root_dir: '/var/lib/tftpboot')
+    Proxy::LegacyModuleLoader.any_instance.expects(:load_configuration_file).with('httpboot.yml').returns(enabled: true, root_dir: '/var/lib/tftpboot')
 
     get '/features'
 
@@ -25,6 +24,23 @@ class HttpbootApiFeaturesTest < Test::Unit::TestCase
     assert_equal([], mod['capabilities'])
 
     expected_settings = {'http_port' => nil, 'https_port' => 8443}
+    assert_equal(expected_settings, mod['settings'])
+  end
+
+  def test_features_http_only
+    Proxy::LegacyModuleLoader.any_instance.expects(:load_configuration_file).with('httpboot.yml').returns(enabled: 'http', root_dir: '/var/lib/tftpboot')
+    Proxy::SETTINGS.http_port = 1234
+    Proxy::SETTINGS.https_port = 5678
+
+    get '/features'
+
+    response = JSON.parse(last_response.body)
+
+    mod = response['httpboot']
+    refute_nil(mod)
+    assert(mod['http_enabled'])
+    refute(mod['https_enabled'])
+    expected_settings = {'http_port' => 1234, 'https_port' => nil}
     assert_equal(expected_settings, mod['settings'])
   end
 end


### PR DESCRIPTION
This fixes the previous commit - when endpoint is disabled, port was not set to `nil` which was confusing design. This fixes it.

https://github.com/theforeman/smart-proxy/pull/676