### PR TITLE
Fixes #34163 - Allow clearing the log buffer

### DIFF
--- a/lib/proxy/log_buffer/buffer.rb
+++ b/lib/proxy/log_buffer/buffer.rb
@@ -105,5 +105,16 @@ module Proxy::LogBuffer
         :failed_modules => @failed_modules,
       }
     end
+
+    private
+
+    # Reset the buffer to its initial state. Only intended for testing.
+    def reset
+      @failed_modules.clear
+      @mutex.synchronize do
+        @main_buffer.clear
+        @tail_buffer.clear
+      end
+    end
   end
 end

--- a/test/bmc/integration_test.rb
+++ b/test/bmc/integration_test.rb
@@ -4,14 +4,7 @@ require 'root/root_v2_api'
 require 'bmc/bmc_plugin'
 require 'bmc/ipmi'
 
-class BmcApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class BmcApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('bmc.yml').returns(enabled: true, bmc_default_provider: 'freeipmi')
     Proxy::BMC::IPMI.stubs(:providers_installed).returns([])

--- a/test/dhcp_isc/root_integration_test.rb
+++ b/test/dhcp_isc/root_integration_test.rb
@@ -4,14 +4,7 @@ require 'root/root_v2_api'
 require 'dhcp/dhcp'
 require 'dhcp_isc/dhcp_isc'
 
-class DhcpIscApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class DhcpIscApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     config = Tempfile.new('config')
     leases = Tempfile.new('leases')

--- a/test/dhcp_libvirt/integration_test.rb
+++ b/test/dhcp_libvirt/integration_test.rb
@@ -4,14 +4,7 @@ require 'root/root_v2_api'
 require 'dhcp/dhcp'
 require 'dhcp_libvirt/dhcp_libvirt'
 
-class DhcpLibvirtApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class DhcpLibvirtApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('dhcp.yml').returns(enabled: true, use_provider: 'dhcp_libvirt')
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('dhcp_libvirt.yml').returns({})

--- a/test/dhcp_ms_native/integration_test.rb
+++ b/test/dhcp_ms_native/integration_test.rb
@@ -4,14 +4,7 @@ require 'root/root_v2_api'
 require 'dhcp/dhcp'
 require 'dhcp_native_ms/dhcp_native_ms'
 
-class DhcpNativeMsApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class DhcpNativeMsApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('dhcp.yml').returns(enabled: true, use_provider: 'dhcp_native_ms')
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('dhcp_native_ms.yml').returns({})

--- a/test/dns_dnscmd/integration_test.rb
+++ b/test/dns_dnscmd/integration_test.rb
@@ -4,14 +4,7 @@ require 'root/root_v2_api'
 require 'dns/dns'
 require 'dns_dnscmd/dns_dnscmd'
 
-class DnsCmdApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class DnsCmdApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('dns.yml').returns(enabled: true, use_provider: 'dns_dnscmd')
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('dns_dnscmd.yml').returns(dns_server: 'dns.example.com')

--- a/test/dns_libvirt/integration_test.rb
+++ b/test/dns_libvirt/integration_test.rb
@@ -4,14 +4,7 @@ require 'root/root_v2_api'
 require 'dns/dns'
 require 'dns_libvirt/dns_libvirt'
 
-class DnsLibvirtApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class DnsLibvirtApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('dns.yml').returns(enabled: true, use_provider: 'dns_libvirt')
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('dns_libvirt.yml').returns(network: 'default')

--- a/test/dns_nsupdate/integration_test.rb
+++ b/test/dns_nsupdate/integration_test.rb
@@ -4,14 +4,7 @@ require 'root/root_v2_api'
 require 'dns/dns'
 require 'dns_nsupdate/dns_nsupdate'
 
-class DnsNsupdateApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class DnsNsupdateApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('dns.yml').returns(enabled: true, use_provider: 'dns_nsupdate')
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('dns_nsupdate.yml').returns(dns_server: 'dns.example.com')

--- a/test/facts/integration_test.rb
+++ b/test/facts/integration_test.rb
@@ -3,14 +3,7 @@ require 'json'
 require 'root/root_v2_api'
 require 'facts/facts_plugin'
 
-class FactsApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class FactsApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('facts.yml').returns(enabled: true)
 

--- a/test/httpboot/integration_test.rb
+++ b/test/httpboot/integration_test.rb
@@ -3,14 +3,7 @@ require 'json'
 require 'root/root_v2_api'
 require 'httpboot/httpboot_plugin'
 
-class HttpbootApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class HttpbootApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('httpboot.yml').returns(enabled: true, root_dir: '/var/lib/tftpboot')
 

--- a/test/logs/integration_test.rb
+++ b/test/logs/integration_test.rb
@@ -3,14 +3,7 @@ require 'json'
 require 'root/root_v2_api'
 require 'logs/logs'
 
-class LogsApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class LogsApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::LegacyModuleLoader.any_instance.expects(:load_configuration_file).with('logs.yml').returns(enabled: true)
 

--- a/test/puppet/integration_test.rb
+++ b/test/puppet/integration_test.rb
@@ -4,14 +4,7 @@ require 'root/root_v2_api'
 require 'puppet_proxy/puppet'
 require 'puppet_proxy_puppet_api/puppet_proxy_puppet_api'
 
-class PuppetApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class PuppetApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     ssl_ca = Tempfile.new('ssl_ca')
     ssl_cert = Tempfile.new('ssl_cert')

--- a/test/puppetca_http_api/integration_test.rb
+++ b/test/puppetca_http_api/integration_test.rb
@@ -5,14 +5,7 @@ require 'puppetca/puppetca'
 require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting'
 require 'puppetca_http_api/puppetca_http_api'
 
-class PuppetcaApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class PuppetcaApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     ssl_ca = Tempfile.new('ssl_ca')
     ssl_cert = Tempfile.new('ssl_cert')

--- a/test/realm_freeipa/integration_test.rb
+++ b/test/realm_freeipa/integration_test.rb
@@ -4,14 +4,7 @@ require 'root/root_v2_api'
 require 'realm/realm'
 require 'realm_freeipa/realm_freeipa'
 
-class RealmFreeipaApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class RealmFreeipaApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     keytab = Tempfile.new('keytab')
     ipa_config = Tempfile.new('ipa_config')

--- a/test/registration/integration_test.rb
+++ b/test/registration/integration_test.rb
@@ -4,14 +4,7 @@ require 'root/root_v2_api'
 require 'templates/templates'
 require 'registration/registration'
 
-class RegistrationApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class RegistrationApiFeaturesTest < SmartProxyRootApiTestCase
   def test_with_templates
     Proxy::LegacyModuleLoader.any_instance.expects(:load_configuration_file).with('templates.yml').returns(enabled: true, template_url: 'http://smart-proxy.example.com:8000')
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('registration.yml').returns(enabled: true)

--- a/test/templates/integration_test.rb
+++ b/test/templates/integration_test.rb
@@ -3,14 +3,7 @@ require 'json'
 require 'root/root_v2_api'
 require 'templates/templates'
 
-class TemplatesApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class TemplatesApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::LegacyModuleLoader.any_instance.expects(:load_configuration_file).with('templates.yml').returns(enabled: true, template_url: 'http://smart-proxy.example.com:8000')
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -66,3 +66,12 @@ module Proxy::IntegrationTestCase
     end
   end
 end
+
+class SmartProxyRootApiTestCase < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
+    Proxy::RootV2Api.new
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,6 +70,10 @@ end
 class SmartProxyRootApiTestCase < Test::Unit::TestCase
   include Rack::Test::Methods
 
+  def setup
+    Proxy::LogBuffer::Buffer.instance.send(:reset)
+  end
+
   def app
     Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
     Proxy::RootV2Api.new

--- a/test/tftp/integration_test.rb
+++ b/test/tftp/integration_test.rb
@@ -3,14 +3,7 @@ require 'json'
 require 'root/root_v2_api'
 require 'tftp/tftp_plugin'
 
-class TftpApiFeaturesTest < Test::Unit::TestCase
-  include Rack::Test::Methods
-
-  def app
-    Proxy::PluginInitializer.new(Proxy::Plugins.instance).initialize_plugins
-    Proxy::RootV2Api.new
-  end
-
+class TftpApiFeaturesTest < SmartProxyRootApiTestCase
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('tftp.yml').returns(enabled: true, tftproot: '/var/lib/tftpboot', tftp_servername: 'tftp.example.com')
 


### PR DESCRIPTION
In testing it can be useful to reset the log buffer. This is not
intended to be used as a public API but tests can use:

```ruby
Proxy::LogBuffer::Buffer.instance.send(:clear)
```