### PR TITLE
Refs #2412 - use curl for downloads

### DIFF
--- a/config/settings.d/tftp.yml.example
+++ b/config/settings.d/tftp.yml.example
@@ -6,17 +6,9 @@
 # Defines the TFTP Servername to use, overrides the name in the subnet declaration
 #:tftp_servername: tftp.domain.com
 
-# Defines the default read timeout in seconds needed to download tftp artifacts
-# like initrd and vmlinuz. Default value 60 seconds
-#:tftp_read_timeout: 60
-
 # Defines the default connection timeout in seconds needed to download tftp artifacts
 # like initrd and vmlinuz. Default value 10 seconds
 #:tftp_connect_timeout: 10
-
-# Defines the default dns timeout in seconds needed to download tftp artifacts
-# like initrd and vmlinuz. Default value 10 seconds
-#:tftp_dns_timeout: 10
 
 # Defines the default certificate action for certificate checking.
 # When false, the argument --no-check-certificate will be used.

--- a/lib/proxy/http_download.rb
+++ b/lib/proxy/http_download.rb
@@ -3,35 +3,57 @@ require 'proxy/file_lock'
 module Proxy
   class HttpDownload < Proxy::Util::CommandTask
     include Util
-    DEFAULT_READ_TIMEOUT = 60
     DEFAULT_CONNECT_TIMEOUT = 10
-    DEFAULT_DNS_TIMEOUT = 10
 
     def initialize(src, dst, read_timeout = nil, connect_timeout = nil, dns_timeout = nil, verify_server_cert = false)
       @dst = dst
-      wget = which("wget")
-      read_timeout ||= DEFAULT_READ_TIMEOUT
-      dns_timeout ||= DEFAULT_CONNECT_TIMEOUT
-      connect_timeout ||= DEFAULT_DNS_TIMEOUT
+      logger.warn('Deprecated: HttpDownload read_timeout is deprecated and will be removed in 4.0') if read_timeout
+      logger.warn('Deprecated: HttpDownload dns_timeout is deprecated and will be removed in 4.0') if dns_timeout
+      connect_timeout ||= DEFAULT_CONNECT_TIMEOUT
+      args = [which('curl')]
 
-      args = ["--connect-timeout=#{connect_timeout}",
-              "--dns-timeout=#{dns_timeout}",
-              "--read-timeout=#{read_timeout}",
-              "--tries=3",
-              "--timestamping", # turn on timestamping to prevent redownloads
-              "--no-if-modified-since", # but use HTTP HEAD instead If-Modified-Since
-              "-nv", src.to_s, "-O", dst.to_s]
-      args.unshift("--no-check-certificate") unless verify_server_cert
-      args.unshift(wget)
+      # no cert verification if set
+      args << "--insecure" unless verify_server_cert
+      # print nothing
+      args << "--silent"
+      # except errors
+      args << "--show-error"
+      # timeout (others were supported by wget but not by curl)
+      args += ["--connect-timeout", connect_timeout.to_s]
+      # try several times
+      args += ["--retry", "3"]
+      # with a short delay
+      args += ["--retry-delay", "10"]
+      # but exit after one hour
+      args += ["--max-time", "3600"]
+      # keep last changed file attribute
+      args << "--remote-time"
+      # only download newer files
+      args += ["--time-cond", dst.to_s]
+      # print stats in the end
+      args += [
+        "--write-out",
+        'Task done, result: %{http_code}, size downloaded: %{size_download}b, speed: %{speed_download}b/s, time: %{time_total}ms',
+      ]
+      # output file
+      args += ["--output", dst.to_s]
+      # follow redirects
+      args << "--location"
+      # and the url to download
+      args << src.to_s
+
       super(args)
     end
 
     def start
-      lock = Proxy::FileLock.try_locking(@dst)
+      lock = Proxy::FileLock.try_locking(File.join(File.dirname(@dst), ".#{File.basename(@dst)}.lock"))
       if lock.nil?
         false
       else
-        super { Proxy::FileLock.unlock(lock) }
+        super do
+          Proxy::FileLock.unlock(lock)
+          File.unlink(lock)
+        end
       end
     end
   end

--- a/lib/proxy/util.rb
+++ b/lib/proxy/util.rb
@@ -23,7 +23,8 @@ module Proxy::Util
       @task = Thread.new(@command, @input) do |cmd, input|
         status = nil
         Open3.popen3(*cmd) do |stdin, stdout, stderr, thr|
-          logger.info "[#{thr.pid}] Started task #{cmd}"
+          cmdline_string = Shellwords.escape(cmd.is_a?(Array) ? cmd.join(' ') : cmd)
+          logger.info "[#{thr.pid}] Started task #{cmdline_string}"
           stdin.write(input) if input
           stdin.close
           stdout.each do |line|

--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -167,9 +167,9 @@ module Proxy::TFTP
     when 'http', 'https', 'ftp'
       ::Proxy::HttpDownload.new(src.to_s,
                                 destination.to_s,
-                                Proxy::TFTP::Plugin.settings.tftp_read_timeout,
+                                nil,
                                 Proxy::TFTP::Plugin.settings.tftp_connect_timeout,
-                                Proxy::TFTP::Plugin.settings.tftp_dns_timeout,
+                                nil,
                                 Proxy::TFTP::Plugin.settings.verify_server_cert).start
 
     when 'nfs'

--- a/modules/tftp/tftp_plugin.rb
+++ b/modules/tftp/tftp_plugin.rb
@@ -5,9 +5,7 @@ module Proxy::TFTP
     rackup_path File.expand_path("http_config.ru", __dir__)
 
     default_settings :tftproot => '/var/lib/tftpboot',
-                     :tftp_read_timeout => 60,
                      :tftp_connect_timeout => 10,
-                     :tftp_dns_timeout => 10,
                      :verify_server_cert => true
 
     expose_setting :tftp_servername

--- a/test/http_download_test.rb
+++ b/test/http_download_test.rb
@@ -2,117 +2,33 @@ require 'test_helper'
 require 'tmpdir'
 
 class HttpDownloadsTest < Test::Unit::TestCase
-  def tmp(name)
-    File.join(Dir.tmpdir(), "http-download-#{name}.tmp")
+  def setup
+    @timeout = Proxy::HttpDownload::DEFAULT_CONNECT_TIMEOUT
+    Proxy::HttpDownload.any_instance.stubs(:which).returns('/usr/bin/curl')
   end
 
-  def test_should_construct_escaped_wget_command
-    default_read = Proxy::HttpDownload::DEFAULT_READ_TIMEOUT
-    default_connect = Proxy::HttpDownload::DEFAULT_CONNECT_TIMEOUT
-    default_dns = Proxy::HttpDownload::DEFAULT_DNS_TIMEOUT
-
-    expected = ["/wget",
-                "--no-check-certificate",
-                "--connect-timeout=#{default_connect}",
-                "--dns-timeout=#{default_dns}",
-                "--read-timeout=#{default_read}",
-                "--tries=3",
-                "--timestamping",
-                "--no-if-modified-since",
-                "-nv", "src", "-O", "dst"]
-    Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
+  def test_regular_call
+    expected = [
+      "/usr/bin/curl",
+      "--insecure",
+      "--silent", "--show-error",
+      "--connect-timeout", "10",
+      "--retry", "3",
+      "--retry-delay", "10",
+      "--max-time", "3600",
+      "--remote-time",
+      "--time-cond", "dst",
+      "--write-out", "Task done, result: %{http_code}, size downloaded: %{size_download}b, speed: %{speed_download}b/s, time: %{time_total}ms",
+      "--output", "dst",
+      "--location", "src"
+    ]
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst').command
   end
 
-  def test_should_construct_escaped_wget_command_true
-    default_read = Proxy::HttpDownload::DEFAULT_READ_TIMEOUT
-    default_connect = Proxy::HttpDownload::DEFAULT_CONNECT_TIMEOUT
-    default_dns = Proxy::HttpDownload::DEFAULT_DNS_TIMEOUT
-
-    expected = ["/wget",
-                "--connect-timeout=#{default_connect}",
-                "--dns-timeout=#{default_dns}",
-                "--read-timeout=#{default_read}",
-                "--tries=3",
-                "--timestamping",
-                "--no-if-modified-since",
-                "-nv", "src", "-O", "dst"]
-    Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
-    assert_equal expected, Proxy::HttpDownload.new('src', 'dst', nil, nil, nil, true).command
-  end
-
-  def test_should_construct_escaped_wget_command_only_read
-    default_connect = Proxy::HttpDownload::DEFAULT_CONNECT_TIMEOUT
-    default_dns = Proxy::HttpDownload::DEFAULT_DNS_TIMEOUT
-
-    read_timeout = 1000
-    expected = ["/wget",
-                "--no-check-certificate",
-                "--connect-timeout=#{default_connect}",
-                "--dns-timeout=#{default_dns}",
-                "--read-timeout=#{read_timeout}",
-                "--tries=3",
-                "--timestamping",
-                "--no-if-modified-since",
-                "-nv", "src", "-O", "dst"]
-    Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
-    assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, nil, nil).command
-  end
-
-  def test_should_construct_escaped_wget_command_only_read_true
-    default_connect = Proxy::HttpDownload::DEFAULT_CONNECT_TIMEOUT
-    default_dns = Proxy::HttpDownload::DEFAULT_DNS_TIMEOUT
-
-    read_timeout = 1000
-    expected = ["/wget",
-                "--connect-timeout=#{default_connect}",
-                "--dns-timeout=#{default_dns}",
-                "--read-timeout=#{read_timeout}",
-                "--tries=3",
-                "--timestamping",
-                "--no-if-modified-since",
-                "-nv", "src", "-O", "dst"]
-    Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
-    assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, nil, nil, true).command
-  end
-
-  def test_should_construct_escaped_wget_command_all_timeout_options
-    read_timeout = 1000
-    connect_timeout = 99
-    dns_timeout = 27
-    expected = ["/wget",
-                "--no-check-certificate",
-                "--connect-timeout=#{connect_timeout}",
-                "--dns-timeout=#{dns_timeout}",
-                "--read-timeout=#{read_timeout}",
-                "--tries=3",
-                "--timestamping",
-                "--no-if-modified-since",
-                "-nv", "src", "-O", "dst"]
-    Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
-    assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, connect_timeout, dns_timeout).command
-  end
-
-  def test_should_construct_escaped_wget_command_all_timeout_options_true
-    read_timeout = 1000
-    connect_timeout = 99
-    dns_timeout = 27
-    expected = ["/wget",
-                "--connect-timeout=#{connect_timeout}",
-                "--dns-timeout=#{dns_timeout}",
-                "--read-timeout=#{read_timeout}",
-                "--tries=3",
-                "--timestamping",
-                "--no-if-modified-since",
-                "-nv", "src", "-O", "dst"]
-    Proxy::HttpDownload.any_instance.stubs(:which).returns('/wget')
-    assert_equal expected, Proxy::HttpDownload.new('src', 'dst', read_timeout, connect_timeout, dns_timeout, true).command
-  end
-
   def test_should_skip_download_if_one_is_in_progress
-    locked = Proxy::FileLock.try_locking(tmp('other'))
-    assert_equal false, Proxy::HttpDownload.new('src', locked.path).start
-  ensure
-    File.delete(locked.path)
+    Dir.mktmpdir do |tmpdir|
+      Proxy::FileLock.try_locking("#{tmpdir}/.dst.lock")
+      assert_equal false, Proxy::HttpDownload.new('src', "#{tmpdir}/dst").start
+    end
   end
 end

--- a/test/tftp/tftp_test.rb
+++ b/test/tftp/tftp_test.rb
@@ -57,38 +57,18 @@ class TftpTest < Test::Unit::TestCase
     end
   end
 
-  def test_choose_protocol_and_fetch_wget_with_timeouts
+  def test_choose_protocol_and_fetch_wget_with_timeout
     src = "https://proxy.test"
     dst = "/destination"
-    tftp_read_timeout = "1000"
     tftp_connect_timeout = "40"
-    tftp_dns_timeout = "14300"
     verify_server_cert = false
     Proxy::TFTP::Plugin.load_test_settings(
-      :tftp_read_timeout => tftp_read_timeout,
       :tftp_connect_timeout => tftp_connect_timeout,
-      :tftp_dns_timeout => tftp_dns_timeout,
       :verify_server_cert => verify_server_cert
     )
 
     ::Proxy::HttpDownload.expects(:new).returns(stub('tftp', :start => true)).
-      with(src, dst, tftp_read_timeout, tftp_connect_timeout, tftp_dns_timeout, verify_server_cert)
-
-    Proxy::TFTP.choose_protocol_and_fetch src, dst
-  end
-
-  def test_choose_protocol_and_fetch_wget_with_read_timeout
-    src = "https://proxy.test"
-    dst = "/destination"
-    tftp_read_timeout = "1000"
-    verify_server_cert = true
-    tftp_connect_timeout = Proxy::TFTP::Plugin.settings.tftp_connect_timeout
-    tftp_dns_timeout = Proxy::TFTP::Plugin.settings.tftp_dns_timeout
-
-    Proxy::TFTP::Plugin.load_test_settings(:tftp_read_timeout => tftp_read_timeout)
-
-    ::Proxy::HttpDownload.expects(:new).returns(stub('tftp', :start => true)).
-      with(src, dst, tftp_read_timeout, tftp_connect_timeout, tftp_dns_timeout, verify_server_cert)
+      with(src, dst, nil, tftp_connect_timeout, nil, verify_server_cert)
 
     Proxy::TFTP.choose_protocol_and_fetch src, dst
   end


### PR DESCRIPTION
This is continuation of an incorrect implementation we merged as https://github.com/theforeman/smart-proxy/pull/785

Unfortunately, `wget` in EL7 seems to be a bit old and required features are no there, however, `curl` has all the features and supports both HTTP and FTP. It can be configured also to print a nice message after download is finished which looks nice. And it correctly supports redownloading of newer files, it performs comparsion of last modification correctly as needed.

The downside is it only supports connect timeout, read/dns timeouts cannot be supported. It is a detail IMHO.

I am creating a draft, please test this. I did testing with:

* CentOS main mirror
* a random Czechia CentOS mirror
* Katello (Satellite 6.9)

Example curl to call proxy API:

```
curl -X POST -d "" "http://localhost:8448/tftp/fetch_boot_file?prefix=test&path=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os/LICENSE"
```

And how it looks like in logs:

```
2021-09-02T10:11:36 bae83840 [I] [1270504] Started task /usr/bin/curl --silent --show-error --connect-timeout 10 --retry 3 --retry-delay 10 --max-time 3600 --remote-time --time-cond /var/lib/tftpboot/test-kernel.img --write-out "Task done, result: %{http_code}, size downloaded: %{size_download}b, speed: %{speed_download}b/s, time: %{time_total}ms" -o /var/lib/tftpboot/test-kernel.img --location http://zzzap.xxx.redhat.com/pulp/repos/Default_Organization/Library/content/dist/rhel8/8.0/s390x/baseos/kickstart/images/kernel.img
2021-09-02T10:11:37 bae83840 [D] [1270504] "Task done, result: 200, size downloaded: 4911272b, speed: 9390577b/s, time: 0.523823ms"
```

Tests are failing because I will fix them only if we agree to proceed with this solution.

There was a proposal to use HTTP ETag to do comparsion instead of last-modified, however, that would not work for FTP protocol.