### PR TITLE
Fixes #34164 - Add enum plugin validator

### DIFF
--- a/lib/proxy/default_plugin_validators.rb
+++ b/lib/proxy/default_plugin_validators.rb
@@ -5,6 +5,7 @@ class Proxy::DefaultPluginValidators
       presence: ::Proxy::PluginValidators::Presence,
       url: ::Proxy::PluginValidators::Url,
       boolean: ::Proxy::PluginValidators::Boolean,
+      enum: ::Proxy::PluginValidators::Enum,
     }
   end
 end

--- a/lib/proxy/plugin_validators.rb
+++ b/lib/proxy/plugin_validators.rb
@@ -64,4 +64,14 @@ module ::Proxy::PluginValidators
       true
     end
   end
+
+  class Enum < Base
+    def validate!(settings)
+      setting_value = settings[@setting_name]
+      unless @params.include?(setting_value)
+        raise ::Proxy::Error::ConfigurationError, "Parameter '#{@setting_name}' must be one of #{@params.join(', ')}"
+      end
+      true
+    end
+  end
 end

--- a/test/plugins/validator_test.rb
+++ b/test/plugins/validator_test.rb
@@ -167,3 +167,38 @@ class BooleanValidatorTest < Test::Unit::TestCase
     assert_match(%r{expected to be true/false}, error.message)
   end
 end
+
+class EnumValidatorTest < Test::Unit::TestCase
+  class TestPlugin < ::Proxy::Plugin
+  end
+
+  def validator
+    ::Proxy::PluginValidators::Enum.new(TestPlugin, 'drink', %w[beer whisky], nil)
+  end
+
+  def test_first_valid_value_passes_validation
+    assert validator.validate!(drink: 'beer')
+  end
+
+  def test_second_valid_value_passes_validation
+    assert validator.validate!(drink: 'whisky')
+  end
+
+  def test_an_invalid_value_fails_validation
+    assert_raise_with_message ::Proxy::Error::ConfigurationError, "Parameter 'drink' must be one of beer, whisky" do
+      validator.validate!(drink: 'wine')
+    end
+  end
+
+  def test_empty_string_fails_validation
+    assert_raise_with_message ::Proxy::Error::ConfigurationError, "Parameter 'drink' must be one of beer, whisky" do
+      validator.validate!(drink: '')
+    end
+  end
+
+  def test_nil_fails_validation
+    assert_raise_with_message ::Proxy::Error::ConfigurationError, "Parameter 'drink' must be one of beer, whisky" do
+      validator.validate!(drink: nil)
+    end
+  end
+end


### PR DESCRIPTION
This allows using:

```ruby
validate :setting, enum: %w[first second]
```