### PR TITLE
Fixes #29137 - Case insensitive version cleanup

### DIFF
--- a/lib/proxy/pluggable.rb
+++ b/lib/proxy/pluggable.rb
@@ -202,6 +202,6 @@ module Proxy::Pluggable
   end
 
   def cleanup_version(version)
-    version.chomp('-develop').sub(/\-RC\d+$/, '')
+    version.chomp('-develop').sub(/\-RC\d+$/i, '')
   end
 end


### PR DESCRIPTION
In 2.0 we accidentaly have `2.0.0-rc1` instead of `2.0.0-RC1` and it doesn't work with our version cleanup.