### PR TITLE
Fixes #30677 - Registration module

### DIFF
--- a/config/settings.d/registration.yml.example
+++ b/config/settings.d/registration.yml.example
@@ -1,0 +1,2 @@
+---
+:enabled: false

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -73,6 +73,7 @@ module Proxy
   require 'realm_freeipa/realm_freeipa'
   require 'logs/logs'
   require 'httpboot/httpboot'
+  require 'registration/registration'
 
   def self.version
     {:version => VERSION}

--- a/modules/registration/http_config.ru
+++ b/modules/registration/http_config.ru
@@ -1,0 +1,5 @@
+require 'registration/registration_api'
+
+map '/register' do
+  run Proxy::Registration::Api
+end

--- a/modules/registration/proxy_request.rb
+++ b/modules/registration/proxy_request.rb
@@ -1,0 +1,37 @@
+require 'proxy/request'
+
+module Proxy::Registration
+  class ProxyRequest < ::Proxy::HttpRequest::ForemanRequest
+    def global_register(request)
+      proxy_req = request_factory.create_get '/register',
+                                             request_params(request),
+                                             headers(request)
+
+      send_request(proxy_req)
+    end
+
+    def host_register(request)
+      proxy_req = request_factory.create_post '/register',
+                                              request.body.read,
+                                              headers(request),
+                                              request_params(request)
+
+      send_request(proxy_req)
+    end
+
+    private
+
+    def request_params(request)
+      params = request.params
+      params[:url] = request.env['REQUEST_URI']&.split('/register')&.first
+      params
+    end
+
+    def headers(request)
+      Hash[request.env.select { |k, v| k =~ /^HTTP_/ && k !~ /^HTTP_(VERSION|HOST)$/ }.map { |k, v| [k[5..-1], v] }]
+    rescue Exception => e
+      logger.warn "Unable to extract request headers: #{e}"
+      {}
+    end
+  end
+end

--- a/modules/registration/registration.rb
+++ b/modules/registration/registration.rb
@@ -1,0 +1,1 @@
+require 'registration/registration_plugin.rb'

--- a/modules/registration/registration_api.rb
+++ b/modules/registration/registration_api.rb
@@ -1,0 +1,40 @@
+require 'registration/proxy_request'
+
+class Proxy::Registration::Api < ::Sinatra::Base
+  get '/' do
+    response = Proxy::Registration::ProxyRequest.new.global_register(request)
+    handle_response(response)
+  rescue StandardError => e
+    logger.exception "Error when rendering Global Registration Template", e
+    render_error(default_error_msg)
+  end
+
+  post '/' do
+    response = Proxy::Registration::ProxyRequest.new.host_register(request)
+    handle_response(response)
+  rescue StandardError => e
+    logger.exception "Error when rendering Host Registration Template", e
+    render_error(default_error_msg)
+  end
+
+  private
+
+  def handle_response(response)
+    if response.code.start_with? '2'
+      response.body
+    else
+      # Return error message only if it is not HTML.
+      message = response["content-type"].include?('text/plain') ? response.body : default_error_msg
+      render_error(message, code: response.code)
+    end
+  end
+
+  def render_error(message, code: 500)
+    status code
+    message
+  end
+
+  def default_error_msg
+    "echo \"Internal Server Error\"\nexit 1\n"
+  end
+end

--- a/modules/registration/registration_plugin.rb
+++ b/modules/registration/registration_plugin.rb
@@ -1,0 +1,8 @@
+module Proxy::Registration
+  class Plugin < ::Proxy::Plugin
+    http_rackup_path  File.expand_path("http_config.ru", File.expand_path(__dir__))
+    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+
+    plugin :registration, ::Proxy::VERSION
+  end
+end

--- a/test/registration/integration_test.rb
+++ b/test/registration/integration_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'json'
+require 'root/root_v2_api'
+require 'registration/registration'
+
+class RegistrationApiFeaturesTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
+    Proxy::RootV2Api.new
+  end
+
+  def test_features
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('registration.yml').returns(enabled: true)
+
+    get '/features'
+    response = JSON.parse(last_response.body)
+    mod = response['registration']
+
+    refute_nil(mod)
+    assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:registration])
+  end
+end

--- a/test/registration/registration_api_test.rb
+++ b/test/registration/registration_api_test.rb
@@ -1,0 +1,97 @@
+require 'test_helper'
+require 'registration/registration_api'
+
+class RegistrationRegisterApiTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Proxy::Registration::Api.new
+  end
+
+  def setup
+    @foreman_url = 'http://foreman.example.com'
+    Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+  end
+
+  def test_global_register_template
+    stub_request(:get, "#{@foreman_url}/register").to_return(body: 'template')
+
+    get "/"
+    assert last_response.ok?
+    assert_match('template', last_response.body)
+  end
+
+  def test_global_register_template_with_args
+    stub_request(:get, "#{@foreman_url}/register?param=test").to_return(body: 'template')
+
+    get '/', { param: 'test' }
+    assert last_response.ok?
+    assert_match('template', last_response.body)
+  end
+
+  def test_host_register_template
+    stub_request(:post, "#{@foreman_url}/register").to_return(body: 'template')
+
+    post '/'
+    assert last_response.ok?
+    assert_match('template', last_response.body)
+  end
+
+  def test_host_register_template_with_args
+    stub_request(:post, "#{@foreman_url}/register?host=test.example.com").to_return(body: 'template')
+
+    post '/', { host: 'test.example.com' }
+    assert last_response.ok?
+    assert_match('template', last_response.body)
+  end
+
+  def test_global_401
+    stub_request(:get, "#{@foreman_url}/register").to_return(body: '401', status: 401, headers: { "Content-Type" => 'text/plain; charset=UTF-8' })
+
+    get '/'
+    assert last_response.unauthorized?
+    assert_match('401', last_response.body)
+  end
+
+  def test_host_401
+    stub_request(:post, "#{@foreman_url}/register").to_return(body: '401', status: 401, headers: { "Content-Type" => 'text/plain; charset=UTF-8' })
+
+    post '/'
+    assert last_response.unauthorized?
+    assert_match('401', last_response.body)
+  end
+
+  def test_global_401_html_response
+    stub_request(:get, "#{@foreman_url}/register").to_return(body: '401', status: 401, headers: { "Content-Type" => 'text/html; charset=UTF-8' })
+
+    get '/'
+    assert last_response.unauthorized?
+    assert_match("echo \"Internal Server Error\"\nexit 1\n", last_response.body)
+  end
+
+  def test_host_401_html_response
+    stub_request(:post, "#{@foreman_url}/register").to_return(body: '401', status: 401, headers: { "Content-Type" => 'text/html; charset=UTF-8' })
+
+    post '/'
+    assert last_response.unauthorized?
+    assert_match("echo \"Internal Server Error\"\nexit 1\n", last_response.body)
+  end
+
+  def test_global_500
+    Rack::NullLogger.any_instance.stubs(:exception)
+    stub_request(:get, "#{@foreman_url}/register").to_timeout
+
+    get '/'
+    assert last_response.server_error?
+    assert_match("echo \"Internal Server Error\"\nexit 1\n", last_response.body)
+  end
+
+  def test_host_500
+    Rack::NullLogger.any_instance.stubs(:exception)
+    stub_request(:post, "#{@foreman_url}/register").to_timeout
+
+    post '/'
+    assert last_response.server_error?
+    assert_match("echo \"Internal Server Error\"\nexit 1\n", last_response.body)
+  end
+end


### PR DESCRIPTION
SmartProxy Registration module allows users to register hosts via GlobalRegistration feature through the Smart Proxy.

**Summary**
Two new endpoints:
* `GET /register` - Render Global registration template
* `POST /register` - Render Host registration template (and create Host)

Both endpoints pass all arguments & headers set by user to the Foreman, plus it adds `:url` parameter - URL of the Smart Proxy. This parameter will be used later in the templates to replace Foreman URLs with the Smart Proxy URL.

![4d6455aeafe4ba320a3f3714c6bc33f204fcd4fa](https://user-images.githubusercontent.com/59385976/94239157-ac644200-ff11-11ea-99d0-b97d89c59285.png)

**How to test**
* For Vanilla Foreman: https://github.com/theforeman/foreman/pull/8018
* With Katello: https://github.com/Katello/katello/pull/8965
```
curl --user admin:changeme -X GET http://smart-proxy.example.com/register" | bash
```

Note that this won't change URLs in the templates (not implemented yet), but there is a [RM#30714](https://projects.theforeman.org/issues/30714) waiting.

**Not covered in this PR:**
* Changing URL in Global & Host registration templates - [RM#30714](https://projects.theforeman.org/issues/30714)
* Secure connection

---
PR is part of **Simple & automatic host registration WF**, see:
* [RFC](https://community.theforeman.org/t/rfc-simple-automatic-host-registration-wf/19588)
* [Redmine (this PR)](https://projects.theforeman.org/issues/30677)
* [Redmine (Parent task)](https://projects.theforeman.org/issues/30440)