### PR TITLE
Fixes #30906 - Add support for Redfish to BMC smart proxy.

### DIFF
--- a/bundler.d/bmc.rb
+++ b/bundler.d/bmc.rb
@@ -1,3 +1,4 @@
 group :bmc do
   gem 'rubyipmi', '>= 0.10.0'
+  gem 'redfish_client', '>= 0.5.1'
 end

--- a/config/settings.d/bmc.yml.example
+++ b/config/settings.d/bmc.yml.example
@@ -4,9 +4,15 @@
 
 # Available providers:
 # - freeipmi / ipmitool - requires the appropriate package installed, and the rubyipmi gem
+# - redfish - requires the redfish_client gem
 # - shell - for local reboot control (requires sudo access to /sbin/shutdown for the proxy user)
 # - ssh - limited remote control (status, reboot, turn off)
 #:bmc_default_provider: freeipmi
+
+# Redfish provider HTTPS certificate verification:
+# - If your BMCs just have the vendor-supplied self-signed certificates, you can set
+#   bmc_redfish_verify_ssl to false. The default is to perform certificate verification.
+#:bmc_redfish_verify_ssl: true
 
 # default user and ssh key for ssh provider
 #:bmc_ssh_user: root

--- a/lib/proxy/default_plugin_validators.rb
+++ b/lib/proxy/default_plugin_validators.rb
@@ -4,6 +4,7 @@ class Proxy::DefaultPluginValidators
       file_readable: ::Proxy::PluginValidators::FileReadable,
       presence: ::Proxy::PluginValidators::Presence,
       url: ::Proxy::PluginValidators::Url,
+      boolean: ::Proxy::PluginValidators::Boolean,
     }
   end
 end

--- a/lib/proxy/plugin_validators.rb
+++ b/lib/proxy/plugin_validators.rb
@@ -56,4 +56,12 @@ module ::Proxy::PluginValidators
       raise ::Proxy::Error::ConfigurationError.new("Setting '#{@setting_name}' contains an invalid url")
     end
   end
+
+  class Boolean < Base
+    def validate!(settings)
+      setting_value = settings[@setting_name]
+      raise ::Proxy::Error::ConfigurationError, "Setting '#{@setting_name}' is expected to be true/false" unless setting_value.is_a?(TrueClass) || setting_value.is_a?(FalseClass)
+      true
+    end
+  end
 end

--- a/modules/bmc/bmc.rb
+++ b/modules/bmc/bmc.rb
@@ -4,7 +4,7 @@ module Proxy
   module BMC
     # Just a bunch of stubs
     def installed_providers
-      Proxy::BMC::IPMI.providers_installed + ['shell']
+      Proxy::BMC::IPMI.providers_installed + ['redfish', 'shell']
     end
 
     def installed_ipmi_providers
@@ -12,15 +12,11 @@ module Proxy
     end
 
     def providers
-      Proxy::BMC::IPMI.providers + ['shell']
+      Proxy::BMC::IPMI.providers + ['redfish', 'shell']
     end
 
     def installed?(provider)
-      if provider == 'shell'
-        true
-      else
-        Proxy::BMC::IPMI.installed?(provider)
-      end
+      %w(redfish shell).include?(provider) || Proxy::BMC::IPMI.installed?(provider)
     end
   end
 end

--- a/modules/bmc/bmc_plugin.rb
+++ b/modules/bmc/bmc_plugin.rb
@@ -3,6 +3,8 @@ module Proxy::BMC
     http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
     https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
 
+    default_settings :redfish_verify_ssl => true
+    validate :redfish_verify_ssl, :boolean => true
     plugin :bmc, ::Proxy::VERSION
   end
 end

--- a/modules/bmc/redfish.rb
+++ b/modules/bmc/redfish.rb
@@ -1,0 +1,238 @@
+require 'redfish_client'
+require 'bmc/base'
+require 'bmc/redfish/dell'
+require 'bmc/redfish/hpe'
+
+module Proxy
+  module BMC
+    class Redfish < Base
+      include Proxy::Log
+      include Proxy::Util
+
+      def initialize(args)
+        @redfish_verify_ssl = Proxy::BMC::Plugin.settings.redfish_verify_ssl
+        super
+        load_vendor_overrides
+      end
+
+      def connect(args = { })
+        connection = RedfishClient.new("https://#{args[:host]}/", verify: @redfish_verify_ssl)
+        connection.login(args[:username], args[:password])
+        connection
+      end
+
+      def load_vendor_overrides
+        mod = case manufacturer
+              when 'Dell Inc.' then :RedfishVendorOverridesDellInc
+              when 'HPE'       then :RedfishVendorOverridesHPE
+              else
+                logger.debug "No #{manufacturer} specific overrides available - using generic Redfish calls"
+                return
+              end
+
+        # Get the actual Module corresponding to the name stored in mod (based on the
+        # manufacturer data returned from this Redfish interface), then extend this
+        # instance of Proxy::BMC::Redfish with the methods in that module (if there is
+        # one). Methods from the override module can use super, etc. as if it had been
+        # a static subclass, but it is a dynamic/runtime effect.
+        #
+        # The manufacturer method must work without overrides -- so all vendor-specific
+        # code may be delegated into override modules _except_ for in manufacturer()
+
+        logger.debug "Extending Redfish with vendor overrides for #{manufacturer}"
+        extend Kernel.const_get(mod)
+      end
+
+      def manufacturer
+        system.Manufacturer
+      end
+
+      # returns boolean if the test is successful
+      def test
+        host.Managers.Members.any?
+      rescue NoMethodError
+        false
+      end
+
+      def identifystatus
+        system.IndicatorLED&.downcase
+      end
+
+      def identifyon
+        system.patch(payload: { 'IndicatorLED' => 'On' })
+      end
+
+      def identifyoff
+        system.patch(payload: { 'IndicatorLED' => 'Off' })
+      end
+
+      def poweroff(soft = false)
+        poweraction(soft ? 'GracefulShutdown' : 'ForceOff')
+      end
+
+      def powercycle
+        poweraction('ForceRestart')
+      end
+
+      def poweron
+        poweraction('On')
+      end
+
+      def powerstatus
+        system.PowerState&.downcase
+      end
+
+      def poweron?
+        powerstatus == 'on'
+      end
+
+      def poweroff?
+        powerstatus == 'off'
+      end
+
+      def bootdevice
+        system.Boot['BootSourceOverrideTarget']
+      end
+
+      def bootdevices
+        # RedFish will tell you which devices can be put in the boot source override
+        # but Foreman seems structurally arranged at present for these values to be
+        # hardcoded. I can think of a few reasons to continue with that pattern. But
+        # if in the future it becomes advantageous to do something more dynamic --
+        # this is how to find out:
+        #
+        #    system.Boot['BootSourceOverrideTarget@Redfish.AllowableValues']
+        #
+        # There's an override for older HPs which have the list of boot devices at a
+        # different spot. (see HPE vendor overrides)
+        #
+        # Dell gives a list like [ None, Floppy, Cd, Hdd, SDCard, Utilities,
+        #                          BiosSetup, Pxe ]
+        # HPE -        [ None, Floppy, Cd, Hdd, Usb, Utilities, BiosSetup, Pxe ]
+        # SuperMicro - [ None, Pxe, Hdd, Diags, Cd, BiosSetup, FloppyRemovableMedia,
+        #                UsbKey, UsbHdd, UsbFloppy, UsbCd, UefiCd, UefiHdd, ... ]
+        #
+        # For the four devices Foreman hardcodes, lucky for us all three use the same set
+        # of values.
+        ['pxe', 'disk', 'bios', 'cdrom']
+      end
+
+      def bootdevice=(args = { :device => nil, :reboot => false, :persistent => false })
+        devmap = { 'bios'  => 'BiosSetup',
+                   'cdrom' => 'Cd',
+                   'disk'  => 'Hdd',
+                   'pxe'   => 'Pxe' }
+
+        system.patch(
+          payload: {
+            'Boot' => {
+              'BootSourceOverrideTarget' => devmap[args[:device]],
+              'BootSourceOverrideEnabled' => args[:persistent] ? 'Enabled' : 'Once',
+            },
+          })
+        powercycle if args[:reboot]
+      end
+
+      def bootpxe(reboot = false, persistent = false)
+        self.bootdevice = { :device => 'pxe', :reboot => reboot, :persistent => persistent }
+      end
+
+      def bootdisk(reboot = false, persistent = false)
+        self.bootdevice = { :device => 'disk', :reboot => reboot, :persistent => persistent }
+      end
+
+      def bootbios(reboot = false, persistent = false)
+        self.bootdevice = { :device => 'bios', :reboot => reboot, :persistent => persistent }
+      end
+
+      def bootcdrom(reboot = false, persistent = false)
+        self.bootdevice = { :device => 'cdrom', :reboot => reboot, :persistent => persistent }
+      end
+
+      def ip
+        bmc_nic.IPv4Addresses&.first&.[]('Address')
+      end
+
+      def mac
+        bmc_nic.MACAddress
+      end
+
+      def gateway
+        bmc_nic.IPv4Addresses&.first&.[]('Gateway')
+      end
+
+      def netmask
+        bmc_nic.IPv4Addresses&.first&.[]('SubnetMask')
+      end
+
+      def vlanid
+        vlaninfo = bmc_nic.VLAN
+        return unless vlaninfo # some older Proliants don't have a VLAN setting at all.
+        return unless vlaninfo.VLANEnable
+        vlaninfo.VLANId
+      end
+
+      def ipsrc
+        bmc_nic.IPv4Addresses&.first&.[]('AddressOrigin')
+      end
+
+      def guid
+        manager.UUID
+      end
+
+      def version
+        manager.FirmwareVersion
+      end
+
+      def reset(type = nil)
+        logger.debug("BMC reset arg #{type.inspect} unused for Redfish - standard reset only") if type
+        host.post(path: manager.Actions&.[]('#Manager.Reset')&.[]('target'), payload: { 'ResetType' => 'Reset' })
+      end
+
+      def model
+        system.Model
+      end
+
+      def serial
+        system.SerialNumber
+      end
+
+      def asset_tag
+        system.AssetTag
+      end
+
+      protected
+
+      attr_reader :host
+
+      private
+
+      def poweraction(action)
+        host.post(path: system.Actions&.[]('#ComputerSystem.Reset')&.[]('target'), payload: { 'ResetType' => action })
+      end
+
+      # I haven't yet encountered a system (apart from a blade chassis, which I think
+      # wouldn't be modeled in Foreman as a host?) which has multiple BMCs, managed systems,
+      # or BMC NICs. But it's part of the Redfish design, so it's at least possible that
+      # someone could. Warn if we encounter such a system, but try to carry on regardless.
+
+      def manager
+        managers = host.Managers&.Members
+        logger.warn("Chassis has multiple BMCs? - using first") if managers.length > 1
+        managers.first
+      end
+
+      def system
+        systems = host.Systems&.Members
+        logger.warn("BMC has multiple managed systems? - using first") if systems.length > 1
+        systems.first
+      end
+
+      def bmc_nic
+        nics = manager.EthernetInterfaces&.Members
+        logger.warn("BMC has multiple NICs? - using first") if nics.length > 1
+        nics.first
+      end
+    end
+  end
+end

--- a/modules/bmc/redfish/dell.rb
+++ b/modules/bmc/redfish/dell.rb
@@ -1,0 +1,22 @@
+module RedfishVendorOverridesDellInc
+  def powercycle
+    # ForceRestart was added in Lifecycle Controller 3.30.30.30
+    # prior to that, it required ForceOff followed by On.
+    if system.Actions&.[]('#ComputerSystem.Reset')&.[]('ResetType@RedfishAllowableValues')&.include? 'ForceRestart'
+      poweraction('ForceRestart')
+    else
+      poweraction('ForceOff')
+      # it only takes a couple seconds to force off, but if you send the 'On' action too
+      # quickly, you'll get an error that the server is already on, because it hasn't
+      # actually shut off yet. fifteen seconds is chosen arbitrarily; hopefully it covers
+      # all scenarios.
+      sleep 15
+      poweraction('On')
+    end
+  end
+
+  def reset(type = nil)
+    logger.debug("BMC reset arg #{type.inspect} unused for Dell Redfish - GracefulRestart only") if type
+    host.post(path: manager.Actions&.[]('#Manager.Reset')&.[]('target'), payload: { 'ResetType' => 'GracefulRestart' })
+  end
+end

--- a/modules/bmc/redfish/hpe.rb
+++ b/modules/bmc/redfish/hpe.rb
@@ -1,0 +1,14 @@
+module RedfishVendorOverridesHPE
+  def poweroff(soft = false)
+    poweraction(soft ? 'PushPowerButton' : 'ForceOff')
+  end
+
+  # -- See note about dynamic bootdevices in redfish.rb --
+  # this override will let Foreman get the list of supported boot devices
+  # from older HPs, if and when potential boot devices become dynamically discovered
+  #
+  # def bootdevices
+  #   # older HPs have the list of supported values at a different location
+  #   system.Boot.BootSourceOverrideSupported || super
+  # end
+end

--- a/test/bmc/bmc_api_test.rb
+++ b/test/bmc/bmc_api_test.rb
@@ -218,7 +218,7 @@ class BmcApiTest < Test::Unit::TestCase
     get "/providers", args
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
     data = JSON.parse(last_response.body)
-    expected = ['freeipmi', 'ipmitool', 'ssh', 'shell']
+    expected = ['freeipmi', 'ipmitool', 'redfish', 'ssh', 'shell']
     assert_equal(expected, data["providers"])
   end
 
@@ -227,7 +227,7 @@ class BmcApiTest < Test::Unit::TestCase
     get "/providers/installed", args
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
     data = JSON.parse(last_response.body)
-    expected = ['freeipmi', 'ipmitool', 'ssh', 'shell']
+    expected = ['freeipmi', 'ipmitool', 'redfish', 'ssh', 'shell']
     assert_equal(expected, data["installed_providers"])
   end
 

--- a/test/plugins/validator_test.rb
+++ b/test/plugins/validator_test.rb
@@ -133,3 +133,37 @@ class UrlValidatorTest < Test::Unit::TestCase
     assert_match(/expected to contain a url/, error.message)
   end
 end
+
+class BooleanValidatorTest < Test::Unit::TestCase
+  class BooleanValidatorTestPlugin < ::Proxy::Plugin
+    default_settings :a_settting => true
+  end
+
+  def test_required_parameter_with_a_value_passes_validation
+    assert ::Proxy::PluginValidators::Boolean.new(BooleanValidatorTestPlugin, 'a_setting', nil, nil).validate!(:a_setting => true)
+  end
+
+  def test_empty_string_treated_as_missing_value
+    error = assert_raises ::Proxy::Error::ConfigurationError do
+      ::Proxy::PluginValidators::Boolean.new(BooleanValidatorTestPlugin, 'a_setting', nil, nil).validate!(:a_setting => '')
+    end
+
+    assert_match(%r{expected to be true/false}, error.message)
+  end
+
+  def test_required_parameter_without_a_value_fails_validation
+    error = assert_raises ::Proxy::Error::ConfigurationError do
+      ::Proxy::PluginValidators::Boolean.new(BooleanValidatorTestPlugin, 'a_setting', nil, nil).validate!(:a_setting => nil)
+    end
+
+    assert_match(%r{expected to be true/false}, error.message)
+  end
+
+  def test_optional_parameter_without_a_value_fails_validation
+    error = assert_raises ::Proxy::Error::ConfigurationError do
+      ::Proxy::PluginValidators::Boolean.new(BooleanValidatorTestPlugin, 'optional_setting', nil, nil).validate!(:optional_setting => nil)
+    end
+
+    assert_match(%r{expected to be true/false}, error.message)
+  end
+end


### PR DESCRIPTION
Initial commit includes support for variations in Redfish
implementation among an arbitrary range of Supermicro, Dell,
and HPE servers. Modular implementation should make it easier
to accommodate additional variations, as they are discovered.

There is a corresponding pull request in the Foreman main project 
to allow selection of Redfish provider from front end.