### PR TITLE
Fixes #30773 - expose template_url setting

### DIFF
--- a/modules/templates/templates_plugin.rb
+++ b/modules/templates/templates_plugin.rb
@@ -5,7 +5,8 @@ module Proxy::Templates
 
     plugin :templates, ::Proxy::VERSION
 
-    validate_presence :template_url
+    validate :template_url, url: true
+    expose_setting :template_url
 
     after_activation do
       loading_failed "missing :foreman_url: from configuration." unless Proxy::SETTINGS.foreman_url

--- a/test/templates/integration_test.rb
+++ b/test/templates/integration_test.rb
@@ -23,6 +23,6 @@ class TemplatesApiFeaturesTest < Test::Unit::TestCase
     assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:templates])
     assert_equal([], mod['capabilities'])
 
-    assert_equal({}, mod['settings'])
+    assert_equal({'template_url' => 'http://smart-proxy.example.com:8000'}, mod['settings'])
   end
 end


### PR DESCRIPTION
It can be useful if Foreman has the templates_url statically available.  Right now this is retrieved via the /templates/templateServer API call but if it's stored statically, Foreman can be modified to not need this API call anymore.