### PR TITLE
Fixes #30951 - Provide a rackup_path plugin DSL

### DIFF
--- a/lib/proxy/plugin.rb
+++ b/lib/proxy/plugin.rb
@@ -37,6 +37,11 @@ class ::Proxy::Plugin
   class << self
     attr_reader :get_http_rackup_path, :get_https_rackup_path, :get_uses_provider
 
+    def rackup_path(path)
+      http_rackup_path(path)
+      https_rackup_path(path)
+    end
+
     def http_rackup_path(path)
       @get_http_rackup_path = path
     end

--- a/modules/bmc/bmc_plugin.rb
+++ b/modules/bmc/bmc_plugin.rb
@@ -1,7 +1,6 @@
 module Proxy::BMC
   class Plugin < Proxy::Plugin
-    http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+    rackup_path File.expand_path("http_config.ru", __dir__)
 
     plugin :bmc, ::Proxy::VERSION
   end

--- a/modules/dhcp/dhcp_plugin.rb
+++ b/modules/dhcp/dhcp_plugin.rb
@@ -1,6 +1,5 @@
 class Proxy::DhcpPlugin < ::Proxy::Plugin
-  http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-  https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+  rackup_path File.expand_path("http_config.ru", __dir__)
 
   uses_provider
   default_settings :use_provider => 'dhcp_isc', :server => '127.0.0.1', :subnets => [], :ping_free_ip => true

--- a/modules/dns/dns_plugin.rb
+++ b/modules/dns/dns_plugin.rb
@@ -1,7 +1,6 @@
 module Proxy::Dns
   class Plugin < ::Proxy::Plugin
-    http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+    rackup_path File.expand_path("http_config.ru", __dir__)
 
     uses_provider
     default_settings :use_provider => 'dns_nsupdate', :dns_ttl => 86_400

--- a/modules/facts/facts_plugin.rb
+++ b/modules/facts/facts_plugin.rb
@@ -1,6 +1,5 @@
 class Proxy::FactsPlugin < ::Proxy::Plugin
-  http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-  https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+  rackup_path File.expand_path("http_config.ru", __dir__)
 
   default_settings :enabled => false
   plugin :facts, ::Proxy::VERSION

--- a/modules/httpboot/httpboot_plugin.rb
+++ b/modules/httpboot/httpboot_plugin.rb
@@ -1,7 +1,6 @@
 module Proxy::Httpboot
   class Plugin < ::Proxy::Plugin
-    http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+    rackup_path File.expand_path("http_config.ru", __dir__)
 
     plugin :httpboot, ::Proxy::VERSION
 

--- a/modules/logs/logs_plugin.rb
+++ b/modules/logs/logs_plugin.rb
@@ -1,6 +1,5 @@
 class ::Proxy::LogsPlugin < ::Proxy::Plugin
-  http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-  https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+  rackup_path File.expand_path("http_config.ru", __dir__)
 
   plugin :logs, ::Proxy::VERSION
   default_settings :enabled => true

--- a/modules/puppet_proxy/puppet_plugin.rb
+++ b/modules/puppet_proxy/puppet_plugin.rb
@@ -1,7 +1,6 @@
 module Proxy::Puppet
   class Plugin < Proxy::Plugin
-    http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+    rackup_path File.expand_path("http_config.ru", __dir__)
 
     plugin :puppet, ::Proxy::VERSION
 

--- a/modules/puppetca/puppetca_plugin.rb
+++ b/modules/puppetca/puppetca_plugin.rb
@@ -1,7 +1,6 @@
 module Proxy::PuppetCa
   class Plugin < ::Proxy::Plugin
-    http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+    rackup_path File.expand_path("http_config.ru", __dir__)
 
     uses_provider
     default_settings :use_provider => 'puppetca_hostname_whitelisting'

--- a/modules/realm/realm_plugin.rb
+++ b/modules/realm/realm_plugin.rb
@@ -1,7 +1,6 @@
 module Proxy::Realm
   class Plugin < ::Proxy::Plugin
-    http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+    rackup_path File.expand_path("http_config.ru", __dir__)
 
     default_settings :use_provider => 'realm_freeipa'
 

--- a/modules/root/root_plugin.rb
+++ b/modules/root/root_plugin.rb
@@ -2,8 +2,7 @@ class ::Proxy::RootPlugin < ::Proxy::Plugin
   plugin :foreman_proxy, ::Proxy::VERSION
   default_settings :enabled => true
 
-  http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-  https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+  rackup_path File.expand_path("http_config.ru", __dir__)
 
   override_module_loader_class ::Proxy::RootPluginLoader
 end

--- a/modules/templates/templates_plugin.rb
+++ b/modules/templates/templates_plugin.rb
@@ -1,7 +1,6 @@
 module Proxy::Templates
   class Plugin < ::Proxy::Plugin
-    http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+    rackup_path File.expand_path("http_config.ru", __dir__)
 
     plugin :templates, ::Proxy::VERSION
 

--- a/modules/tftp/tftp_plugin.rb
+++ b/modules/tftp/tftp_plugin.rb
@@ -2,8 +2,7 @@ module Proxy::TFTP
   class Plugin < ::Proxy::Plugin
     plugin :tftp, ::Proxy::VERSION
 
-    http_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
-    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+    rackup_path File.expand_path("http_config.ru", __dir__)
 
     default_settings :tftproot => '/var/lib/tftpboot',
                      :tftp_read_timeout => 60,

--- a/test/plugins/plugin_test.rb
+++ b/test/plugins/plugin_test.rb
@@ -7,6 +7,16 @@ class PluginTest < Test::Unit::TestCase
     assert_equal "", TestPlugin2.https_rackup
   end
 
+  class TestPluginSingleRackupPath < Proxy::Plugin
+    plugin :test2, '1.0'
+    rackup_path '/dev/null'
+  end
+
+  def test_combined_rackup_path_returns_http_and_https
+    assert_equal '/dev/null', TestPluginSingleRackupPath.get_http_rackup_path
+    assert_equal '/dev/null', TestPluginSingleRackupPath.get_https_rackup_path
+  end
+
   class TestBundlerGroupPlugin < ::Proxy::Plugin
     plugin :test_bundler_group, '1.0'
     bundler_group :test_group


### PR DESCRIPTION
Currently there's http_rackup_path and https_rackup_path. In practice all built in modules and most (all?) plugins that I know define the same rackup config for both HTTP and HTTPS. Having a DSL method to do this simplifies code.