### PR TITLE
Refs #30677 - support also urlencoded data

### DIFF
--- a/lib/proxy/request.rb
+++ b/lib/proxy/request.rb
@@ -26,7 +26,7 @@ module Proxy::HttpRequest
 
     def add_headers(req, headers = {})
       req.add_field('Accept', 'application/json,version=2')
-      req.content_type = headers["Content-Type"] || 'application/json'
+      req.content_type = headers.delete("Content-Type") || 'application/json'
       headers.each do |k, v|
         req.add_field(k, v)
       end

--- a/modules/registration/proxy_request.rb
+++ b/modules/registration/proxy_request.rb
@@ -10,11 +10,25 @@ module Proxy::Registration
       send_request(proxy_req)
     end
 
+    # we support two way of sending data - either a JSON or url encoded data
     def host_register(request)
-      proxy_req = request_factory.create_post '/register',
-                                              request.body.read,
-                                              headers(request),
-                                              request_params(request)
+      if request.content_type == 'application/x-www-form-urlencoded'
+        # the request has a different content type, ForemanRequestFactory sets content type to json, unless
+        # specified explicitly
+        # also request.params contain the same data that is in request.body, just parsed to hash,
+        # in case they are nested (e.g. host hash) we need this causes problem during CGI escaping
+        # therefore we only add url, everything else should be in body in this type of request
+        proxy_req = request_factory.create_post '/register',
+                                                request.body.read,
+                                                headers(request).merge("Content-Type" => request.content_type),
+                                                { url: register_url(request) }
+      else
+        # the application/json request body contains the data - JSON as a string, query contains only the URL
+        proxy_req = request_factory.create_post '/register',
+                                                request.body.read,
+                                                headers(request),
+                                                request_params(request)
+      end
 
       send_request(proxy_req)
     end
@@ -23,8 +37,12 @@ module Proxy::Registration
 
     def request_params(request)
       params = request.params
-      params[:url] = request.env['REQUEST_URI']&.split('/register')&.first
+      params[:url] = register_url(request)
       params
+    end
+
+    def register_url(request)
+      request.env['REQUEST_URI']&.split('/register')&.first
     end
 
     def headers(request)

--- a/test/registration/registration_api_test.rb
+++ b/test/registration/registration_api_test.rb
@@ -38,9 +38,17 @@ class RegistrationRegisterApiTest < Test::Unit::TestCase
   end
 
   def test_host_register_template_with_args
-    stub_request(:post, "#{@foreman_url}/register?host=test.example.com").to_return(body: 'template')
+    stub_request(:post, "#{@foreman_url}/register").to_return(body: 'template')
 
-    post '/', { host: 'test.example.com' }
+    post '/', { host: { name: 'test.example.com', build: false } }
+    assert last_response.ok?
+    assert_match('template', last_response.body)
+  end
+
+  def test_host_register_template_with_args_using_json
+    stub_request(:post, "#{@foreman_url}/register").to_return(body: 'template')
+
+    post '/', { host: { name: 'test.example.com', build: false } }, { 'CONTENT_TYPE' => 'application/json' }
     assert last_response.ok?
     assert_match('template', last_response.body)
   end


### PR DESCRIPTION
The default registration template in Foreman started to send the data in
urlencoded form instead of a JSON, as of https://projects.theforeman.org/issues/31043

In order to support that, we need to remove host parameter from query,
since Sinatra parses it from body automatically. We only need to proxy
the body of the request. ForemanRequestProxy also defaults to
application/json if not set explicitly, in this case we need to enforce
the correct content-type through headers.

---

comment to this PR: I tried to add a test for this, turns out the Rack test methods use url-encoded by default. I didn't find a good way to correctly distinguish between the two requests, given the testing target is stubbed anyway.