### PR TITLE
Fixes #29185 - expose TFTP via /EFI/BOOT

### DIFF
--- a/config/settings.d/httpboot.yml.example
+++ b/config/settings.d/httpboot.yml.example
@@ -1,7 +1,7 @@
 ---
-# Enable publishing of a given directory under /EFI and /httpboot paths.
-# Directory listing is not possible, symlinks are followed but not outside
-# of the root directory specified in this file.
+# Enable publishing of a given directory under /EFI/BOOT, /EFI and /httpboot
+# paths. Directory listing is not possible, symlinks are followed but not
+# outside of the root directory specified in this file.
 
 # Enables the module, make sure to enable TFTP module as well to allow
 # configuration files deployment.

--- a/modules/httpboot/http_config.ru
+++ b/modules/httpboot/http_config.ru
@@ -1,5 +1,9 @@
 require 'httpboot/httpboot_api'
 
+map "/EFI/BOOT" do
+  run Proxy::HttpbootApi
+end
+
 map "/EFI" do
   run Proxy::HttpbootApi
 end


### PR DESCRIPTION
Javier Martinez Canillas of Red Hat explained to me that grub2 from grub2-efi-x64-cdboot package expects files to be on /EFI/BOOT path and this is where we should expose them both via TFTP and HTTP. Let's change this to comply with how grub2 expects things, currently we expose the TFTP directory via /httpboot and /EFI root paths.

This patch retains backward compatibility, so a file `/var/lib/tftpboot/TEST` is available under three paths:

* http://localhost:8448/EFI/BOOT/TEST
* http://localhost:8448/EFI/TEST
* http://localhost:8448/httpboot/TEST

An attempt to list BOOT subdirectory fails, that's expected:

```
$ curl http://localhost:8448/EFI/BOOT
Invalid or empty path
```