### PR TITLE
Fixes #2412 - don't continue wget downloads (CP 3.0)

### DIFF
--- a/lib/proxy/http_download.rb
+++ b/lib/proxy/http_download.rb
@@ -14,11 +14,15 @@ module Proxy
       dns_timeout ||= DEFAULT_CONNECT_TIMEOUT
       connect_timeout ||= DEFAULT_DNS_TIMEOUT
 
-      args = [wget, "--connect-timeout=#{connect_timeout}",
+      args = ["--connect-timeout=#{connect_timeout}",
               "--dns-timeout=#{dns_timeout}",
               "--read-timeout=#{read_timeout}",
-              "--tries=3", "-nv", "-c", src.to_s, "-O", dst.to_s]
-      args << "--no-check-certificate" unless verify_server_cert
+              "--tries=3",
+              "--timestamping", # turn on timestamping to prevent redownloads
+              "--no-if-modified-since", # but use HTTP HEAD instead If-Modified-Since
+              "-nv", src.to_s, "-O", dst.to_s]
+      args.unshift("--no-check-certificate") unless verify_server_cert
+      args.unshift(wget)
       super(args)
     end
 

--- a/lib/proxy/plugin_initializer.rb
+++ b/lib/proxy/plugin_initializer.rb
@@ -114,7 +114,7 @@ class ::Proxy::PluginGroup
   end
 
   def fail_group(an_exception)
-    fail_group_with_message("Disabling all modules in the group #{printable_module_names(member_names)} due to a failure in one of them: #{an_exception}", an_exception.backtrace)
+    fail_group_with_message("Disabling all modules in the group #{printable_module_names(member_names)} due to a failure in one of them: #{an_exception}", an_exception)
   end
 
   def fail_group_with_message(a_message, an_exception = nil)

--- a/test/http_download_test.rb
+++ b/test/http_download_test.rb
@@ -12,10 +12,14 @@ class HttpDownloadsTest < Test::Unit::TestCase
     default_dns = Proxy::HttpDownload::DEFAULT_DNS_TIMEOUT
 
     expected = ["/wget",
+                "--no-check-certificate",
                 "--connect-timeout=#{default_connect}",
                 "--dns-timeout=#{default_dns}",
                 "--read-timeout=#{default_read}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst", "--no-check-certificate"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst').command
   end
@@ -29,7 +33,10 @@ class HttpDownloadsTest < Test::Unit::TestCase
                 "--connect-timeout=#{default_connect}",
                 "--dns-timeout=#{default_dns}",
                 "--read-timeout=#{default_read}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', nil, nil, nil, true).command
   end
@@ -40,10 +47,14 @@ class HttpDownloadsTest < Test::Unit::TestCase
 
     read_timeout = 1000
     expected = ["/wget",
+                "--no-check-certificate",
                 "--connect-timeout=#{default_connect}",
                 "--dns-timeout=#{default_dns}",
                 "--read-timeout=#{read_timeout}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst", "--no-check-certificate"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, nil, nil).command
   end
@@ -57,7 +68,10 @@ class HttpDownloadsTest < Test::Unit::TestCase
                 "--connect-timeout=#{default_connect}",
                 "--dns-timeout=#{default_dns}",
                 "--read-timeout=#{read_timeout}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, nil, nil, true).command
   end
@@ -67,10 +81,14 @@ class HttpDownloadsTest < Test::Unit::TestCase
     connect_timeout = 99
     dns_timeout = 27
     expected = ["/wget",
+                "--no-check-certificate",
                 "--connect-timeout=#{connect_timeout}",
                 "--dns-timeout=#{dns_timeout}",
                 "--read-timeout=#{read_timeout}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst", "--no-check-certificate"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, connect_timeout, dns_timeout).command
   end
@@ -83,7 +101,10 @@ class HttpDownloadsTest < Test::Unit::TestCase
                 "--connect-timeout=#{connect_timeout}",
                 "--dns-timeout=#{dns_timeout}",
                 "--read-timeout=#{read_timeout}",
-                "--tries=3", "-nv", "-c", "src", "-O", "dst"]
+                "--tries=3",
+                "--timestamping",
+                "--no-if-modified-since",
+                "-nv", "src", "-O", "dst"]
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, connect_timeout, dns_timeout, true).command
   end


### PR DESCRIPTION
(cherry picked from commit b94c9b07a78fc8c4eb382eb574b28eed48001d25)