### PR TITLE
Fixes #30677 - Global registration endpoint

### DIFF
--- a/modules/templates/http_config.ru
+++ b/modules/templates/http_config.ru
@@ -1,5 +1,6 @@
 require 'templates/templates_unattended_api'
 require 'templates/templates_userdata_api'
+require 'templates/templates_register_api'
 
 map "/unattended" do
   run Proxy::TemplatesUnattendedApi
@@ -7,4 +8,8 @@ end
 
 map "/userdata" do
   run Proxy::TemplatesUserdataApi
+end
+
+map "/register" do
+  run Proxy::TemplatesRegisterApi
 end

--- a/modules/templates/templates_plugin.rb
+++ b/modules/templates/templates_plugin.rb
@@ -7,6 +7,7 @@ module Proxy::Templates
 
     validate :template_url, url: true
     expose_setting :template_url
+    capability 'global_registration'
 
     after_activation do
       loading_failed "missing :foreman_url: from configuration." unless Proxy::SETTINGS.foreman_url

--- a/modules/templates/templates_register_api.rb
+++ b/modules/templates/templates_register_api.rb
@@ -1,0 +1,11 @@
+require 'templates/proxy_request'
+
+class Proxy::TemplatesRegisterApi < Sinatra::Base
+  helpers ::Proxy::Helpers
+
+  get "/" do
+    log_halt(500, "Failed to retrieve Global registration template.") do
+      Proxy::Templates::ProxyRequest.new.get(['register'], request.env, params)
+    end
+  end
+end

--- a/test/templates/integration_test.rb
+++ b/test/templates/integration_test.rb
@@ -21,7 +21,7 @@ class TemplatesApiFeaturesTest < Test::Unit::TestCase
     mod = response['templates']
     refute_nil(mod)
     assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:templates])
-    assert_equal([], mod['capabilities'])
+    assert_equal(['global_registration'], mod['capabilities'])
 
     assert_equal({'template_url' => 'http://smart-proxy.example.com:8000'}, mod['settings'])
   end

--- a/test/templates/templates_register_api_test.rb
+++ b/test/templates/templates_register_api_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+require 'templates/templates_register_api'
+require 'templates/templates'
+require 'webmock/test_unit'
+
+class TemplatesRegisterApiTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Proxy::TemplatesRegisterApi.new
+  end
+
+  def setup
+    @foreman_url = 'http://foreman.example.com'
+    Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+    @template_url = 'http://smart-proxy.example.com'
+    Proxy::Templates::Plugin.settings.stubs(:template_url).returns(@template_url)
+  end
+
+  def test_api_global_registration
+    stub_request(:get, "#{@foreman_url}/register").with(query: {"url" => @template_url}).to_return(:body => 'GRT content')
+    get "/", {}
+    assert last_response.ok?, "Last response was ok"
+    assert_match("GRT content", last_response.body)
+  end
+end


### PR DESCRIPTION
Allows to render Global registration template.

How to test:
```
curl -X GET http://smart-proxy.devv/register --user admin:changeme
```


Notes:
* PR is part of **Simple & automatic host registration WF**, [RFC](https://community.theforeman.org/t/rfc-simple-automatic-host-registration-wf/19588) & [Redmine](https://projects.theforeman.org/issues/30440)