### PR TITLE
Fixes #34141 - Make validators modern Ruby compatible

### DIFF
--- a/lib/proxy/pluggable.rb
+++ b/lib/proxy/pluggable.rb
@@ -42,16 +42,17 @@ module Proxy::Pluggable
     raise "#{plugin_name}: 'initialize_after' method has been removed."
   end
 
-  def validate_readable(*settings)
-    validate(*settings.push(:file_readable => true))
+  def validate_readable(*settings, **validator_params)
+    validator_params[:file_readable] = true
+    validate(*settings, **validator_params)
   end
 
-  def validate_presence(*settings)
-    validate(*settings.push(:presence => true))
+  def validate_presence(*settings, **validator_params)
+    validator_params[:presence] = true
+    validate(*settings, **validator_params)
   end
 
-  def validate(*settings)
-    validator_params = settings.pop
+  def validate(*settings, **validator_params)
     predicate = validator_params.delete(:if)
     validator_name = validator_params.keys.first
     validator_args = validator_params[validator_name]


### PR DESCRIPTION
In old Ruby versions a hash was pushed as the last argument but in modern Ruby there is first class support for this via kwargs. This worked if a single argument was provided but if they were combined it failed:

```ruby
validate_presence :setting, if: ->(settings) { true }
```

This then tried to create a validator of a hash.

It looks like this code currently has no coverage which is why this never showed up. I'm also not sure if this is used in any plugins. I'm taking a look at writing tests.