### PR TITLE
Fixes #30719 - allow spawning without shell

### DIFF
--- a/lib/proxy/http_download.rb
+++ b/lib/proxy/http_download.rb
@@ -14,8 +14,13 @@ module Proxy
       dns_timeout ||= DEFAULT_CONNECT_TIMEOUT
       connect_timeout ||= DEFAULT_DNS_TIMEOUT
 
-      super("#{wget} --connect-timeout=#{connect_timeout} --dns-timeout=#{dns_timeout} --read-timeout=#{read_timeout}"\
-            " --tries=3 --no-check-certificate -nv -c \"#{escape_for_shell(src.to_s)}\" -O \"#{escape_for_shell(dst.to_s)}\"")
+      super([wget,
+             "--connect-timeout=#{connect_timeout}",
+             "--dns-timeout=#{dns_timeout}",
+             "--read-timeout=#{read_timeout}",
+             "--tries=3",
+             "--no-check-certificate",
+             "-nv", "-c", src.to_s, "-O", dst.to_s])
     end
 
     def start

--- a/lib/proxy/log.rb
+++ b/lib/proxy/log.rb
@@ -93,8 +93,10 @@ module Proxy
           env['rack.input'].rewind
           if env['CONTENT_TYPE'] == 'application/json' && body.size < @max_body_size
             "Body: #{body}"
+          elsif env['CONTENT_TYPE'] == 'text/plain' && body.size < @max_body_size
+            "Body: #{body}"
           else
-            "Body: [unknown content type or body too large - filtered out]"
+            "Body: [filtered out]"
           end
         else
           ''

--- a/test/http_download_test.rb
+++ b/test/http_download_test.rb
@@ -11,7 +11,11 @@ class HttpDownloadsTest < Test::Unit::TestCase
     default_connect = Proxy::HttpDownload::DEFAULT_CONNECT_TIMEOUT
     default_dns = Proxy::HttpDownload::DEFAULT_DNS_TIMEOUT
 
-    expected = "/wget --connect-timeout=#{default_connect} --dns-timeout=#{default_dns} --read-timeout=#{default_read} --tries=3 --no-check-certificate -nv -c \"src\" -O \"dst\""
+    expected = ["/wget",
+                "--connect-timeout=#{default_connect}",
+                "--dns-timeout=#{default_dns}",
+                "--read-timeout=#{default_read}",
+                "--tries=3", "--no-check-certificate", "-nv", "-c", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst').command
   end
@@ -21,7 +25,11 @@ class HttpDownloadsTest < Test::Unit::TestCase
     default_dns = Proxy::HttpDownload::DEFAULT_DNS_TIMEOUT
 
     read_timeout = 1000
-    expected = "/wget --connect-timeout=#{default_connect} --dns-timeout=#{default_dns} --read-timeout=#{read_timeout} --tries=3 --no-check-certificate -nv -c \"src\" -O \"dst\""
+    expected = ["/wget",
+                "--connect-timeout=#{default_connect}",
+                "--dns-timeout=#{default_dns}",
+                "--read-timeout=#{read_timeout}",
+                "--tries=3", "--no-check-certificate", "-nv", "-c", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, nil, nil).command
   end
@@ -30,7 +38,11 @@ class HttpDownloadsTest < Test::Unit::TestCase
     read_timeout = 1000
     connect_timeout = 99
     dns_timeout = 27
-    expected = "/wget --connect-timeout=#{connect_timeout} --dns-timeout=#{dns_timeout} --read-timeout=#{read_timeout} --tries=3 --no-check-certificate -nv -c \"src\" -O \"dst\""
+    expected = ["/wget",
+                "--connect-timeout=#{connect_timeout}",
+                "--dns-timeout=#{dns_timeout}",
+                "--read-timeout=#{read_timeout}",
+                "--tries=3", "--no-check-certificate", "-nv", "-c", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, connect_timeout, dns_timeout).command
   end

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -21,6 +21,16 @@ class ProxyUtilTest < Test::Unit::TestCase
     assert_equal t.join, 0
   end
 
+  def test_commandtask_as_array_with_exit_0
+    t = Proxy::Util::CommandTask.new(["echo", "test"]).start
+    assert_equal t.join, 0
+  end
+
+  def test_commandtask_with_input_and_exit_0
+    t = Proxy::Util::CommandTask.new('cat', 'hello').start
+    assert_equal t.join, 0
+  end
+
   def test_commandtask_with_exit_1
     t = Proxy::Util::CommandTask.new('false').start
     assert_equal t.join, 1


### PR DESCRIPTION
For https://github.com/theforeman/smart_proxy_shellhooks we need to be able to spawn a command through the utility helper without shell to prevent possible problems. Popen3 supports this via multiple arguments, but the utility helper did not allow passing an array.

Also logging was improved ("Started task" now contains also the thread PID) and logging of plain/text body was improved for easy to understand examples in the plugin README.