### PR TITLE
Fixes #2412 - don't continue wget downloads

### DIFF
--- a/lib/proxy/http_download.rb
+++ b/lib/proxy/http_download.rb
@@ -14,11 +14,15 @@ module Proxy
       dns_timeout ||= DEFAULT_CONNECT_TIMEOUT
       connect_timeout ||= DEFAULT_DNS_TIMEOUT
 
-      args = [wget, "--connect-timeout=#{connect_timeout}",
+      args = ["--connect-timeout=#{connect_timeout}",
               "--dns-timeout=#{dns_timeout}",
               "--read-timeout=#{read_timeout}",
-              "--tries=3", "-nv", "-c", src.to_s, "-O", dst.to_s]
-      args << "--no-check-certificate" unless verify_server_cert
+              "--tries=3",
+              "--timestamping", # turn on timestamping to prevent redownloads
+              "--no-if-modified-since", # but use HTTP HEAD instead If-Modified-Since
+              "-nv", src.to_s, "-O", dst.to_s]
+      args.unshift("--no-check-certificate") unless verify_server_cert
+      args.unshift(wget)
       super(args)
     end
 

--- a/lib/proxy/plugin_initializer.rb
+++ b/lib/proxy/plugin_initializer.rb
@@ -114,7 +114,7 @@ class ::Proxy::PluginGroup
   end
 
   def fail_group(an_exception)
-    fail_group_with_message("Disabling all modules in the group #{printable_module_names(member_names)} due to a failure in one of them: #{an_exception}", an_exception.backtrace)
+    fail_group_with_message("Disabling all modules in the group #{printable_module_names(member_names)} due to a failure in one of them: #{an_exception}", an_exception)
   end
 
   def fail_group_with_message(a_message, an_exception = nil)

--- a/test/http_download_test.rb
+++ b/test/http_download_test.rb
@@ -12,10 +12,14 @@ class HttpDownloadsTest < Test::Unit::TestCase
     default_dns = Proxy::HttpDownload::DEFAULT_DNS_TIMEOUT
 
     expected = ["/wget",
+                "--no-check-certificate",
                 "--connect-timeout=#{default_connect}",
                 "--dns-timeout=#{default_dns}",
                 "--read-timeout=#{default_read}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst", "--no-check-certificate"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst').command
   end
@@ -29,7 +33,10 @@ class HttpDownloadsTest < Test::Unit::TestCase
                 "--connect-timeout=#{default_connect}",
                 "--dns-timeout=#{default_dns}",
                 "--read-timeout=#{default_read}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', nil, nil, nil, true).command
   end
@@ -40,10 +47,14 @@ class HttpDownloadsTest < Test::Unit::TestCase
 
     read_timeout = 1000
     expected = ["/wget",
+                "--no-check-certificate",
                 "--connect-timeout=#{default_connect}",
                 "--dns-timeout=#{default_dns}",
                 "--read-timeout=#{read_timeout}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst", "--no-check-certificate"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, nil, nil).command
   end
@@ -57,7 +68,10 @@ class HttpDownloadsTest < Test::Unit::TestCase
                 "--connect-timeout=#{default_connect}",
                 "--dns-timeout=#{default_dns}",
                 "--read-timeout=#{read_timeout}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, nil, nil, true).command
   end
@@ -67,10 +81,14 @@ class HttpDownloadsTest < Test::Unit::TestCase
     connect_timeout = 99
     dns_timeout = 27
     expected = ["/wget",
+                "--no-check-certificate",
                 "--connect-timeout=#{connect_timeout}",
                 "--dns-timeout=#{dns_timeout}",
                 "--read-timeout=#{read_timeout}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst", "--no-check-certificate"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, connect_timeout, dns_timeout).command
   end
@@ -83,7 +101,10 @@ class HttpDownloadsTest < Test::Unit::TestCase
                 "--connect-timeout=#{connect_timeout}",
                 "--dns-timeout=#{dns_timeout}",
                 "--read-timeout=#{read_timeout}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, connect_timeout, dns_timeout, true).command
   end


### PR DESCRIPTION
With CentOS 8 Stream this is a more painful issue, I was planning rewriting this code but there is no time - let's change -c to --timestamping --no-if-modified-since. This will keep the current behavior - if a file is present and the same size and its timestamp matches what server reports, do not redownload it. If it's different, redownload it from the beginning - no longer attempt to continue and append.

The second option `--no-if-modified-since` makes `wget` to request the timestamp via HEAD HTTP call instead of If-Modified-Since because not all mirrors support this option:

```
$ LC_ALL=C wget --timestamping --no-if-modified-since http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz
--2021-02-09 15:02:49--  http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz
Resolving mirror.centos.org (mirror.centos.org)... 95.216.19.148, 2a00:1dc0:3061::10
Connecting to mirror.centos.org (mirror.centos.org)|95.216.19.148|:80... connected.
HTTP request sent, awaiting response... 200 OK
Length: 9936008 (9.5M)
Server file no newer than local file 'vmlinuz' -- not retrieving.

$ LC_ALL=C wget --timestamping http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz
--2021-02-09 15:02:55--  http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/images/pxeboot/vmlinuz
Resolving mirror.centos.org (mirror.centos.org)... 95.216.19.148, 2a00:1dc0:3061::10
Connecting to mirror.centos.org (mirror.centos.org)|95.216.19.148|:80... connected.
HTTP request sent, awaiting response... 304 Not Modified
File 'vmlinuz' not modified on server. Omitting download.

$ LC_ALL=C wget --timestamping http://ftp.sh.cvut.cz/centos/8-stream/BaseOS/x86_64/os/images/pxeboot/initrd.img
--2021-02-09 15:03:20--  http://ftp.sh.cvut.cz/centos/8-stream/BaseOS/x86_64/os/images/pxeboot/initrd.img
Resolving ftp.sh.cvut.cz (ftp.sh.cvut.cz)... 147.32.127.196, 2001:718:2::196
Connecting to ftp.sh.cvut.cz (ftp.sh.cvut.cz)|147.32.127.196|:80... connected.
HTTP request sent, awaiting response... 200 OK
Server ignored If-Modified-Since header for file 'initrd.img'.
You might want to add --no-if-modified-since option.
```