### PR TITLE
Refs #30856 - Fix class loading

### DIFF
--- a/modules/puppet_proxy_puppet_api/plugin_configuration.rb
+++ b/modules/puppet_proxy_puppet_api/plugin_configuration.rb
@@ -14,6 +14,7 @@ module ::Proxy::PuppetApi
       require 'puppet_proxy_common/api_request'
       require 'puppet_proxy_puppet_api/v3_api_request'
       require 'puppet_proxy_puppet_api/v3_environments_retriever'
+      require 'puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever'
     end
 
     def load_dependency_injection_wirings(container_instance, settings)


### PR DESCRIPTION
025c1f3098f139ba5056cb2e97f3ceeefda68d78 removed this require, but that file also contains the V3EnvironmentClassesApiClassesRetriever class which is still used. This is a case of a bad rebase from my side.