### PR TITLE
Fixes #27789 - skip debug logging of large bodies

### DIFF
--- a/lib/proxy/log.rb
+++ b/lib/proxy/log.rb
@@ -77,6 +77,7 @@ module Proxy
 
     def initialize(app)
       @app = app
+      @max_body_size = ENV['FOREMAN_LOG_MAX_BODY_SIZE'] || 2000
     end
 
     def call(env)
@@ -88,7 +89,11 @@ module Proxy
       logger.trace do
         if env['rack.input'] && !(body = env['rack.input'].read).empty?
           env['rack.input'].rewind
-          "Body: #{body}"
+          if env['CONTENT_TYPE'] = 'application/json' && body.size < @max_body_size
+            "Body: #{body}"
+          else
+            "Body: [unknown content type or body too large - filtered out]"
+          end
         else
           ''
         end


### PR DESCRIPTION
While I find logging of whole body when TRACE environmental variable is enabled
very useful, OpenSCAP plugin uploads quite large artifact (bzi2 of XML report)
and the log line is not very useful. I am going to create a patch that will
filter out body which is longer than 2000 characters, that is exactly one 80x25
terminal screen.