### PR TITLE
Fixes #29252 - Stop accepting TLS 1.1 connections

### DIFF
--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -72,6 +72,7 @@ module Proxy
       ssl_options |= OpenSSL::SSL::OP_NO_SSLv2 if defined?(OpenSSL::SSL::OP_NO_SSLv2)
       ssl_options |= OpenSSL::SSL::OP_NO_SSLv3 if defined?(OpenSSL::SSL::OP_NO_SSLv3)
       ssl_options |= OpenSSL::SSL::OP_NO_TLSv1 if defined?(OpenSSL::SSL::OP_NO_TLSv1)
+      ssl_options |= OpenSSL::SSL::OP_NO_TLSv1_1 if defined?(OpenSSL::SSL::OP_NO_TLSv1_1)
 
       Proxy::SETTINGS.tls_disabled_versions&.each do |version|
         constant = OpenSSL::SSL.const_get("OP_NO_TLSv#{version.to_s.tr('.', '_')}") rescue nil


### PR DESCRIPTION
TLS 1.1 is not needed since all tools connecting to the Smart Proxy should support TLS 1.2. A general rule in security is to disable what's not needed.