### PR TITLE
Fixes #33356 - APP_ROOT defined for tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ pkg/
 test/tmp/*
 /tmp/
 /vendor
+/data/*

--- a/data/README
+++ b/data/README
@@ -1,0 +1,6 @@
+This directory is reserved for data in development mode. To access it, use
+DATA_DIR constant. Plugins should create subdirectories within the directory.
+
+The constant is set to /var/lib/foreman-proxy, if such directory exists.
+Otherwise this directory is used. When running tests, DATA_DIR is set to
+../tmp/data.

--- a/lib/smart_proxy_for_testing.rb
+++ b/lib/smart_proxy_for_testing.rb
@@ -26,6 +26,10 @@ require 'launcher'
 require 'sinatra/base'
 require 'sinatra/authorization'
 
+APP_ROOT = File.absolute_path(File.expand_path("#{__dir__}/.."))
+DATA_ROOT = File.absolute_path(File.expand_path("#{__dir__}/../tmp/data"))
+FileUtils.mkdir_p(DATA_ROOT) unless Dir.exist?(DATA_ROOT)
+
 Proxy::SETTINGS = ::Proxy::Settings::Global.new(:log_file => './logs/test.log', :log_level => 'DEBUG')
 Proxy::VERSION = File.read(File.join(__dir__, '..', 'VERSION')).chomp
 

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -1,4 +1,9 @@
-APP_ROOT = "#{__dir__}/.."
+APP_ROOT = File.absolute_path(File.expand_path("#{__dir__}/.."))
+if Dir.exist?('/var/lib/foreman-proxy')
+  DATA_ROOT = '/var/lib/foreman-proxy'
+else
+  DATA_ROOT = File.absolute_path(File.expand_path("#{__dir__}/../data"))
+end
 
 require 'smart_proxy'
 require 'launcher'


### PR DESCRIPTION
OpenSCAP plugin class requires this to be defined, tests do fail when openscap plugin is enabled.