### PR TITLE
fixes #18069 - Add ip/mac Addr. validations (DHCP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ pkg/
 test/tmp/*
 /tmp/
 /vendor
+/1
+config/settings.d/host_report.yml.example

--- a/lib/proxy/validations.rb
+++ b/lib/proxy/validations.rb
@@ -1,8 +1,15 @@
+require 'ipaddr'
+require 'resolv'
+
 module Proxy::Validations
   MAC_REGEXP_48BIT = /\A([a-f0-9]{1,2}:){5}[a-f0-9]{1,2}\z/i
   MAC_REGEXP_64BIT = /\A([a-f0-9]{1,2}:){19}[a-f0-9]{1,2}\z/i
 
   class Error < RuntimeError; end
+  class InvalidIPAddress < Error; end
+  class InvalidMACAddress < Error; end
+  class InvalidSubnet < Error; end
+
   private
 
   def valid_mac?(mac)
@@ -11,20 +18,36 @@ module Proxy::Validations
     false
   end
 
+  def valid_ip?(ip)
+    valid_ip4?(ip) || valid_ip6?(ip)
+  end
+
+  def valid_ip4?(ip)
+    Resolv::IPv4::Regex.match?(ip)
+  end
+
+  def valid_ip6?(ip)
+    Resolv::IPv6::Regex.match?(ip)
+  end
+
   # validates the ip address
-  def validate_ip(ip)
-    raise Error, "Invalid IP Address #{ip}" unless ip =~ /(\d{1,3}\.){3}\d{1,3}/
+  def validate_ip(ip, version = nil)
+    valid = false
+    valid = valid_ip4?(ip) if version == 4
+    valid = valid_ip6?(ip) if version == 6
+    valid = valid_ip?(ip) if version.nil?
+    raise InvalidIPAddress, "Invalid IP Address #{ip}" unless valid
     ip
   end
 
   # validates the mac
   def validate_mac(mac)
-    raise Error, "Invalid MAC #{mac}" unless valid_mac?(mac)
+    raise InvalidMACAddress, "Invalid MAC #{mac}" unless valid_mac?(mac)
     mac.downcase
   end
 
   def validate_subnet(subnet)
-    raise Error, "Invalid Subnet #{subnet}" unless subnet.is_a?(Proxy::DHCP::Subnet)
+    raise InvalidSubnet, "Invalid Subnet #{subnet}" unless subnet.is_a?(Proxy::DHCP::Subnet)
     subnet
   end
 

--- a/modules/dhcp_common/isc/omapi_provider.rb
+++ b/modules/dhcp_common/isc/omapi_provider.rb
@@ -14,6 +14,12 @@ module Proxy::DHCP::CommonISC
       @omapi_port = omapi_port
     end
 
+    def validate_supported_address(*args)
+      args.each do |ip|
+        validate_ip(ip, 4)
+      end
+    end
+
     def del_record(record)
       validate_record record
       raise InvalidRecord, "#{record} is static - unable to delete" unless record.deleteable?

--- a/modules/dhcp_common/server.rb
+++ b/modules/dhcp_common/server.rb
@@ -29,6 +29,10 @@ module Proxy::DHCP
                          end
     end
 
+    def validate_supported_address(ip)
+      validate_ip(ip)
+    end
+
     def subnets
       service.all_subnets
     end
@@ -132,7 +136,6 @@ module Proxy::DHCP
 
       name, ip_address, mac_address, subnet_address, options = clean_up_add_record_parameters(options)
 
-      validate_ip(ip_address)
       validate_mac(mac_address)
       raise(Proxy::DHCP::Error, "Must provide hostname") unless name
 

--- a/modules/dhcp_libvirt/dhcp_libvirt_main.rb
+++ b/modules/dhcp_libvirt/dhcp_libvirt_main.rb
@@ -8,6 +8,12 @@ module Proxy::DHCP::Libvirt
       super(@network, nil, subnet_service, free_ips_service)
     end
 
+    def validate_supported_address(*args)
+      args.each do |ip|
+        validate_ip(ip, 4)
+      end
+    end
+
     def add_record(options = {})
       record = super(options)
       libvirt_network.add_dhcp_record record

--- a/modules/dhcp_native_ms/dhcp_native_ms_main.rb
+++ b/modules/dhcp_native_ms/dhcp_native_ms_main.rb
@@ -13,6 +13,12 @@ module Proxy::DHCP::NativeMS
       @free_ips = free_ips_service
     end
 
+    def validate_supported_address(*args)
+      args.each do |ip|
+        validate_ip(ip, 4)
+      end
+    end
+
     def del_record(record)
       logger.debug "Deleting '#{record}'"
       if record.is_a?(::Proxy::DHCP::Reservation)
@@ -25,8 +31,6 @@ module Proxy::DHCP::NativeMS
     def add_record(options)
       name, ip_address, mac_address, subnet_address, options = clean_up_add_record_parameters(options)
 
-      validate_ip(ip_address)
-      validate_mac(mac_address)
       subnet = retrieve_subnet_from_server(subnet_address)
 
       create_reservation(ip_address, subnet.netmask, mac_address, name)

--- a/test/dhcp/dhcp_api_test.rb
+++ b/test/dhcp/dhcp_api_test.rb
@@ -23,6 +23,7 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def setup
     @server = Object.new
+    @server.stubs(:validate_supported_address).returns(true)
 
     @subnets = [
       Proxy::DHCP::Subnet.new("192.168.122.0", "255.255.255.0", "routers" => ["192.168.122.250"]),
@@ -71,6 +72,7 @@ class DhcpApiTest < Test::Unit::TestCase
   end
 
   def test_get_network
+    @server.expects(:validate_supported_address).returns(true)
     @server.expects(:all_hosts).with(@subnet.network).returns(@reservations)
     @server.expects(:all_leases).with(@subnet.network).returns(@leases)
 
@@ -87,11 +89,13 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_get_network_for_non_existent_network
     @server.expects(:all_hosts).raises(::Proxy::DHCP::SubnetNotFound)
+    @server.expects(:validate_supported_address).returns(true)
     get "/192.168.122.0"
     assert_equal 404, last_response.status
   end
 
   def test_get_network_unused_ip
+    @server.expects(:validate_supported_address).returns(true)
     @server.expects(:unused_ip).with('192.168.122.0', "01:02:03:04:05:06", "192.168.122.10", "192.168.122.20").returns("192.168.122.11")
     get "/192.168.122.0/unused_ip?mac=01:02:03:04:05:06&from=192.168.122.10&to=192.168.122.20"
 
@@ -100,12 +104,14 @@ class DhcpApiTest < Test::Unit::TestCase
   end
 
   def test_get_unused_ip_for_nonexistent_network
+    @server.expects(:validate_supported_address).returns(true)
     @server.expects(:unused_ip).with('192.168.122.0', "01:02:03:04:05:06", "192.168.122.10", "192.168.122.20").raises(::Proxy::DHCP::SubnetNotFound)
     get "/192.168.122.0/unused_ip?mac=01:02:03:04:05:06&from=192.168.122.10&to=192.168.122.20"
     assert_equal 404, last_response.status
   end
 
   def test_get_unused_when_not_inmplemented
+    @server.expects(:validate_supported_address).returns(true)
     @server.expects(:unused_ip).raises(::Proxy::DHCP::NotImplemented)
     get "/192.168.122.0/unused_ip?mac=01:02:03:04:05:06&from=192.168.122.10&to=192.168.122.20"
     assert_equal 501, last_response.status
@@ -139,6 +145,7 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_get_reservation_record_by_ip
     @server.expects(:find_records_by_ip).with("192.168.122.0", "192.168.122.1").returns([@reservations.first])
+    @server.expects(:validate_supported_address).returns(true)
 
     get "/192.168.122.0/ip/192.168.122.1"
 
@@ -156,6 +163,7 @@ class DhcpApiTest < Test::Unit::TestCase
   end
 
   def test_get_lease_record_by_ip
+    @server.expects(:validate_supported_address).returns(true)
     @server.expects(:find_records_by_ip).with("192.168.122.0", "192.168.122.1").returns([@leases.first])
 
     get "/192.168.122.0/ip/192.168.122.1"
@@ -177,18 +185,21 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_get_record_by_ip_for_nonexistent_ip
     @server.expects(:find_records_by_ip).with("192.168.122.0", "192.168.122.1").returns([])
+    @server.expects(:validate_supported_address).returns(true)
     get "/192.168.122.0/ip/192.168.122.1"
     assert_equal 404, last_response.status
   end
 
   def test_get_record_by_ip_for_nonexistent_network
     @server.expects(:find_records_by_ip).with("192.168.122.0", "192.168.122.1").raises(::Proxy::DHCP::SubnetNotFound)
+    @server.expects(:validate_supported_address).returns(true)
     get "/192.168.122.0/ip/192.168.122.1"
     assert_equal 404, last_response.status
   end
 
   def test_get_record_by_mac
     @server.expects(:find_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee").returns(@reservations.first)
+    @server.expects(:validate_supported_address).returns(true)
 
     get "/192.168.122.0/mac/00:11:bb:cc:dd:ee"
 
@@ -207,6 +218,7 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_get_record_by_mac_64
     @server.expects(:find_record_by_mac).with("192.168.122.0", "80:00:02:08:fe:80:00:00:00:00:00:00:00:02:aa:bb:cc:dd:ee:ff").returns(@leases.last)
+    @server.expects(:validate_supported_address).returns(true)
 
     get "/192.168.122.0/mac/80:00:02:08:fe:80:00:00:00:00:00:00:00:02:aa:bb:cc:dd:ee:ff"
 
@@ -226,6 +238,7 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_get_record_by_mac_uppercase
     @server.expects(:find_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee").returns(@reservations.first)
+    @server.expects(:validate_supported_address).returns(true)
 
     get "/192.168.122.0/mac/00:11:BB:CC:DD:EE"
 
@@ -244,12 +257,14 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_get_record_by_mac_for_nonexistent_mac
     @server.expects(:find_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee").returns(nil)
+    @server.expects(:validate_supported_address).returns(true)
     get "/192.168.122.0/mac/00:11:bb:cc:dd:ee"
     assert_equal 404, last_response.status
   end
 
   def test_get_record_by_mac_for_nonexistent_network
     @server.expects(:find_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee").raises(::Proxy::DHCP::SubnetNotFound)
+    @server.expects(:validate_supported_address).returns(true)
     get "/192.168.122.0/mac/00:11:bb:cc:dd:ee"
     assert_equal 404, last_response.status
   end
@@ -262,6 +277,7 @@ class DhcpApiTest < Test::Unit::TestCase
       "mac"        => "00:11:bb:cc:dd:ee",
       "network"    => "192.168.122.0",
     }
+    @server.expects(:validate_supported_address).returns(true)
     @server.expects(:add_record).raises(Proxy::DHCP::Collision)
 
     post "/192.168.122.0", params
@@ -276,6 +292,7 @@ class DhcpApiTest < Test::Unit::TestCase
       "mac"       => "00:11:bb:cc:dd:ee",
       "network"   => "192.168.122.0",
     }
+    @server.expects(:validate_supported_address).returns(true)
     @server.expects(:add_record).raises(Proxy::DHCP::AlreadyExists)
 
     post "/192.168.122.0", params
@@ -290,6 +307,7 @@ class DhcpApiTest < Test::Unit::TestCase
       "mac"      => "10:10:10:10:10:10",
       "network"  => "192.168.122.0",
     }
+    @server.expects(:validate_supported_address).returns(true)
     @server.expects(:add_record).with { |params| record.all? { |k_v| params[k_v[0]] == k_v[1] } }
 
     post "/192.168.122.0", record
@@ -298,6 +316,7 @@ class DhcpApiTest < Test::Unit::TestCase
   end
 
   def test_sparc_host_creation
+    @server.expects(:validate_supported_address).returns(true)
     @server.expects(:add_record).with() { |params| sparc_attrs.all? { |k_v| params[k_v[0]] == k_v[1] } }
 
     post '/192.168.122.0', sparc_attrs
@@ -316,6 +335,7 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_delete_records_by_ip
     @server.expects(:del_records_by_ip).with("192.168.122.0", "192.168.122.1")
+    @server.expects(:validate_supported_address).returns(true)
     delete "/192.168.122.0/ip/192.168.122.1"
     assert_equal 200, last_response.status
     assert_empty last_response.body
@@ -323,6 +343,7 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_delete_records_by_ip_for_nonexistent_subnet
     @server.expects(:del_records_by_ip).with("192.168.122.0", "192.168.122.1").raises(::Proxy::DHCP::SubnetNotFound)
+    @server.expects(:validate_supported_address).returns(true)
     delete "/192.168.122.0/ip/192.168.122.1"
     assert_equal 200, last_response.status
     assert_empty last_response.body
@@ -330,6 +351,7 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_delete_records_by_mac
     @server.expects(:del_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee")
+    @server.expects(:validate_supported_address).returns(true)
     delete "/192.168.122.0/mac/00:11:bb:cc:dd:ee"
     assert_equal 200, last_response.status
     assert_empty last_response.body
@@ -337,6 +359,7 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_delete_records_by_mac_uppercase
     @server.expects(:del_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee")
+    @server.expects(:validate_supported_address).returns(true)
     delete "/192.168.122.0/mac/00:11:BB:CC:DD:EE"
     assert_equal 200, last_response.status
     assert_empty last_response.body
@@ -344,6 +367,8 @@ class DhcpApiTest < Test::Unit::TestCase
 
   def test_delete_records_by_mac_for_nonexistent_subnet
     @server.expects(:del_record_by_mac).with("192.168.122.0", "00:11:bb:cc:dd:ee").raises(::Proxy::DHCP::SubnetNotFound)
+    @server.expects(:validate_supported_address).returns(true)
+
     delete "/192.168.122.0/mac/00:11:bb:cc:dd:ee"
     assert_equal 200, last_response.status
     assert_empty last_response.body

--- a/test/dhcp/record_test.rb
+++ b/test/dhcp/record_test.rb
@@ -9,7 +9,7 @@ require 'dhcp_common/record/lease'
 class Proxy::DHCPRecordTest < Test::Unit::TestCase
   def setup
     @subnet = Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0")
-    @ip = "123.321.123.321"
+    @ip = "123.255.123.255"
     @mac = "aa:bb:CC:dd:ee:ff"
     @record = Proxy::DHCP::Record.new(@ip, @mac, @subnet)
   end
@@ -26,7 +26,7 @@ class Proxy::DHCPRecordTest < Test::Unit::TestCase
 
   def test_should_not_save_invalid_ip_addresses
     ip = "1..1.1"
-    assert_raise(Proxy::Validations::Error) { Proxy::DHCP::Record.new(ip, @mac, @subnet) }
+    assert_raise(Proxy::Validations::InvalidIPAddress) { Proxy::DHCP::Record.new(ip, @mac, @subnet) }
   end
 
   def test_mac_should_be_saved_lower_case
@@ -36,11 +36,11 @@ class Proxy::DHCPRecordTest < Test::Unit::TestCase
   end
 
   def test_should_not_save_invalid_mac
-    assert_raise(Proxy::Validations::Error) { Proxy::DHCP::Record.new(@ip, "XYZxxVVcc123", @subnet) }
+    assert_raise(Proxy::Validations::InvalidMACAddress) { Proxy::DHCP::Record.new(@ip, "XYZxxVVcc123", @subnet) }
   end
 
   def test_should_not_save_invalid_subnets
-    assert_raise(Proxy::Validations::Error) { Proxy::DHCP::Record.new(@ip, @mac, nil) }
+    assert_raise(Proxy::Validations::InvalidSubnet) { Proxy::DHCP::Record.new(@ip, @mac, nil) }
   end
 
   def test_equality

--- a/test/dhcp/subnet_test.rb
+++ b/test/dhcp/subnet_test.rb
@@ -14,22 +14,22 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
   end
 
   def test_should_not_save_invalid_network_addresses
-    assert_raise Proxy::Validations::Error do
+    assert_raise Proxy::Validations::InvalidIPAddress do
       Proxy::DHCP::Subnet.new("1..1.1", @netmask)
     end
   end
 
   def test_should_not_save_invalid_router_addresses
-    assert_raise Proxy::Validations::Error do
+    assert_raise Proxy::Validations::InvalidIPAddress do
       Proxy::DHCP::Subnet.new(@network, @netmask, :routers => ["192.168..1"])
     end
   end
 
   def test_should_not_save_invalid_range
-    assert_raise Proxy::Validations::Error do
+    assert_raise Proxy::Validations::InvalidIPAddress do
       Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.0..", "192.168.0.50"])
     end
-    assert_raise Proxy::Validations::Error do
+    assert_raise Proxy::Validations::InvalidIPAddress do
       Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.0.3", "192.168.0.."])
     end
     assert_raise Proxy::DHCP::Error do
@@ -45,7 +45,7 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
 
   def test_should_not_save_invalid_netmask
     netmask = "XYZxxVVcc123"
-    assert_raise Proxy::Validations::Error do
+    assert_raise Proxy::Validations::InvalidIPAddress do
       Proxy::DHCP::Subnet.new(@network, netmask)
     end
   end

--- a/test/validations_test.rb
+++ b/test/validations_test.rb
@@ -21,11 +21,19 @@ class ProxyValidationsTest < Test::Unit::TestCase
     assert_equal "192.168.1.1", validate_ip("192.168.1.1")
   end
 
+  def test_should_validate_ip4
+    assert_equal "172.16.10.1", validate_ip("172.16.10.1", 4)
+  end
+
+  def test_should_validate_ip6
+    assert_equal "2001:db8::8:800:200c:417a", validate_ip("2001:db8::8:800:200c:417a", 6)
+  end
+
   def test_should_not_return_invalid_ip
-    assert_raise Error do
+    assert_raise InvalidIPAddress do
       validate_ip "192.168.1"
     end
-    assert_raise Error do
+    assert_raise InvalidIPAddress do
       validate_ip "192.168.1.i"
     end
   end
@@ -45,10 +53,10 @@ class ProxyValidationsTest < Test::Unit::TestCase
   end
 
   def test_should_not_return_invalid_mac
-    assert_raise Error do
+    assert_raise InvalidMACAddress do
       validate_mac "aa:bb:cc:00:11:22:33"
     end
-    assert_raise Error do
+    assert_raise InvalidMACAddress do
       validate_mac "aa:bb:cc:00:11:zz"
     end
   end


### PR DESCRIPTION
Add ip and mac address validations to api endpoints in dhcp api controller

Reporting an invalid mac or ip address for easier troubleshooting. I also made the Error class more self-describing, it should not be used anywhere else in the project now. I am not sure if I should have changed the MAC validation. From what I know, there is no other option than regex and it did work so far so I left it as it was.