### PR TITLE
Fixes #29639 - fix tr error on invalid MAC

### DIFF
--- a/modules/dhcp_common/record/lease.rb
+++ b/modules/dhcp_common/record/lease.rb
@@ -6,7 +6,7 @@ module Proxy::DHCP
 
     def initialize(name, ip_address, mac_address, subnet, starts, ends, state, options = {})
       @type = "lease"
-      @name = name || "lease-#{mac_address.tr(':-', '')}"
+      @name = name || "lease-#{mac_address&.tr(':-', '')}"
       @starts = starts
       @ends = ends
       @state = state


### PR DESCRIPTION
Infoblox attempts to create records with MAC address. This erros out with nil exception although it should be "Invalid MAC address" which comes later. This fixes it.