### PR TITLE
Fixes #30683 - Hosts module

### DIFF
--- a/config/settings.d/hosts.yml.example
+++ b/config/settings.d/hosts.yml.example
@@ -1,0 +1,2 @@
+---
+:enabled: false

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -77,6 +77,7 @@ module Proxy
   require 'realm_freeipa/realm_freeipa'
   require 'logs/logs'
   require 'httpboot/httpboot'
+  require 'hosts/hosts'
 
   def self.version
     {:version => VERSION}

--- a/modules/hosts/hosts.rb
+++ b/modules/hosts/hosts.rb
@@ -1,0 +1,1 @@
+require 'hosts/hosts_plugin'

--- a/modules/hosts/hosts_api.rb
+++ b/modules/hosts/hosts_api.rb
@@ -1,0 +1,13 @@
+require 'hosts/proxy_request'
+
+class Proxy::Hosts::Api < ::Sinatra::Base
+  helpers ::Proxy::Helpers
+
+  get '/*' do
+    Proxy::Hosts::ProxyRequest.new.get(request)
+  end
+
+  post '/*' do
+    Proxy::Hosts::ProxyRequest.new.post(request)
+  end
+end

--- a/modules/hosts/hosts_plugin.rb
+++ b/modules/hosts/hosts_plugin.rb
@@ -1,0 +1,8 @@
+module Proxy::Hosts
+  class Plugin < ::Proxy::Plugin
+    http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+
+    plugin :hosts, ::Proxy::VERSION
+  end
+end

--- a/modules/hosts/http_config.ru
+++ b/modules/hosts/http_config.ru
@@ -1,0 +1,5 @@
+require 'hosts/hosts_api'
+
+map "/hosts" do
+  run Proxy::Hosts::Api
+end

--- a/modules/hosts/proxy_request.rb
+++ b/modules/hosts/proxy_request.rb
@@ -1,0 +1,34 @@
+require "proxy/util"
+require 'proxy/request'
+require 'uri'
+
+module Proxy::Hosts
+  class ProxyRequest < ::Proxy::HttpRequest::ForemanRequest
+    def get(request)
+      headers = extract_request_headers(request.env)
+      path = "/api#{request.path}"
+      proxy_req = request_factory.create_get(path, {}, headers)
+      res = send_request(proxy_req)
+
+      res.body
+    end
+
+    def post(request)
+      headers = extract_request_headers(request.env)
+      path = "/api#{request.path}"
+      proxy_req = request_factory.create_post(path, request.body.read, headers, {})
+      res = send_request(proxy_req)
+
+      res.body
+    end
+
+    private
+
+    def extract_request_headers(env)
+      Hash[env.select { |k, v| k =~ /^HTTP_/ && k !~ /^HTTP_(VERSION|HOST)$/ }.map { |k, v| [k[5..-1], v] }]
+    rescue Exception => e
+      logger.warn "Unable to extract request headers: #{e}"
+      {}
+    end
+  end
+end


### PR DESCRIPTION
Add new Hosts module to the Smart proxy, allowing to call :get & :post requests to the Foreman /hosts api (needed for the Global registration feature)

Notes:
* PR is part of **Simple & automatic host registration WF**, [RFC](https://community.theforeman.org/t/rfc-simple-automatic-host-registration-wf/19588) & [Redmine](https://projects.theforeman.org/issues/30440)