### PR TITLE
Fixes #31118 - Remove daemonize support

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -42,12 +42,6 @@
 #:foreman_ssl_cert: ssl/certs/fqdn.pem
 #:foreman_ssl_key: ssl/private_keys/fqdn.pem
 
-# by default smart_proxy runs in the foreground. To enable running as a daemon, uncomment 'daemon' setting
-#:daemon: true
-# Only used when 'daemon' is set to true.
-# Uncomment and modify if you want to change the default pid file '/var/run/foreman-proxy/foreman-proxy.pid'
-#:daemon_pid: /var/run/foreman-proxy/foreman-proxy.pid
-
 # host and ports configuration
 # an array of interfaces to bind ports to (possible values: *, localhost, 0.0.0.0)
 #:bind_host: ['*']

--- a/extra/systemd/foreman-proxy.service
+++ b/extra/systemd/foreman-proxy.service
@@ -6,7 +6,7 @@ After=basic.target network.target
 [Service]
 Type=notify
 User=foreman-proxy
-ExecStart=/usr/share/foreman-proxy/bin/smart-proxy --no-daemonize
+ExecStart=/usr/share/foreman-proxy/bin/smart-proxy
 Environment=MALLOC_ARENA_MAX=2
 
 [Install]

--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -18,10 +18,6 @@ module Proxy
       @settings = settings
     end
 
-    def pid_path
-      settings.daemon_pid
-    end
-
     def http_enabled?
       !settings.http_port.nil?
     end
@@ -127,37 +123,6 @@ module Proxy
       raise e
     end
 
-    def pid_status
-      return :exited unless File.exist?(pid_path)
-      pid = ::File.read(pid_path).to_i
-      return :dead if pid == 0
-      Process.kill(0, pid)
-      :running
-    rescue Errno::ESRCH
-      :dead
-    rescue Errno::EPERM
-      :not_owned
-    end
-
-    def check_pid
-      case pid_status
-      when :running, :not_owned
-        logger.error "A server is already running. Check #{pid_path}"
-        exit(2)
-      when :dead
-        File.delete(pid_path)
-      end
-    end
-
-    def write_pid
-      FileUtils.mkdir_p(File.dirname(pid_path)) unless File.exist?(pid_path)
-      File.open(pid_path, ::File::CREAT | ::File::EXCL | ::File::WRONLY) { |f| f.write(Process.pid.to_s) }
-      at_exit { File.delete(pid_path) if File.exist?(pid_path) }
-    rescue Errno::EEXIST
-      check_pid
-      retry
-    end
-
     def webrick_server(app, addresses, port)
       server = ::WEBrick::HTTPServer.new(app)
       addresses.each { |a| server.listen(a, port) }
@@ -167,12 +132,6 @@ module Proxy
 
     def launch
       raise Exception.new("Both http and https are disabled, unable to start.") unless http_enabled? || https_enabled?
-
-      if settings.daemon
-        check_pid
-        Process.daemon
-        write_pid
-      end
 
       ::Proxy::PluginInitializer.new(::Proxy::Plugins.instance).initialize_plugins
 

--- a/lib/proxy/log.rb
+++ b/lib/proxy/log.rb
@@ -25,10 +25,6 @@ module Proxy
       notime_layout = Logging::Layouts.pattern(pattern: ::Proxy::SETTINGS.system_logging_pattern + "\n")
       logger = Logging.logger.root
       if log_file.casecmp('STDOUT').zero?
-        if SETTINGS.daemon
-          puts "Settings log_file=STDOUT and daemon=true cannot be used together"
-          exit(1)
-        end
         logger.add_appenders(Logging.appenders.stdout(logger_name, layout: layout))
       elsif log_file.casecmp('SYSLOG').zero?
         unless syslog_available?

--- a/lib/proxy/settings.rb
+++ b/lib/proxy/settings.rb
@@ -8,9 +8,7 @@ module Proxy::Settings
   SETTINGS_PATH = Pathname.new(__dir__).join("..", "..", "config", "settings.yml")
 
   def self.initialize_global_settings(settings_path = nil, argv = ARGV)
-    global = ::Proxy::Settings::Global.new(YAML.load(File.read(settings_path || SETTINGS_PATH)))
-    global.apply_argv(argv)
-    global
+    ::Proxy::Settings::Global.new(YAML.load(File.read(settings_path || SETTINGS_PATH)))
   end
 
   def self.load_plugin_settings(defaults, settings_file, settings_directory = nil)

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -10,8 +10,6 @@ module ::Proxy::Settings
       :file_logging_pattern => '%d %.8X{request} [%.1l] %m',
       :system_logging_pattern => '%m',
       :log_level => "INFO",
-      :daemon => false,
-      :daemon_pid => "/var/run/foreman-proxy/foreman-proxy.pid",
       :forward_verify => true,
       :bind_host => ["*"],
       :log_buffer => 2000,
@@ -48,11 +46,6 @@ module ::Proxy::Settings
     def normalize_setting(key, value, how_to)
       return value unless how_to.has_key?(key)
       how_to[key].call(value)
-    end
-
-    def apply_argv(args)
-      self.daemon = true if args.include?('--daemonize')
-      self.daemon = false if args.include?('--no-daemonize')
     end
   end
 end

--- a/test/global_settings_test.rb
+++ b/test/global_settings_test.rb
@@ -7,8 +7,6 @@ class GlobalSettingsTest < Test::Unit::TestCase
     assert_equal 8443, settings.https_port
     assert_equal "/var/log/foreman-proxy/proxy.log", settings.log_file
     assert_equal "INFO", settings.log_level
-    assert_equal false, settings.daemon
-    assert_equal "/var/run/foreman-proxy/foreman-proxy.pid", settings.daemon_pid
   end
 
   def test_normalize_setting
@@ -27,17 +25,5 @@ class GlobalSettingsTest < Test::Unit::TestCase
   def test_bind_host_is_normalized
     assert_equal ['127.0.0.1'], ::Proxy::Settings::Global.new(:bind_host => '127.0.0.1').bind_host
     assert_equal ['127.0.0.1'], ::Proxy::Settings::Global.new(:bind_host => ['127.0.0.1']).bind_host
-  end
-
-  def test_apply_argv_daemonize
-    settings = ::Proxy::Settings::Global.new(daemon: false)
-    settings.apply_argv(['--daemonize'])
-    assert_equal true, settings.daemon
-  end
-
-  def test_apply_argv_no_daemonize
-    settings = ::Proxy::Settings::Global.new(daemon: true)
-    settings.apply_argv(['--no-daemonize'])
-    assert_equal false, settings.daemon
   end
 end

--- a/test/launcher_test.rb
+++ b/test/launcher_test.rb
@@ -4,40 +4,6 @@ require 'launcher'
 class LauncherTest < Test::Unit::TestCase
   def setup
     @launcher = Proxy::Launcher.new
-    @launcher.stubs(:pid_path).returns("launcher_test.pid")
-  end
-
-  def test_pid_status_exited
-    assert_equal :exited, @launcher.pid_status
-  end
-
-  def test_write_pid_success
-    @launcher.write_pid
-    assert File.exist?(@launcher.pid_path)
-  ensure
-    FileUtils.rm_f @launcher.pid_path
-  end
-
-  def test_pid_status_running
-    @launcher.write_pid
-    assert_equal :running, @launcher.pid_status
-  ensure
-    FileUtils.rm_f @launcher.pid_path
-  end
-
-  def test_check_pid_deletes_dead
-    Process.stubs(:kill).returns { raise Errno::ESRCH }
-    @launcher.check_pid
-    assert_equal false, File.exist?(@launcher.pid_path)
-  end
-
-  def test_check_pid_exits_program
-    @launcher.write_pid
-    assert_raises SystemExit do
-      @launcher.check_pid
-    end
-  ensure
-    FileUtils.rm_f @launcher.pid_path
   end
 
   def test_install_webrick_callback

--- a/test/migrations/migration_settings.yml
+++ b/test/migrations/migration_settings.yml
@@ -9,8 +9,6 @@
 - foreman.prod.domain
 - foreman.dev.domain
 
-:daemon: true
-:daemon_pid: /var/run/foreman-proxy/foreman-proxy.pid
 :port: 8443
 
 :tftp: true

--- a/test/migrations/monolithic_config_file_migration_test.rb
+++ b/test/migrations/monolithic_config_file_migration_test.rb
@@ -19,8 +19,6 @@ class MonolithicConfigMigrationTest < Test::Unit::TestCase
                  :ssl_certificate => "/var/lib/puppet/ssl/certs/foo.bar.example.com.pem",
                  :ssl_private_key => "/var/lib/puppet/ssl/private_keys/foo.bar.example.com.org.pem",
                  :trusted_hosts   => ["foreman.prod.domain", "foreman.dev.domain"],
-                 :daemon          => true,
-                 :daemon_pid      => "/var/run/foreman-proxy/foreman-proxy.pid",
                  :log_file        => "/var/log/foreman-proxy/proxy.log",
                  :log_level       => "DEBUG",
                  :https_port      => 8443,


### PR DESCRIPTION
Currently Smart Proxy is able to daemonize and manage a pid file.  However, in the common deployments under systemd and Windows this isn't actually used. There are also other solutions out there to manage it externally if it's needed.

Removing this simplifies the code and config file.