### PR TITLE
Fixes #33881 - deprecations for 3.2

### DIFF
--- a/lib/proxy/http_download.rb
+++ b/lib/proxy/http_download.rb
@@ -5,11 +5,8 @@ module Proxy
     include Util
     DEFAULT_CONNECT_TIMEOUT = 10
 
-    def initialize(src, dst, read_timeout = nil, connect_timeout = nil, dns_timeout = nil, verify_server_cert = false)
+    def initialize(src, dst, connect_timeout: DEFAULT_CONNECT_TIMEOUT, verify_server_cert: false)
       @dst = dst
-      logger.warn('Deprecated: HttpDownload read_timeout is deprecated and will be removed in 4.0') if read_timeout
-      logger.warn('Deprecated: HttpDownload dns_timeout is deprecated and will be removed in 4.0') if dns_timeout
-      connect_timeout ||= DEFAULT_CONNECT_TIMEOUT
       args = [which('curl')]
 
       # no cert verification if set

--- a/lib/proxy/plugins.rb
+++ b/lib/proxy/plugins.rb
@@ -51,10 +51,6 @@ class ::Proxy::Plugins
     end
   end
 
-  #
-  # below are methods that are going to be removed/deprecated
-  #
-
   def enabled_plugins
     loaded.select { |p| p[:state] == :running && p[:class].ancestors.include?(::Proxy::Plugin) }.map { |p| p[:class] }
   end

--- a/modules/dhcp/dhcp_api.rb
+++ b/modules/dhcp/dhcp_api.rb
@@ -42,22 +42,6 @@ class Proxy::DhcpApi < ::Sinatra::Base
     log_halt 400, e
   end
 
-  # Deprecated, returns a single record
-  get "/:network/:record" do
-    content_type :json
-
-    logger.warn('GET dhcp/:network/:record endpoint has been deprecated and will be removed in future versions. '\
-                'Please use GET dhcp/:network/mac/:mac_address or GET dhcp/:network/ip/:ip_address instead.')
-
-    record = server.find_record(params[:network], params[:record])
-    log_halt 404, "No DHCP record for #{params[:network]}/#{params[:record]} found" unless record
-    {:hostname => (record.hostname rescue record.name), :ip => record.ip, :mac => record.mac }.to_json
-  rescue ::Proxy::DHCP::SubnetNotFound
-    log_halt 404, "Subnet #{params[:network]} could not found"
-  rescue => e
-    log_halt 400, e
-  end
-
   # returns an array of records for an ip address
   get "/:network/ip/:ip_address" do
     server.validate_supported_address(params[:network], params[:ip_address])
@@ -100,21 +84,6 @@ class Proxy::DhcpApi < ::Sinatra::Base
   rescue Proxy::DHCP::AlreadyExists
     # no need to do anything
   rescue => e
-    log_halt 400, e
-  end
-
-  # deprecated, delete a record from a network
-  delete "/:network/:record" do
-    logger.warn('DELETE dhcp/:network/:record endpoint has been deprecated and will be removed in future versions. '\
-                'Please use DELETE dhcp/:network/mac/:mac_address or DELETE dhcp/:network/ip/:ip_address instead.')
-
-    record = server.find_record(params[:network], params[:record])
-    log_halt 404, "No DHCP record for #{params[:network]}/#{params[:record]} found" unless record
-    server.del_record(record)
-    nil
-  rescue ::Proxy::DHCP::SubnetNotFound
-    log_halt 404, "Subnet #{params[:network]} could not found"
-  rescue Exception => e
     log_halt 400, e
   end
 

--- a/modules/dns_common/dns_common.rb
+++ b/modules/dns_common/dns_common.rb
@@ -99,50 +99,6 @@ module Proxy::Dns
       raise(Proxy::Dns::Error, "Deletion of #{type} not implemented")
     end
 
-    def get_name(a_ptr)
-      logger.warn('Deprecated: Proxy::Dns::Record#get_name is deprecated and will be removed in 1.24')
-      get_resource_as_string(a_ptr, Resolv::DNS::Resource::IN::PTR, :name)
-    end
-
-    def get_name!(a_ptr)
-      logger.warn('Deprecated: Proxy::Dns::Record#get_name! is deprecated and will be removed in 1.24')
-      get_resource_as_string!(a_ptr, Resolv::DNS::Resource::IN::PTR, :name)
-    end
-
-    def get_ipv4_address!(fqdn)
-      logger.warn('Deprecated: Proxy::Dns::Record#get_ipv4_address! is deprecated and will be removed in 1.24')
-      get_resource_as_string!(fqdn, Resolv::DNS::Resource::IN::A, :address)
-    end
-
-    def get_ipv4_address(fqdn)
-      logger.warn('Deprecated: Proxy::Dns::Record#get_ipv4_address is deprecated and will be removed in 1.24')
-      get_resource_as_string(fqdn, Resolv::DNS::Resource::IN::A, :address)
-    end
-
-    def get_ipv6_address!(fqdn)
-      logger.warn('Deprecated: Proxy::Dns::Record#get_ipv6_address! is deprecated and will be removed in 1.24')
-      get_resource_as_string!(fqdn, Resolv::DNS::Resource::IN::AAAA, :address)
-    end
-
-    def get_ipv6_address(fqdn)
-      logger.warn('Deprecated: Proxy::Dns::Record#get_ipv6_address is deprecated and will be removed in 1.24')
-      get_resource_as_string(fqdn, Resolv::DNS::Resource::IN::AAAA, :address)
-    end
-
-    def get_resource_as_string(value, resource_type, attr)
-      logger.warn('Deprecated: Proxy::Dns::Record#get_resource_as_string is deprecated and will be removed in 1.24')
-      resolver.getresource(value, resource_type).send(attr).to_s
-    rescue Resolv::ResolvError
-      false
-    end
-
-    def get_resource_as_string!(value, resource_type, attr)
-      logger.warn('Deprecated: Proxy::Dns::Record#get_resource_as_string! is deprecated and will be removed in 1.24')
-      resolver.getresource(value, resource_type).send(attr).to_s
-    rescue Resolv::ResolvError
-      raise Proxy::Dns::NotFound.new("Cannot find DNS entry for #{value}")
-    end
-
     def ptr_to_ip(ptr)
       if ptr =~ /\.in-addr\.arpa$/
         ptr.split('.')[0..-3].reverse.join('.')
@@ -169,11 +125,6 @@ module Proxy::Dns
 
     def ptr_record_conflicts(content, name)
       record_conflicts_name(name, Resolv::DNS::Resource::IN::PTR, content)
-    end
-
-    def to_ipaddress(ip)
-      logger.warn('Deprecated: Proxy::Dns::Record#to_ipaddress is deprecated and will be removed in 1.24')
-      IPAddr.new(ip) rescue false
     end
 
     private

--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -38,7 +38,7 @@ module Proxy::Dns::Dnscmd
       std_in = std_out = std_err = nil
       real_cmd = ['c:\Windows\System32\dnscmd.exe', @server] + args
       begin
-        Timeout::timeout(tsecs) do
+        Timeout.timeout(tsecs) do
           logger.debug { "executing: #{real_cmd}" }
           std_in, std_out, std_err = popen3(*real_cmd)
           response = [std_out&.readlines, std_err&.readlines].flatten.compact

--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'timeout'
 
 module Proxy::Dns::Dnscmd
   class Record < ::Proxy::Dns::Record
@@ -37,7 +38,7 @@ module Proxy::Dns::Dnscmd
       std_in = std_out = std_err = nil
       real_cmd = ['c:\Windows\System32\dnscmd.exe', @server] + args
       begin
-        timeout(tsecs) do
+        Timeout::timeout(tsecs) do
           logger.debug { "executing: #{real_cmd}" }
           std_in, std_out, std_err = popen3(*real_cmd)
           response = [std_out&.readlines, std_err&.readlines].flatten.compact

--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -165,12 +165,9 @@ module Proxy::TFTP
   def self.choose_protocol_and_fetch(src, destination)
     case URI(src).scheme
     when 'http', 'https', 'ftp'
-      ::Proxy::HttpDownload.new(src.to_s,
-                                destination.to_s,
-                                nil,
-                                Proxy::TFTP::Plugin.settings.tftp_connect_timeout,
-                                nil,
-                                Proxy::TFTP::Plugin.settings.verify_server_cert).start
+      ::Proxy::HttpDownload.new(src.to_s, destination.to_s,
+                                connect_timeout: Proxy::TFTP::Plugin.settings.tftp_connect_timeout,
+                                verify_server_cert: Proxy::TFTP::Plugin.settings.verify_server_cert).start
 
     when 'nfs'
       logger.debug "NFS as a protocol for installation medium detected."

--- a/test/dhcp/dhcp_api_test.rb
+++ b/test/dhcp/dhcp_api_test.rb
@@ -112,32 +112,6 @@ class DhcpApiTest < Test::Unit::TestCase
     assert_equal 501, last_response.status
   end
 
-  def test_get_record
-    @server.expects(:find_record).with("192.168.122.0", "192.168.122.1").returns(@reservations.first)
-
-    get "/192.168.122.0/192.168.122.1"
-
-    assert last_response.ok?, "Last response was not ok: #{last_response.status} #{last_response.body}"
-    expected = {
-      "hostname" => "test.example.com",
-      "ip"       => "192.168.122.1",
-      "mac"      => "00:11:bb:cc:dd:ee",
-    }
-    assert_equal expected, JSON.parse(last_response.body)
-  end
-
-  def test_get_record_for_non_existent_record
-    @server.expects(:find_record).with("192.168.122.0", "192.168.122.1").returns(nil)
-    get "/192.168.122.0/192.168.122.1"
-    assert_equal 404, last_response.status
-  end
-
-  def test_get_record_for_nonexistent_network
-    @server.expects(:find_record).with("192.168.122.0", "192.168.122.1").raises(::Proxy::DHCP::SubnetNotFound)
-    get "/192.168.122.0/192.168.122.1"
-    assert_equal 404, last_response.status
-  end
-
   def test_get_reservation_record_by_ip
     @server.expects(:find_records_by_ip).with("192.168.122.0", "192.168.122.1").returns([@reservations.first])
 
@@ -305,16 +279,6 @@ class DhcpApiTest < Test::Unit::TestCase
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
   end
 
-  def test_delete_record
-    @server.expects(:find_record).with("192.168.122.0", "192.168.122.1").returns(@reservations.first)
-    @server.expects(:del_record).with(@reservations.first).returns(nil)
-
-    delete "/192.168.122.0/192.168.122.1"
-
-    assert_equal 200, last_response.status
-    assert_empty last_response.body
-  end
-
   def test_delete_records_by_ip
     @server.expects(:del_records_by_ip).with("192.168.122.0", "192.168.122.1")
     delete "/192.168.122.0/ip/192.168.122.1"
@@ -348,11 +312,5 @@ class DhcpApiTest < Test::Unit::TestCase
     delete "/192.168.122.0/mac/00:11:bb:cc:dd:ee"
     assert_equal 200, last_response.status
     assert_empty last_response.body
-  end
-
-  def test_delete_non_existent_record
-    @server.expects(:find_record).with("192.168.122.0", "192.168.122.1").returns(nil)
-    delete "/192.168.122.0/192.168.122.1"
-    assert_equal 404, last_response.status
   end
 end

--- a/test/dns_common/record_test.rb
+++ b/test/dns_common/record_test.rb
@@ -6,66 +6,6 @@ class DnsRecordTest < Test::Unit::TestCase
     @record = Proxy::Dns::Record.new
   end
 
-  def test_get_name_with_sideeffect_for_ipv4
-    @record.expects(:get_resource_as_string!).with('2.0.13.127.in-addr.arpa', Resolv::DNS::Resource::IN::PTR, :name).returns('not_existing.example.com')
-    assert 'not_existing.example.com', @record.get_name!('2.0.13.127.in-addr.arpa')
-  end
-
-  def test_get_name_with_sideeffect_for_ipv6
-    @record.expects(:get_resource_as_string!).with('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa', Resolv::DNS::Resource::IN::PTR, :name).returns('not_existing.example.com')
-    assert 'not_existing.example.com', @record.get_name!('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa')
-  end
-
-  def test_get_name_for_ipv4
-    @record.expects(:get_resource_as_string).with('2.0.13.127.in-addr.arpa', Resolv::DNS::Resource::IN::PTR, :name).returns('not_existing.example.com')
-    assert 'not_existing.example.com', @record.get_name('2.0.13.127.in-addr.arpa')
-  end
-
-  def test_get_name_for_ipv6
-    @record.expects(:get_resource_as_string).with('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa', Resolv::DNS::Resource::IN::PTR, :name).returns('not_existing.example.com')
-    assert 'not_existing.example.com', @record.get_name('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa')
-  end
-
-  def test_get_ipv4_address_with_sideeffects
-    @record.expects(:get_resource_as_string!).with('some.host', Resolv::DNS::Resource::IN::A, :address).returns('127.13.0.2')
-    assert '127.13.0.2', @record.get_ipv4_address!('some.host')
-  end
-
-  def test_get_ipv4_address
-    @record.expects(:get_resource_as_string).with('some.host', Resolv::DNS::Resource::IN::A, :address).returns('127.13.0.2')
-    assert '127.13.0.2', @record.get_ipv4_address('some.host')
-  end
-
-  def test_get_ipv6_address_with_sideeffects
-    @record.expects(:get_resource_as_string!).with('some.host', Resolv::DNS::Resource::IN::AAAA, :address).returns('2A00:1450:400C:C04::6A')
-    assert '2A00:1450:400C:C04::6A', @record.get_ipv6_address!('some.host')
-  end
-
-  def test_get_ipv6_address
-    @record.expects(:get_resource_as_string).with('some.host', Resolv::DNS::Resource::IN::AAAA, :address).returns('2A00:1450:400C:C04::6A')
-    assert '2A00:1450:400C:C04::6A', @record.get_ipv6_address('some.host')
-  end
-
-  def test_get_resource_as_string_with_sideeffects
-    Resolv::DNS.any_instance.expects(:getresource).with('some.host', Resolv::DNS::Resource::IN::A).returns(Resolv::DNS::Resource::IN::A.new('127.13.0.2'))
-    assert_equal '127.13.0.2', @record.get_resource_as_string!('some.host', Resolv::DNS::Resource::IN::A, :address)
-  end
-
-  def test_get_resource_as_string_with_sideeffects_raises_exception_when_resource_is_not_found
-    Resolv::DNS.any_instance.expects(:getresource).with('some.host', Resolv::DNS::Resource::IN::A).raises(Resolv::ResolvError)
-    assert_raises(Proxy::Dns::NotFound) { @record.get_resource_as_string!('some.host', Resolv::DNS::Resource::IN::A, :address) }
-  end
-
-  def test_get_resource_as_string
-    Resolv::DNS.any_instance.expects(:getresource).with('some.host', Resolv::DNS::Resource::IN::A).returns(Resolv::DNS::Resource::IN::A.new('127.13.0.2'))
-    assert_equal '127.13.0.2', @record.get_resource_as_string('some.host', Resolv::DNS::Resource::IN::A, :address)
-  end
-
-  def test_get_resource_as_string_wjen_resource_is_not_found
-    Resolv::DNS.any_instance.expects(:getresource).with('some.host', Resolv::DNS::Resource::IN::A).raises(Resolv::ResolvError)
-    assert_false @record.get_resource_as_string('some.host', Resolv::DNS::Resource::IN::A, :address)
-  end
-
   def test_ptr_to_ip_ipv4
     assert_equal('192.168.33.30', Proxy::Dns::Record.new.ptr_to_ip('30.33.168.192.in-addr.arpa'))
   end
@@ -128,12 +68,6 @@ class DnsRecordTest < Test::Unit::TestCase
   def test_aaaa_record_conflicts_is_case_insensetive
     Resolv::DNS.any_instance.expects(:getresources).with('some.host', Resolv::DNS::Resource::IN::AAAA).returns(ips('2001:DB8:DEEF::1'))
     assert_equal 0, Proxy::Dns::Record.new.aaaa_record_conflicts('some.host', '2001:db8:deef::1')
-  end
-
-  def test_validate_ip
-    assert_equal '192.168.33.33', Proxy::Dns::Record.new.to_ipaddress('192.168.33.33').to_s
-    assert_equal '2001:db8:deef::1', Proxy::Dns::Record.new.to_ipaddress('2001:db8:deef::1').to_s
-    assert_equal false, Proxy::Dns::Record.new.to_ipaddress('some.host')
   end
 
   def test_create_srv_record

--- a/test/http_download_test.rb
+++ b/test/http_download_test.rb
@@ -25,6 +25,23 @@ class HttpDownloadsTest < Test::Unit::TestCase
     assert_equal expected, Proxy::HttpDownload.new('src', 'dst').command
   end
 
+  def test_regular_call_with_ssl_verify
+    expected = [
+      "/usr/bin/curl",
+      "--silent", "--show-error",
+      "--connect-timeout", "10",
+      "--retry", "3",
+      "--retry-delay", "10",
+      "--max-time", "3600",
+      "--remote-time",
+      "--time-cond", "dst",
+      "--write-out", "Task done, result: %{http_code}, size downloaded: %{size_download}b, speed: %{speed_download}b/s, time: %{time_total}ms",
+      "--output", "dst",
+      "--location", "src"
+    ]
+    assert_equal expected, Proxy::HttpDownload.new('src', 'dst', verify_server_cert: true).command
+  end
+
   def test_should_skip_download_if_one_is_in_progress
     Dir.mktmpdir do |tmpdir|
       Proxy::FileLock.try_locking("#{tmpdir}/.dst.lock")

--- a/test/tftp/tftp_test.rb
+++ b/test/tftp/tftp_test.rb
@@ -68,7 +68,7 @@ class TftpTest < Test::Unit::TestCase
     )
 
     ::Proxy::HttpDownload.expects(:new).returns(stub('tftp', :start => true)).
-      with(src, dst, nil, tftp_connect_timeout, nil, verify_server_cert)
+      with(src, dst, connect_timeout: tftp_connect_timeout, verify_server_cert: verify_server_cert)
 
     Proxy::TFTP.choose_protocol_and_fetch src, dst
   end


### PR DESCRIPTION
Ton of deprecations, I searched the codebase and here are several commits which either deprecate some stuff or keeps the code in forever. Most of this was created by Dmitry when he was writing the DI plugin framework. I think some are still useful and we should not deprecate them, some are obvious.

The one I am not sure about is the DNS common module one, whole no core plugin use this, this might break others.

I suggest to review commit by commit. Do not merge before 3.1 branching! This is post-branch material.