### PR TITLE
Fixes #31537 - Expose BMC providers as capabilities

### DIFF
--- a/modules/bmc/bmc_plugin.rb
+++ b/modules/bmc/bmc_plugin.rb
@@ -5,5 +5,16 @@ module Proxy::BMC
     default_settings :redfish_verify_ssl => true
     validate :redfish_verify_ssl, :boolean => true
     plugin :bmc, ::Proxy::VERSION
+
+    # Various installed providers are exposed as capabilties
+    capability 'redfish'
+    capability 'shell'
+    capability 'ssh'
+    capability -> { Proxy::BMC::IPMI.providers_installed }
+
+    # Load IPMI to ensure the capabilities can be determined
+    load_classes do
+      require 'bmc/ipmi'
+    end
   end
 end

--- a/test/bmc/integration_test.rb
+++ b/test/bmc/integration_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 require 'json'
 require 'root/root_v2_api'
 require 'bmc/bmc'
+require 'bmc/ipmi'
 
 class BmcApiFeaturesTest < Test::Unit::TestCase
   include Rack::Test::Methods
@@ -13,6 +14,7 @@ class BmcApiFeaturesTest < Test::Unit::TestCase
 
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('bmc.yml').returns(enabled: true, bmc_default_provider: 'freeipmi')
+    Proxy::BMC::IPMI.stubs(:providers_installed).returns([])
 
     get '/features'
 
@@ -21,7 +23,23 @@ class BmcApiFeaturesTest < Test::Unit::TestCase
     mod = response['bmc']
     refute_nil(mod)
     assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:bmc])
-    assert_equal([], mod['capabilities'])
+    assert_equal(['redfish', 'shell', 'ssh'], mod['capabilities'])
+
+    assert_equal({}, mod['settings'])
+  end
+
+  def test_features_with_freeipmi_installed
+    Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('bmc.yml').returns(enabled: true, bmc_default_provider: 'freeipmi')
+    Proxy::BMC::IPMI.stubs(:providers_installed).returns(['freeipmi'])
+
+    get '/features'
+
+    response = JSON.parse(last_response.body)
+
+    mod = response['bmc']
+    refute_nil(mod)
+    assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:bmc])
+    assert_equal(['freeipmi', 'redfish', 'shell', 'ssh'], mod['capabilities'])
 
     assert_equal({}, mod['settings'])
   end


### PR DESCRIPTION
Currently the BMC module exposes an API endpoint /providers/installed but this can also be provided as capabilities or settings. This allows Foreman to determine up front if a proxy is even a valid choice without making API requests over the network.

The load_classes part is needed because capabilities are exectuted before loading the main API (which already has the same require). The require is explicit in the tests to stub out the implementation, making the tests reliable, regardless of which providers are installed.

While writing up the issue, I realized that perhaps this is hard to consume on the Foreman side. There is no way to recognize a capability is actually a provider. Assuming every capability is a provider is also wrong.

For this I can think of two solutions:
* Prefix all provider capabilities with `provider_`
* Expose installed providers as a setting

Rather than coming up with essentially 3 PRs I decided to submit this one (since I already wrote the code) and have the discussion here.