### PR TITLE
Fixes #32915 - accept strings as setting names

### DIFF
--- a/lib/proxy/settings.rb
+++ b/lib/proxy/settings.rb
@@ -16,7 +16,7 @@ module Proxy::Settings
   def self.load_plugin_settings(defaults, settings_file, settings_directory = nil)
     settings = {}
     begin
-      settings = YAML.load(File.read(File.join(settings_directory || ::Proxy::SETTINGS.settings_directory, settings_file))) || {}
+      settings = read_settings_file(settings_file, settings_directory)
     rescue Errno::ENOENT
       logger.warn("Couldn't find settings file #{settings_directory || ::Proxy::SETTINGS.settings_directory}/#{settings_file}. Using default settings.")
     end
@@ -24,6 +24,6 @@ module Proxy::Settings
   end
 
   def self.read_settings_file(settings_file, settings_directory = nil)
-    YAML.load(File.read(File.join(settings_directory || ::Proxy::SETTINGS.settings_directory, settings_file))) || {}
+    YAML.load(File.read(File.join(settings_directory || ::Proxy::SETTINGS.settings_directory, settings_file))).transform_keys(&:to_sym) || {}
   end
 end


### PR DESCRIPTION
I do not know why we use the super-weird :setting: "xyz" syntax but it is confusing. This is not a typical YAML. It is not a typical UNIX config. It's some kind of Ruby-YAML hybrid.

This patch converts all keys to symbols, we can do a followup puppet update and write all config files without the colons.