### PR TITLE
Fixes #34162 - Allow calling load_test_settings without settings

### DIFF
--- a/lib/smart_proxy_for_testing.rb
+++ b/lib/smart_proxy_for_testing.rb
@@ -33,7 +33,7 @@ Proxy::VERSION = File.read(File.join(__dir__, '..', 'VERSION')).chomp
 ::Sinatra::Base.register ::Sinatra::Authorization
 
 module ::Proxy::Pluggable
-  def load_test_settings(a_hash)
+  def load_test_settings(a_hash = {})
     @settings = ::Proxy::Settings::Plugin.new(plugin_default_settings, a_hash)
   end
 end

--- a/test/dhcp/dhcp_config_test.rb
+++ b/test/dhcp/dhcp_config_test.rb
@@ -3,7 +3,7 @@ require 'dhcp/dhcp_plugin'
 
 class DhcpConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
-    Proxy::DhcpPlugin.load_test_settings({})
+    Proxy::DhcpPlugin.load_test_settings()
     assert_equal '127.0.0.1', Proxy::DhcpPlugin.settings.server
     assert_equal 'dhcp_isc', Proxy::DhcpPlugin.settings.use_provider
     assert Proxy::DhcpPlugin.settings.ping_free_ip

--- a/test/dhcp/server_test.rb
+++ b/test/dhcp/server_test.rb
@@ -108,7 +108,7 @@ class DHCPServerTest < Test::Unit::TestCase
   end
 
   def test_managed_subnet_should_return_true_when_setting_is_undefined
-    ::Proxy::DhcpPlugin.load_test_settings({})
+    ::Proxy::DhcpPlugin.load_test_settings()
     assert @server.managed_subnet?('192.168.1.0/255.255.255.0')
   end
 

--- a/test/dhcp_isc/dhcp_isc_config_test.rb
+++ b/test/dhcp_isc/dhcp_isc_config_test.rb
@@ -3,7 +3,7 @@ require 'dhcp_isc/dhcp_isc'
 
 class DhcpIscConfigTest < ::Test::Unit::TestCase
   def test_default_configuration
-    Proxy::DHCP::ISC::Plugin.load_test_settings({})
+    Proxy::DHCP::ISC::Plugin.load_test_settings()
     assert_equal '7911', Proxy::DHCP::ISC::Plugin.settings.omapi_port
     assert_equal '/etc/dhcp/dhcpd.conf', Proxy::DHCP::ISC::Plugin.settings.config
     assert_equal '/var/lib/dhcpd/dhcpd.leases', Proxy::DHCP::ISC::Plugin.settings.leases

--- a/test/dhcp_libvirt/dhcp_libvirt_config_test.rb
+++ b/test/dhcp_libvirt/dhcp_libvirt_config_test.rb
@@ -3,7 +3,7 @@ require 'dhcp_libvirt/dhcp_libvirt'
 
 class DhcpLibvirtConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
-    ::Proxy::DHCP::Libvirt::Plugin.load_test_settings({})
+    ::Proxy::DHCP::Libvirt::Plugin.load_test_settings()
     assert_equal 'default', ::Proxy::DHCP::Libvirt::Plugin.settings.network
     assert_equal 'qemu:///system', ::Proxy::DHCP::Libvirt::Plugin.settings.url
   end

--- a/test/dns/dns_config_test.rb
+++ b/test/dns/dns_config_test.rb
@@ -3,7 +3,7 @@ require 'dns/dns'
 
 class DnsConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
-    Proxy::Dns::Plugin.load_test_settings({})
+    Proxy::Dns::Plugin.load_test_settings()
     assert_equal 'dns_nsupdate', Proxy::Dns::Plugin.settings.use_provider
     assert_equal 86_400, Proxy::Dns::Plugin.settings.dns_ttl
   end

--- a/test/dns_dnscmd/dnscmd_config_test.rb
+++ b/test/dns_dnscmd/dnscmd_config_test.rb
@@ -6,7 +6,7 @@ require 'dns_dnscmd/dns_dnscmd_main'
 
 class DnsCmdConfigTest < Test::Unit::TestCase
   def test_default_configuration
-    ::Proxy::Dns::Dnscmd::Plugin.load_test_settings({})
+    ::Proxy::Dns::Dnscmd::Plugin.load_test_settings()
     assert_equal 'localhost', ::Proxy::Dns::Dnscmd::Plugin.settings.dns_server
   end
 end

--- a/test/dns_libvirt/dns_libvirt_configuration_test.rb
+++ b/test/dns_libvirt/dns_libvirt_configuration_test.rb
@@ -4,7 +4,7 @@ require 'dns_libvirt/dns_libvirt_main'
 
 class DnsLibvirtConfigTest < Test::Unit::TestCase
   def test_default_settings
-    ::Proxy::Dns::Libvirt::Plugin.load_test_settings({})
+    ::Proxy::Dns::Libvirt::Plugin.load_test_settings()
     assert_equal 'default', Proxy::Dns::Libvirt::Plugin.settings.network
   end
 end

--- a/test/dns_nsupdate/dns_nsupdate_config_test.rb
+++ b/test/dns_nsupdate/dns_nsupdate_config_test.rb
@@ -7,14 +7,14 @@ require 'dns_nsupdate/dns_nsupdate_gss_main'
 
 class DnsNsupdateConfigTest < Test::Unit::TestCase
   def test_nsupdate_default_settings
-    Proxy::Dns::Nsupdate::Plugin.load_test_settings({})
+    Proxy::Dns::Nsupdate::Plugin.load_test_settings()
 
     assert_equal "localhost", Proxy::Dns::Nsupdate::Plugin.settings.dns_server
     assert_nil Proxy::Dns::Nsupdate::Plugin.settings.dns_key
   end
 
   def test_nsupdate_gss_default_settings
-    Proxy::Dns::NsupdateGSS::Plugin.load_test_settings({})
+    Proxy::Dns::NsupdateGSS::Plugin.load_test_settings()
 
     assert_equal "localhost", Proxy::Dns::NsupdateGSS::Plugin.settings.dns_server
     assert_equal '/usr/share/foreman-proxy/dns.keytab', Proxy::Dns::NsupdateGSS::Plugin.settings.dns_tsig_keytab

--- a/test/plugins/validator_test.rb
+++ b/test/plugins/validator_test.rb
@@ -42,7 +42,7 @@ class FileReadableValidatorTest < Test::Unit::TestCase
   end
 
   def test_file_readable_returns_true_for_optional_undefined_settings
-    FileReadableValidatorTestPlugin.load_test_settings({})
+    FileReadableValidatorTestPlugin.load_test_settings()
     assert ::Proxy::PluginValidators::FileReadable.new(FileReadableValidatorTestPlugin, 'optional_setting', nil, nil).validate!({})
   end
 

--- a/test/puppet/puppet_api_configuration_test.rb
+++ b/test/puppet/puppet_api_configuration_test.rb
@@ -17,7 +17,7 @@ end
 
 class PuppetApiDefaultSettingsTest < Test::Unit::TestCase
   def test_default_settings
-    Proxy::PuppetApi::Plugin.load_test_settings({})
+    Proxy::PuppetApi::Plugin.load_test_settings()
     assert_equal '/var/lib/puppet/ssl/certs/ca.pem', Proxy::PuppetApi::Plugin.settings.puppet_ssl_ca
     assert_equal 30, Proxy::PuppetApi::Plugin.settings.api_timeout
   end

--- a/test/puppetca/puppetca_config_test.rb
+++ b/test/puppetca/puppetca_config_test.rb
@@ -3,7 +3,7 @@ require 'puppetca/puppetca'
 
 class PuppetCAConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
-    Proxy::PuppetCa::Plugin.load_test_settings({})
+    Proxy::PuppetCa::Plugin.load_test_settings()
     assert_equal 'puppetca_hostname_whitelisting', Proxy::PuppetCa::Plugin.settings.use_provider
   end
 

--- a/test/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_config_test.rb
+++ b/test/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_config_test.rb
@@ -5,7 +5,7 @@ require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_plugin'
 
 class PuppetCaHostnameWhitelistingConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
-    Proxy::PuppetCa::HostnameWhitelisting::Plugin.load_test_settings({})
+    Proxy::PuppetCa::HostnameWhitelisting::Plugin.load_test_settings()
     assert_equal '/etc/puppet/autosign.conf', Proxy::PuppetCa::HostnameWhitelisting::Plugin.settings.autosignfile
   end
 end

--- a/test/puppetca_http_api/puppetca_http_api_config_test.rb
+++ b/test/puppetca_http_api/puppetca_http_api_config_test.rb
@@ -3,7 +3,7 @@ require 'puppetca_http_api/puppetca_http_api'
 
 class PuppetCaHttpApiConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
-    Proxy::PuppetCa::PuppetcaHttpApi::Plugin.load_test_settings({})
+    Proxy::PuppetCa::PuppetcaHttpApi::Plugin.load_test_settings()
     assert_equal '/etc/puppetlabs/puppet/ssl/certs/ca.pem', Proxy::PuppetCa::PuppetcaHttpApi::Plugin.settings.puppet_ssl_ca
   end
 end

--- a/test/puppetca_puppet_cert/puppetca_puppet_cert_config_test.rb
+++ b/test/puppetca_puppet_cert/puppetca_puppet_cert_config_test.rb
@@ -3,7 +3,7 @@ require 'puppetca_puppet_cert/puppetca_puppet_cert'
 
 class PuppetCaPuppetCertConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
-    Proxy::PuppetCa::PuppetcaPuppetCert::Plugin.load_test_settings({})
+    Proxy::PuppetCa::PuppetcaPuppetCert::Plugin.load_test_settings()
     assert_equal '/var/lib/puppet/ssl', Proxy::PuppetCa::PuppetcaPuppetCert::Plugin.settings.ssldir
   end
 end

--- a/test/puppetca_token_whitelisting/puppetca_token_whitelisting_config_test.rb
+++ b/test/puppetca_token_whitelisting/puppetca_token_whitelisting_config_test.rb
@@ -5,7 +5,7 @@ require 'puppetca_token_whitelisting/puppetca_token_whitelisting_plugin'
 
 class PuppetCATokenWhitelistingConfigTest < Test::Unit::TestCase
   def test_omitted_settings_have_default_values
-    Proxy::PuppetCa::TokenWhitelisting::Plugin.load_test_settings({})
+    Proxy::PuppetCa::TokenWhitelisting::Plugin.load_test_settings()
     assert_equal false, Proxy::PuppetCa::TokenWhitelisting::Plugin.settings.sign_all
     assert_equal '/var/lib/foreman-proxy/tokens.yml', Proxy::PuppetCa::TokenWhitelisting::Plugin.settings.tokens_file
     assert_equal 360, Proxy::PuppetCa::TokenWhitelisting::Plugin.settings.token_ttl

--- a/test/tftp/tftp_test.rb
+++ b/test/tftp/tftp_test.rb
@@ -13,7 +13,7 @@ class TftpTest < Test::Unit::TestCase
   end
 
   def test_path_to_tftp_directory_without_tftproot_setting
-    Proxy::TFTP::Plugin.load_test_settings({})
+    Proxy::TFTP::Plugin.load_test_settings()
     assert_equal "/var/lib/tftpboot", @tftp.send(:path)
   end
 


### PR DESCRIPTION
This allows loading only the default settings:

```ruby
Proxy::MyPlugin::Plugin.load_test_settings
```

Or

```ruby
Proxy::MyPlugin::Plugin.load_test_settings()
```

Previously this had to be written as

```ruby
Proxy::MyPlugin::Plugin.load_test_settings({})
```