### PR TITLE
Fixes #30856 - Drop  Puppet class cache initializer

### DIFF
--- a/modules/puppet_proxy_puppet_api/plugin_configuration.rb
+++ b/modules/puppet_proxy_puppet_api/plugin_configuration.rb
@@ -14,7 +14,6 @@ module ::Proxy::PuppetApi
       require 'puppet_proxy_common/api_request'
       require 'puppet_proxy_puppet_api/v3_api_request'
       require 'puppet_proxy_puppet_api/v3_environments_retriever'
-      require 'puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever'
     end
 
     def load_dependency_injection_wirings(container_instance, settings)
@@ -30,12 +29,6 @@ module ::Proxy::PuppetApi
                                                   settings[:puppet_ssl_key],
                                                   settings[:api_timeout])
                                               end)
-      container_instance.dependency :class_cache_initializer,
-                                    (lambda do
-                                      Proxy::PuppetApi::EnvironmentClassesCacheInitializer.new(
-                                        container_instance.get_dependency(:class_retriever_impl),
-                                        container_instance.get_dependency(:environment_retriever_impl))
-                                    end)
     end
   end
 end

--- a/modules/puppet_proxy_puppet_api/puppet_proxy_puppet_api_plugin.rb
+++ b/modules/puppet_proxy_puppet_api/puppet_proxy_puppet_api_plugin.rb
@@ -11,7 +11,5 @@ module Proxy::PuppetApi
     validate :puppet_url, :url => true
     expose_setting :puppet_url
     validate_readable :puppet_ssl_ca, :puppet_ssl_cert, :puppet_ssl_key
-
-    start_services :class_cache_initializer
   end
 end


### PR DESCRIPTION
Retrieving all classes for all environments only makes sense if caching is enabled on the Puppetserver. By default this is the case. Even if this is not the case, it only works for environments that don't change.  It's sufficient to lazy load this.

This saves load on start up of services.