### PR TITLE
Fixes #27692 - ping optional for unused_ip call

### DIFF
--- a/config/settings.d/dhcp.yml.example
+++ b/config/settings.d/dhcp.yml.example
@@ -10,3 +10,8 @@
 #:server: 127.0.0.1
 # subnets restricts the subnets queried to a subset, to reduce the query time.
 #:subnets: [192.168.205.0/255.255.255.128, 192.168.205.128/255.255.255.128]
+
+# Perform ICMP and TCP ping when searching free IPs from the pool. This makes
+# sure that active IP address is not suggested as free, however in locked down
+# network environments this can cause no free IPs. Enabled by default
+#:ping_free_ip: true

--- a/modules/dhcp/dhcp_plugin.rb
+++ b/modules/dhcp/dhcp_plugin.rb
@@ -3,7 +3,7 @@ class Proxy::DhcpPlugin < ::Proxy::Plugin
   https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
   uses_provider
-  default_settings :use_provider => 'dhcp_isc', :server => '127.0.0.1', :subnets => []
+  default_settings :use_provider => 'dhcp_isc', :server => '127.0.0.1', :subnets => [], :ping_free_ip => true
   plugin :dhcp, ::Proxy::VERSION
 
   load_classes ::Proxy::DHCP::ConfigurationLoader

--- a/modules/dhcp_common/free_ips.rb
+++ b/modules/dhcp_common/free_ips.rb
@@ -66,6 +66,7 @@ module Proxy::DHCP
             false
           end
         end
+        return possible_ip unless Proxy::DhcpPlugin.settings.ping_free_ip
         begin
           logger.debug "Searching for free IP - pinging #{possible_ip}."
           if tcp_pingable?(possible_ip) || icmp_pingable?(possible_ip)

--- a/test/dhcp/dhcp_config_test.rb
+++ b/test/dhcp/dhcp_config_test.rb
@@ -6,6 +6,7 @@ class DhcpConfigTest < Test::Unit::TestCase
     Proxy::DhcpPlugin.load_test_settings({})
     assert_equal '127.0.0.1', Proxy::DhcpPlugin.settings.server
     assert_equal 'dhcp_isc', Proxy::DhcpPlugin.settings.use_provider
+    assert Proxy::DhcpPlugin.settings.ping_free_ip
     assert_equal [], Proxy::DhcpPlugin.settings.subnets
   end
 end


### PR DESCRIPTION
This should be pretty straightforward. Will do installer change once this is merged.