### PR TITLE
Fixes #32418,34552 - foreman request timeout config option

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -33,7 +33,11 @@
 # (default: true)
 #:forward_verify: true
 
+# URL to Foreman instance
 #:foreman_url: http://127.0.0.1:3000
+
+# Open, read, write HTTP(S) timeout (in seconds) for requests to Foreman
+#:foreman_http_timeout: 60
 
 # SSL settings for client authentication against Foreman. If undefined, the values
 # from general SSL options are used instead. Mainly useful when Foreman uses

--- a/lib/proxy/request.rb
+++ b/lib/proxy/request.rb
@@ -63,9 +63,13 @@ module Proxy::HttpRequest
     private
 
     def http_init
-      http             = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl     = uri.scheme == 'https'
+      http = Net::HTTP.new(uri.host, uri.port)
+      http.use_ssl = (uri.scheme == 'https')
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      http.open_timeout = Proxy::SETTINGS.foreman_http_timeout
+      http.ssl_timeout = Proxy::SETTINGS.foreman_http_timeout
+      http.read_timeout = Proxy::SETTINGS.foreman_http_timeout
+      http.write_timeout = Proxy::SETTINGS.foreman_http_timeout if http.respond_to?(:write_timeout)
 
       if http.use_ssl?
         ca_file = Proxy::SETTINGS.foreman_ssl_ca || Proxy::SETTINGS.ssl_ca_file

--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -19,6 +19,7 @@ module ::Proxy::Settings
       :ssl_disabled_ciphers => [],
       :tls_disabled_versions => [],
       :dns_resolv_timeouts => [5, 8, 13], # Ruby default is [5, 20, 40] which is a bit too much for us
+      :foreman_http_timeout => 60,
     }
 
     HOW_TO_NORMALIZE = {

--- a/modules/registration/registration_api.rb
+++ b/modules/registration/registration_api.rb
@@ -1,6 +1,8 @@
 require 'registration/proxy_request'
 
 class Proxy::Registration::Api < ::Sinatra::Base
+  include Proxy::Log
+
   get '/' do
     response = Proxy::Registration::ProxyRequest.new.global_register(request)
     handle_response(response)


### PR DESCRIPTION
It is set to the default 60 seconds with no way to override this.

I am going for a simple solution of setting multiple timeouts via a single setting. I am not sure if it is worth introducing all of them.