### PR TITLE
Fixes #34226 - dnscmd nil string error (3.1 CP)

### DIFF
--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -50,7 +50,7 @@ module Proxy::Dns::Dnscmd
         std_out&.close
         std_err&.close
       end
-      report keyword_args[:msg], response, keyword_args[:error_only || false]
+      report keyword_args[:msg], response, keyword_args[:error_only] || false
       response
     end
 
@@ -97,7 +97,7 @@ module Proxy::Dns::Dnscmd
 
     def enum_zones
       zones = []
-      response = execute '/EnumZones', nil, true
+      response = execute '/EnumZones', error_only: true
       response.each do |line|
         next unless line =~  / Primary /
         zones << line.sub(/^ +/, '').sub(/ +.*$/, '').chomp("\n")
@@ -108,7 +108,7 @@ module Proxy::Dns::Dnscmd
 
     def enum_records(zone_name, node_name, type)
       records = []
-      response = execute "/EnumRecords #{zone_name} #{node_name}. /Type #{type}", "EnumRecords", true
+      response = execute "/EnumRecords #{zone_name} #{node_name}. /Type #{type}", "EnumRecords", error_only: true
       response.each do |line|
         line.chomp!
         logger.debug "Extracting record from dnscmd output '#{line}'"

--- a/test/dns_dnscmd/dnscmd_test.rb
+++ b/test/dns_dnscmd/dnscmd_test.rb
@@ -106,7 +106,7 @@ Enumerated zone list:
  domain.com                     Secondary    File
  TrustAnchors                   Primary    AD-Forest
 Command completed successfully.'.split("\n")
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumZones', nil, true).returns(to_parse)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumZones', error_only: true).returns(to_parse)
     assert_equal [
       "_msdcs.bar.domain.local",
       "168.192.in-addr.arpa",
@@ -126,7 +126,7 @@ Returned records:
 
 Command completed successfully.
 '.split("\n")
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords domain.local host.domain.local. /Type A', 'EnumRecords', true).returns(to_parse)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords domain.local host.domain.local. /Type A', 'EnumRecords', error_only: true).returns(to_parse)
     assert_equal ['192.168.33.33', '192.168.33.34'], Proxy::Dns::Dnscmd::Record.new('server', 999).enum_records('domain.local', 'host.domain.local', 'A')
   end
 
@@ -138,7 +138,7 @@ Returned records:
 
 Command completed successfully.
 '.split("\n")
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords domain.local host.domain.local. /Type AAAA', 'EnumRecords', true).returns(to_parse)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords domain.local host.domain.local. /Type AAAA', 'EnumRecords', error_only: true).returns(to_parse)
     assert_equal ['2001:db8:85a3::8a2e:370:7335', '2001:db8:85a3::8a2e:370:7334'], Proxy::Dns::Dnscmd::Record.new('server', 999).enum_records('domain.local', 'host.domain.local', 'AAAA')
   end
 
@@ -149,7 +149,7 @@ Returned records:
 
 Command completed successfully.
 '.split("\n")
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords example.com alias.example.com. /Type CNAME', 'EnumRecords', true).returns(to_parse)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords example.com alias.example.com. /Type CNAME', 'EnumRecords', error_only: true).returns(to_parse)
     assert_equal ['alias.example.com.'], Proxy::Dns::Dnscmd::Record.new('server', 999).enum_records('example.com', 'alias.example.com', 'CNAME')
   end
 
@@ -160,7 +160,7 @@ Returned records:
 
 Command completed successfully.
 '.split("\n")
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords 33.168.192.in-addr.arpa 33.33.168.192.in-addr.arpa. /Type PTR', 'EnumRecords', true).returns(to_parse)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords 33.168.192.in-addr.arpa 33.33.168.192.in-addr.arpa. /Type PTR', 'EnumRecords', error_only: true).returns(to_parse)
     assert_equal ['host.domain.local.'], Proxy::Dns::Dnscmd::Record.new('server', 999).enum_records('33.168.192.in-addr.arpa', '33.33.168.192.in-addr.arpa', 'PTR')
   end
 
@@ -172,7 +172,7 @@ Returned records:
 
 Command completed successfully.
 '.split("\n")
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords 33.168.192.in-addr.arpa 33.33.168.192.in-addr.arpa. /Type PTR', 'EnumRecords', true).returns(to_parse)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords 33.168.192.in-addr.arpa 33.33.168.192.in-addr.arpa. /Type PTR', 'EnumRecords', error_only: true).returns(to_parse)
     assert_equal ['host.domain.local.', 'host2.domain.local.'], Proxy::Dns::Dnscmd::Record.new('server', 999).enum_records('33.168.192.in-addr.arpa', '33.33.168.192.in-addr.arpa', 'PTR')
   end
 
@@ -182,7 +182,7 @@ DNS Server failed to enumerate records for node 33.33.168.192.in-addr.arpa..
     Status = 9714 (0x000025f2)
 Command failed:  DNS_ERROR_NAME_DOES_NOT_EXIST     9714    0x25F2
 '.split("\n")
-    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords 33.168.192.in-addr.arpa 33.33.168.192.in-addr.arpa. /Type PTR', 'EnumRecords', true).returns(to_parse)
+    Proxy::Dns::Dnscmd::Record.any_instance.expects(:execute).with('/EnumRecords 33.168.192.in-addr.arpa 33.33.168.192.in-addr.arpa. /Type PTR', 'EnumRecords', error_only: true).returns(to_parse)
     assert_equal [], Proxy::Dns::Dnscmd::Record.new('server', 999).enum_records('33.168.192.in-addr.arpa', '33.33.168.192.in-addr.arpa', 'PTR')
   end
 end


### PR DESCRIPTION
(cherry picked from commit 7b3508a8444c04148f6c99f426a5de5d805f99a6)

Since this bug was a regression 3.1 and it is a small one on a non-critical component, I propose 3.1 backport.