### PR TITLE
Fixes #29378 - DHCP conflict on hardware_type

### DIFF
--- a/modules/dhcp_common/isc/subnet_service_initialization.rb
+++ b/modules/dhcp_common/isc/subnet_service_initialization.rb
@@ -80,7 +80,8 @@ module Proxy::DHCP::CommonISC
       name = parsed_host.name
       ip_address = parsed_host.node_attributes.delete(:fixed_address)
       mac_address = parsed_host.node_attributes.delete(:hardware_address)
-      return nil if ip_address.nil? || ip_address.empty? || mac_address.nil? || mac_address.empty?
+      hardware_type = parsed_host.node_attributes.delete(:hardware_type) # only ethernet is supported
+      return nil if ip_address.nil? || ip_address.empty? || mac_address.nil? || mac_address.empty? || hardware_type.nil? || hardware_type != 'ethernet'
 
       subnet = subnet_service.find_subnet(ip_address)
       return nil if subnet.nil?

--- a/test/dhcp/dhcp_isc_subnet_service_initialization_test.rb
+++ b/test/dhcp/dhcp_isc_subnet_service_initialization_test.rb
@@ -197,6 +197,13 @@ class DhcpIscSubnetServiceInitializationTest < Test::Unit::TestCase
     assert_equal false, @subnet_service.find_host_by_hostname("static.example.com").deleteable?
   end
 
+  def test_host_hardware_type_not_parsed
+    subnet = Proxy::DHCP::Subnet.new("192.168.122.0", "255.255.255.0")
+    @subnet_service.add_subnet(subnet)
+    @initialization.load_leases_file(File.read("./test/fixtures/dhcp/dhcp.leases"))
+    refute @subnet_service.find_host_by_hostname("otherhwtype.example.com")
+  end
+
   def test_parsing_and_loading_leases
     @subnet_service.add_subnet(Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0"))
     @initialization.load_leases_file(%[

--- a/test/fixtures/dhcp/dhcp.leases
+++ b/test/fixtures/dhcp/dhcp.leases
@@ -221,3 +221,12 @@ lease 192.168.122.53 {
   binding state free;
   hardware ethernet 00:1d:60:a5:b1:2a;
 }
+
+# host with other hardware type
+host otherhwtype.example.com {
+  dynamic;
+  hardware other 44:1e:a1:73:36:96;
+  fixed-address 192.168.122.95;
+  option host-name "otherhwtype.example.com";
+}
+


### PR DESCRIPTION
Equality of DHCP records is poorly defined as arbitrary hash named "options" is used. Various implementations parse/fetch various DHCP options into the hash while SmartProxy DHCP API only defines few options (hostname, filename, ip, mac). In the reported problem, ISC DHCP configuration file parser also adds "hardware_type" option (set to "ethernet") while newly created DHCP record don't have this option. Comparsion of the two same DHCP records fails which lead to DHCP conflict.

The solution is either to add hardware_type to all DHCP Record instances for ISC DHCP or to remove it when data is parsed, because only "ethernet" hardware type is supported at the moment. This is hardcoded in the code, therefore I lean towards the latter solution.