### PR TITLE
Fixes #34359 - fix DHCP IP validation arguments

### DIFF
--- a/modules/dhcp_common/server.rb
+++ b/modules/dhcp_common/server.rb
@@ -29,8 +29,10 @@ module Proxy::DHCP
                          end
     end
 
-    def validate_supported_address(ip)
-      validate_ip(ip)
+    def validate_supported_address(*args)
+      args.each do |ip|
+        validate_ip(ip)
+      end
     end
 
     def subnets


### PR DESCRIPTION
This sneaked into develop and 3.1 because the method is stubbed in all tests.

This is a blocker bug, let's put it into 3.1 too.