### PR TITLE
Fixes #32164 - skip IPv6 link local addresses in FQDN lookups

### DIFF
--- a/lib/proxy/helpers.rb
+++ b/lib/proxy/helpers.rb
@@ -83,6 +83,9 @@ module Proxy::Helpers
     ip = request.env['REMOTE_ADDR']
     log_halt 403, 'could not get remote address from environment' if ip.empty?
 
+    # IPv6 with NIC identifier are not resolved
+    return ip if ip.include?('%')
+
     begin
       dns = resolv
       fqdn = dns.getname(ip)


### PR DESCRIPTION
REMOTE_ADDR on IPv6 can contain %ident part with network interface identifier, this breaks our code.

I tried to pass this into IPAddr.new but Ruby does not understand the syntax, so I am proposing a dummy search and replace.