### PR TITLE
Fixes #31086 - Use __dir__ when possible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,6 @@ gemspec
 
 gem 'concurrent-ruby', '~> 1.0', require: 'concurrent'
 
-Dir["#{File.dirname(__FILE__)}/bundler.d/*.rb"].each do |bundle|
+Dir[File.join(__dir__, 'bundler.d', '*.rb')].each do |bundle|
   instance_eval(Bundler.read_file(bundle))
 end

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require 'rake/testtask'
 require 'rdoc/task'
 require 'fileutils'
 require 'tmpdir'
-require File.join(File.dirname(__FILE__), 'extra/migrate_settings')
+require File.join(__dir__, 'extra/migrate_settings')
 
 load 'tasks/jenkins.rake'
 load 'tasks/pkg.rake'
@@ -33,7 +33,7 @@ end
 
 desc 'Migrate configuration settings.'
 task :migrate_settings do
-  app_dir = File.dirname(__FILE__)
+  app_dir = __dir__
   config_src_path = File.join(app_dir, "config", "settings.yml")
   modules_config_src_path = File.join(app_dir, "config", "settings.d")
   migrations_dir_path = File.join(app_dir, "extra", "migrations")

--- a/bin/smart-proxy-win-service
+++ b/bin/smart-proxy-win-service
@@ -1,4 +1,4 @@
-$LOAD_PATH.unshift(*Dir[File.expand_path("../../lib", __FILE__), File.expand_path("../../modules", __FILE__)])
+$LOAD_PATH.unshift(*Dir[File.expand_path("../lib", __dir__), File.expand_path("../modules", __dir__)])
 
 raise "win-service executable can only be used as a service in windows environment" unless RUBY_PLATFORM =~ /mingw/
 
@@ -9,7 +9,7 @@ require 'smart_proxy_main'
 
 include Win32
 
-LOG_DIR_PATH = File.expand_path("../../log", __FILE__)
+LOG_DIR_PATH = File.expand_path("../log", __dir__)
 Dir.mkdir(LOG_DIR_PATH) unless Dir.exist?(LOG_DIR_PATH)
 
 def log(a_msg)

--- a/extra/migrate_settings.rb
+++ b/extra/migrate_settings.rb
@@ -202,7 +202,7 @@ module ::Proxy
 end
 
 def app_dir
-  path("../../", __FILE__)
+  path("../", __dir__)
 end
 
 def path(part_one, part_two = nil)
@@ -248,7 +248,7 @@ def load_main_config_file(main_config_file_path)
 end
 
 def module_configuration_dir(main_config_file)
-  main_config_file[:settings_directory] || Pathname.new(__FILE__).join("..", "..", "config", "settings.d").expand_path.to_s
+  main_config_file[:settings_directory] || Pathname.new(__dir__).join("..", "config", "settings.d").expand_path.to_s
 end
 
 if $PROGRAM_NAME == __FILE__

--- a/extra/query.rb
+++ b/extra/query.rb
@@ -67,7 +67,7 @@ end
 
 unless key && cert && ca
   if RUBY_PLATFORM =~ /mingw/
-    origin = Pathname.new(__FILE__).dirname.parent.join "config"
+    origin = Pathname.new(__dir__).parent.join "config"
     key  ||= origin.join "private.pem"
     cert ||= origin.join "signed.pem"
     ca   ||= origin.join "ca.pem"

--- a/extra/register_service.rb
+++ b/extra/register_service.rb
@@ -10,9 +10,9 @@ require 'win32/service'
 include Win32
 include RbConfig
 
-executable = Pathname.new(__FILE__).dirname.parent.join("bin", "smart-proxy-win-service")
+executable = Pathname.new(__dir__).parent.join("bin", "smart-proxy-win-service")
 executable = executable.realpath.to_s.tr('/', '\\')
-working_dir = Pathname.new(__FILE__).dirname.parent.realpath
+working_dir = Pathname.new(__dir__).parent.realpath
 ruby = File.join(CONFIG['bindir'], 'ruby').tr('/', '\\')
 cmd  = "#{ruby} -C #{working_dir} \"#{executable}\""
 puts "Installing #{cmd} as a service"

--- a/lib/proxy/plugin.rb
+++ b/lib/proxy/plugin.rb
@@ -15,7 +15,7 @@ end
 # class ExamplePlugin < ::Proxy::Plugin
 #  plugin :example, "1.2.3"
 #  config_file "example.yml"
-#  http_rackup_path File.expand_path("http_config.ru", File.expand_path("../", __FILE__)) # note no https rackup path, module will not be available over https
+#  http_rackup_path File.expand_path("http_config.ru", __dir__) # note no https rackup path, module will not be available over https
 #  requires :foreman_proxy, ">= 1.5.develop"
 #  requires :another_plugin, "~> 1.3.0"
 #  default_settings :first => 'first', :second => 'second'

--- a/lib/proxy/settings.rb
+++ b/lib/proxy/settings.rb
@@ -5,7 +5,7 @@ require "pathname"
 module Proxy::Settings
   extend ::Proxy::Log
 
-  SETTINGS_PATH = Pathname.new(__FILE__).join("..", "..", "..", "config", "settings.yml")
+  SETTINGS_PATH = Pathname.new(__dir__).join("..", "..", "config", "settings.yml")
 
   def self.initialize_global_settings(settings_path = nil, argv = ARGV)
     global = ::Proxy::Settings::Global.new(YAML.load(File.read(settings_path || SETTINGS_PATH)))

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -1,7 +1,7 @@
 module ::Proxy::Settings
   class Global < ::OpenStruct
     DEFAULT_SETTINGS = {
-      :settings_directory => Pathname.new(__FILE__).join("..", "..", "..", "..", "config", "settings.d").expand_path.to_s,
+      :settings_directory => Pathname.new(__dir__).join("..", "..", "..", "config", "settings.d").expand_path.to_s,
       :https_port => 8443,
       :log_file => "/var/log/foreman-proxy/proxy.log",
       :file_rolling_keep => 6,

--- a/lib/smart_proxy_for_testing.rb
+++ b/lib/smart_proxy_for_testing.rb
@@ -27,7 +27,7 @@ require 'sinatra/base'
 require 'sinatra/authorization'
 
 Proxy::SETTINGS = ::Proxy::Settings::Global.new(:log_file => './logs/test.log', :log_level => 'DEBUG')
-Proxy::VERSION = File.read(File.join(File.dirname(__FILE__), '../VERSION')).chomp
+Proxy::VERSION = File.read(File.join(__dir__, '..', 'VERSION')).chomp
 
 ::Sinatra::Base.set :run, false
 ::Sinatra::Base.register ::Sinatra::Authorization

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -1,4 +1,4 @@
-APP_ROOT = "#{File.dirname(__FILE__)}/.."
+APP_ROOT = "#{__dir__}/.."
 
 require 'smart_proxy'
 require 'launcher'
@@ -38,7 +38,7 @@ require 'sinatra/default_not_found_page'
 
 module Proxy
   SETTINGS = Settings.initialize_global_settings
-  VERSION = File.read(File.join(File.dirname(__FILE__), '../VERSION')).chomp
+  VERSION = File.read(File.join(__dir__, '..', 'VERSION')).chomp
 
   ::Sinatra::Base.set :run, false
   ::Sinatra::Base.set :root, APP_ROOT

--- a/test/global_settings_test.rb
+++ b/test/global_settings_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class GlobalSettingsTest < Test::Unit::TestCase
   def test_default_values
     settings = ::Proxy::Settings::Global.new({})
-    assert_equal Pathname.new(__FILE__).join("..", "..", "config", "settings.d").expand_path.to_s, settings.settings_directory
+    assert_equal Pathname.new(__dir__).join("..", "config", "settings.d").expand_path.to_s, settings.settings_directory
     assert_equal 8443, settings.https_port
     assert_equal "/var/log/foreman-proxy/proxy.log", settings.log_file
     assert_equal "INFO", settings.log_level

--- a/test/migrations/autosign_migration_test.rb
+++ b/test/migrations/autosign_migration_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-require File.join(File.dirname(__FILE__), '../../extra/migrate_settings')
+require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
-require File.join(File.dirname(__FILE__), '../../extra/migrations/20170523000000_migrate_autosign_setting.rb')
+require File.join(__dir__, '../../extra/migrations/20170523000000_migrate_autosign_setting.rb')
 
 class ProxyAutosignMigrationTest < Test::Unit::TestCase
   def setup

--- a/test/migrations/dhcp_migration_test.rb
+++ b/test/migrations/dhcp_migration_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-require File.join(File.dirname(__FILE__), '../../extra/migrate_settings')
+require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
-require File.join(File.dirname(__FILE__), '../../extra/migrations/20150826000000_migrate_dhcp_settings')
+require File.join(__dir__, '../../extra/migrations/20150826000000_migrate_dhcp_settings')
 
 class ProxyDhcpMigrationTest < Test::Unit::TestCase
   def setup

--- a/test/migrations/dns_migration_test.rb
+++ b/test/migrations/dns_migration_test.rb
@@ -1,11 +1,11 @@
 require 'test_helper'
-require File.join(File.dirname(__FILE__), '../../extra/migrate_settings')
+require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
-require File.join(File.dirname(__FILE__), '../../extra/migrations/20150611000000_migrate_dns_settings')
+require File.join(__dir__, '../../extra/migrations/20150611000000_migrate_dns_settings')
 
 class ProxyDnsMigrationTest < Test::Unit::TestCase
   def setup
-    @old_config = YAML.load_file(File.join(File.dirname(__FILE__), './migration_dns_settings.yml'))
+    @old_config = YAML.load_file(File.join(__dir__, './migration_dns_settings.yml'))
     @migration = MigrateDnsSettings.new("/tmp")
     @output, @unknown = @migration.migrate_dns_configuration(@old_config.dup)
   end

--- a/test/migrations/libvirt_migration_test.rb
+++ b/test/migrations/libvirt_migration_test.rb
@@ -1,11 +1,11 @@
 require 'test_helper'
-require File.join(File.dirname(__FILE__), '../../extra/migrate_settings')
+require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
-require File.join(File.dirname(__FILE__), '../../extra/migrations/20160411000000_migrate_libvirt_settings')
+require File.join(__dir__, '../../extra/migrations/20160411000000_migrate_libvirt_settings')
 
 class ProxyLibvirtMigrationTest < Test::Unit::TestCase
   def setup
-    @old_config = YAML.load_file(File.join(File.dirname(__FILE__), './migration_settings.yml'))
+    @old_config = YAML.load_file(File.join(__dir__, './migration_settings.yml'))
     @migration = MigrateVirshToLibvirtConfig.new("/tmp")
   end
 

--- a/test/migrations/migration_test.rb
+++ b/test/migrations/migration_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require File.join(File.dirname(__FILE__), '../../extra/migrate_settings')
+require File.join(__dir__, '../../extra/migrate_settings')
 
 class MigrationTest < Test::Unit::TestCase
   def setup

--- a/test/migrations/monolithic_config_file_migration_test.rb
+++ b/test/migrations/monolithic_config_file_migration_test.rb
@@ -1,11 +1,11 @@
 require 'test_helper'
-require File.join(File.dirname(__FILE__), '../../extra/migrate_settings')
+require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
-require File.join(File.dirname(__FILE__), '../../extra/migrations/20150327000000_migrate_monolithic_config')
+require File.join(__dir__, '../../extra/migrations/20150327000000_migrate_monolithic_config')
 
 class MonolithicConfigMigrationTest < Test::Unit::TestCase
   def setup
-    @old_config = YAML.load_file(File.join(File.dirname(__FILE__), './migration_settings.yml'))
+    @old_config = YAML.load_file(File.join(__dir__, './migration_settings.yml'))
     @output, @unknown = MigrateMonolithicConfig.new("/tmp").migrate_monolithic_config(@old_config)
   end
 

--- a/test/migrations/puppet_migration_test.rb
+++ b/test/migrations/puppet_migration_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-require File.join(File.dirname(__FILE__), '../../extra/migrate_settings')
+require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
-require File.join(File.dirname(__FILE__), '../../extra/migrations/20160413000000_migrate_puppet_settings.rb')
+require File.join(__dir__, '../../extra/migrations/20160413000000_migrate_puppet_settings.rb')
 
 class ProxyPuppetMigrationTest < Test::Unit::TestCase
   def setup

--- a/test/migrations/realm_migration_test.rb
+++ b/test/migrations/realm_migration_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
-require File.join(File.dirname(__FILE__), '../../extra/migrate_settings')
+require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
-require File.join(File.dirname(__FILE__), '../../extra/migrations/20161209000000_migrate_realm_settings.rb')
+require File.join(__dir__, '../../extra/migrations/20161209000000_migrate_realm_settings.rb')
 
 class ProxyRealmMigrationTest < Test::Unit::TestCase
   def setup

--- a/test/puppetca_http_api/ca_v1_api_request_test.rb
+++ b/test/puppetca_http_api/ca_v1_api_request_test.rb
@@ -76,6 +76,6 @@ class CaApiv1RequestTest < Test::Unit::TestCase
   end
 
   def fixture(file)
-    File.open(File.expand_path(File.join(File.dirname(__FILE__), '.', 'fixtures', file)))
+    File.open(File.expand_path(File.join(__dir__, '.', 'fixtures', file)))
   end
 end

--- a/test/puppetca_puppet_cert/puppetca_puppet_cert_test.rb
+++ b/test/puppetca_puppet_cert/puppetca_puppet_cert_test.rb
@@ -103,7 +103,7 @@ class PuppetCaPuppetCertImplTest < Test::Unit::TestCase
 
   def test_should_list_certs
     @puppet_cert.stubs(:find_puppetca)
-    @puppet_cert.stubs(:ssldir).returns(File.expand_path(File.join(File.dirname(__FILE__), '.', 'fixtures')))
+    @puppet_cert.stubs(:ssldir).returns(File.expand_path(File.join(__dir__, '.', 'fixtures')))
     @puppet_cert.instance_variable_set('@puppetca', '/tmp/puppet cert')
     @puppet_cert.stubs('`').with(' /tmp/puppet cert --list --all').returns(PUPPET_CERT_LIST_OUTPUT)
     Process::Status.any_instance.stubs(:exitstatus).returns(0)
@@ -171,7 +171,7 @@ class PuppetCaPuppetCertImplTest < Test::Unit::TestCase
   private
 
   def stub_puppetca_executables
-    @ssldir = File.expand_path(File.join(File.dirname(__FILE__), '.', 'fixtures'))
+    @ssldir = File.expand_path(File.join(__dir__, '.', 'fixtures'))
     @puppet_cert.stubs(:ssldir).returns(@ssldir)
 
     @puppet_cert.stubs(:which).with('puppetca', anything).returns(nil)

--- a/test/sinatra/ssl_client_verification_integration_test.rb
+++ b/test/sinatra/ssl_client_verification_integration_test.rb
@@ -73,6 +73,6 @@ class SSLClientVerificationIntegrationTest < Test::Unit::TestCase
   end
 
   def fixtures
-    File.expand_path(File.join(File.dirname(__FILE__), '..', 'fixtures', 'ssl'))
+    File.expand_path(File.join(__dir__, '..', 'fixtures', 'ssl'))
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,10 +2,10 @@ require 'English'
 require "test/unit"
 require 'fileutils'
 
-$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'lib')
-$LOAD_PATH << File.join(File.dirname(__FILE__), '..', 'modules')
+$LOAD_PATH << File.join(__dir__, '..', 'lib')
+$LOAD_PATH << File.join(__dir__, '..', 'modules')
 
-logdir = File.join(File.dirname(__FILE__), '..', 'logs')
+logdir = File.join(__dir__, '..', 'logs')
 FileUtils.mkdir_p(logdir) unless File.exist?(logdir)
 
 ENV['RACK_ENV'] = 'test'

--- a/test/tftp/tftp_test.rb
+++ b/test/tftp/tftp_test.rb
@@ -23,7 +23,7 @@ class TftpTest < Test::Unit::TestCase
 
   def test_path_to_tftp_directory_with_relative_tftproot_setting
     Proxy::TFTP::Plugin.load_test_settings(:tftproot => "./some/root")
-    assert_equal Pathname.new(__FILE__).join("..", "..", "..", "modules", "tftp", "some", "root").to_s, @tftp.send(:path)
+    assert_equal Pathname.new(__dir__).join("..", "..", "modules", "tftp", "some", "root").to_s, @tftp.send(:path)
   end
 
   def test_paths_inside_tftp_directory_dont_raise_errors


### PR DESCRIPTION
`__dir__` is equal to `File.dirname(__FILE__)` and easier to read.