### PR TITLE
Refs #27654 - Account for module enabled over http or not

### DIFF
--- a/lib/proxy/plugin_initializer.rb
+++ b/lib/proxy/plugin_initializer.rb
@@ -2,9 +2,6 @@ require 'proxy/default_di_wirings'
 require 'proxy/default_plugin_validators'
 
 class ::Proxy::PluginGroup
-  HTTP_ENABLED = [true, 'http']
-  HTTPS_ENABLED = [true, 'https']
-
   include ::Proxy::Log
   attr_reader :plugin, :providers, :state, :di_container
 
@@ -87,8 +84,8 @@ class ::Proxy::PluginGroup
   end
 
   def update_group_initial_state(enabled_setting)
-    @http_enabled = HTTP_ENABLED.include?(enabled_setting)
-    @https_enabled = HTTPS_ENABLED.include?(enabled_setting)
+    @http_enabled = ::Proxy::Settings::Plugin.http_enabled?(enabled_setting)
+    @https_enabled = ::Proxy::Settings::Plugin.https_enabled?(enabled_setting)
     @state = (http_enabled? || https_enabled?) ? :starting : :disabled
   end
 
@@ -321,8 +318,8 @@ module ::Proxy::DefaultSettingsLoader
   def log_used_settings(settings)
     log_provider_settings(settings)
     logger.debug("'%s' ports: 'http': %s, 'https': %s" % [plugin.plugin_name,
-                                                          ::Proxy::PluginGroup::HTTP_ENABLED.include?(settings[:enabled]),
-                                                          ::Proxy::PluginGroup::HTTPS_ENABLED.include?(settings[:enabled])])
+                                                          ::Proxy::Settings::Plugin.http_enabled?(settings[:enabled]),
+                                                          ::Proxy::Settings::Plugin.https_enabled?(settings[:enabled])])
   end
 
   def log_provider_settings(settings)

--- a/lib/proxy/settings/plugin.rb
+++ b/lib/proxy/settings/plugin.rb
@@ -1,6 +1,8 @@
 module ::Proxy::Settings
   class Plugin < ::OpenStruct
     SHARED_DEFAULTS = { :enabled => false }
+    HTTP_ENABLED = [true, 'http']
+    HTTPS_ENABLED = [true, 'https']
 
     attr_reader :defaults, :used_defaults
 
@@ -8,6 +10,14 @@ module ::Proxy::Settings
       @defaults = SHARED_DEFAULTS.merge(default_settings || {})
       @used_defaults = @defaults.keys - settings.keys
       super(@defaults.merge(settings))
+    end
+
+    def self.http_enabled?(setting)
+      HTTP_ENABLED.include?(setting)
+    end
+
+    def self.https_enabled?(setting)
+      HTTPS_ENABLED.include?(setting)
     end
   end
 end

--- a/modules/httpboot/httpboot.rb
+++ b/modules/httpboot/httpboot.rb
@@ -1,2 +1,1 @@
-require 'httpboot/httpboot_plugin_configuration'
 require 'httpboot/httpboot_plugin'

--- a/modules/httpboot/httpboot_plugin.rb
+++ b/modules/httpboot/httpboot_plugin.rb
@@ -4,7 +4,12 @@ module Proxy::Httpboot
     https_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__))
 
     plugin :httpboot, ::Proxy::VERSION
-    load_programmable_settings ::Proxy::Httpboot::PluginConfiguration
+
+    load_programmable_settings do |settings|
+      settings[:http_port] = ::Proxy::Settings::Plugin.http_enabled?(settings[:enabled]) ? Proxy::SETTINGS.http_port : nil
+      settings[:https_port] = ::Proxy::Settings::Plugin.https_enabled?(settings[:enabled]) ? Proxy::SETTINGS.https_port : nil
+      settings
+    end
 
     default_settings :root_dir => '/var/lib/tftpboot'
 

--- a/modules/httpboot/httpboot_plugin_configuration.rb
+++ b/modules/httpboot/httpboot_plugin_configuration.rb
@@ -1,9 +1,0 @@
-module ::Proxy::Httpboot
-  class PluginConfiguration
-    def load_programmable_settings(settings)
-      settings[:http_port] = Proxy::SETTINGS.http_port
-      settings[:https_port] = Proxy::SETTINGS.https_port
-      settings
-    end
-  end
-end

--- a/test/httpboot/httpboot_api_test.rb
+++ b/test/httpboot/httpboot_api_test.rb
@@ -1,6 +1,5 @@
 require 'test_helper'
 require 'tempfile'
-require 'httpboot/httpboot_plugin_configuration'
 require 'httpboot/httpboot_plugin'
 require 'httpboot/httpboot_api'
 

--- a/test/httpboot/integration_test.rb
+++ b/test/httpboot/integration_test.rb
@@ -1,7 +1,6 @@
 require 'test_helper'
 require 'json'
 require 'root/root_v2_api'
-require 'httpboot/httpboot_plugin_configuration'
 require 'httpboot/httpboot_plugin'
 
 class HttpbootApiFeaturesTest < Test::Unit::TestCase
@@ -25,6 +24,26 @@ class HttpbootApiFeaturesTest < Test::Unit::TestCase
     assert_equal([], mod['capabilities'])
 
     expected_settings = {'http_port' => nil, 'https_port' => 8443}
+    assert_equal(expected_settings, mod['settings'])
+  end
+
+  def test_features_http
+    Proxy::SETTINGS.http_port = 1234
+    Proxy::SETTINGS.https_port = 5678
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('httpboot.yml').returns(enabled: 'http', root_dir: '/var/lib/tftpboot')
+
+    get '/features'
+
+    response = JSON.parse(last_response.body)
+
+    mod = response['httpboot']
+    refute_nil(mod)
+    assert(mod['http_enabled'])
+    refute(mod['https_enabled'])
+    assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:httpboot])
+    assert_equal([], mod['capabilities'])
+
+    expected_settings = {'http_port' => 1234, 'https_port' => nil}
     assert_equal(expected_settings, mod['settings'])
   end
 end


### PR DESCRIPTION
The module can be enabled for http-only while the proxy is https-only (or other combinations). This patch takes the enabled setting into account and guarantees that the http_port is only set when the module is actually available over http. The same goes for https_port.

This did need a minor refactor to make this easier to use.