### PR TITLE
Refs #26591 - Drop unused ResourceTypeApiv3

### DIFF
--- a/modules/puppet_proxy_puppet_api/v3_api_request.rb
+++ b/modules/puppet_proxy_puppet_api/v3_api_request.rb
@@ -7,15 +7,6 @@ module Proxy::PuppetApi
     end
   end
 
-  class ResourceTypeApiv3 < ::Proxy::Puppet::ApiRequest
-    # kind (optional) can be 'class', 'node', or 'defined_type'
-    def list_classes(environment, kind = nil)
-      kind_filter = kind.nil? || kind.empty? ? "" : "kind=#{kind}&"
-      response = send_request("puppet/v3/resource_types/*?#{kind_filter}&environment=#{environment}")
-      response.code == '404' ? [] : handle_response(response) # resource api responds with a 404 if filter returns no results
-    end
-  end
-
   class EnvironmentClassesApiv3 < ::Proxy::Puppet::ApiRequest
     NOT_MODIFIED = Object.new
 

--- a/test/puppet/api_request_test.rb
+++ b/test/puppet/api_request_test.rb
@@ -9,17 +9,4 @@ class PuppetApiRequestTest < Test::Unit::TestCase
     result = Proxy::PuppetApi::EnvironmentsApiv3.new('http://localhost:8140', nil, nil, nil).find_environments
     assert_equal({"environments" => {}}, result)
   end
-
-  def test_list_classes_apiv3
-    return_json = '[{"stdlib": {}}]'
-    stub_request(:get, 'http://localhost:8140/puppet/v3/resource_types/*?kind=class&environment=testing').to_return(:body => return_json)
-    result = Proxy::PuppetApi::ResourceTypeApiv3.new('http://localhost:8140', nil, nil, nil).list_classes('testing', 'class')
-    assert_equal([{'stdlib' => {}}], result)
-  end
-
-  def test_list_classes_apiv3_returns_an_empty_list_if_no_classes_were_found
-    stub_request(:get, 'http://localhost:8140/puppet/v3/resource_types/*?kind=class&environment=testing').to_return(:status => 404, :body => "Could not find instances in resource_type with '*'")
-    result = Proxy::PuppetApi::ResourceTypeApiv3.new('http://localhost:8140', nil, nil, nil).list_classes('testing', 'class')
-    assert_equal([], result)
-  end
 end


### PR DESCRIPTION
7e7015aba068db541bd4f4cf1856bf69ebbe2953 removed the legacy Puppet implementation but left an unused ResourceTypeApiv3 class.