### PR TITLE
Fixes #34563 - Drop rdoc from test dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,9 @@ Lint/UnusedBlockArgument:
 Lint/UnusedMethodArgument:
   Enabled: false
 
+Lint/SuppressedException:
+  AllowComments: true
+
 Metrics:
   Enabled: false
 

--- a/Rakefile
+++ b/Rakefile
@@ -27,7 +27,7 @@ Rake::RDocTask.new(:rdoc) do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title    = 'Proxy'
   rdoc.options << '--line-numbers' << '--inline-source'
-  rdoc.rdoc_files.include('README')
+  rdoc.rdoc_files.include('README.md')
   rdoc.rdoc_files.include('lib/**/*.rb')
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 require 'rake'
 require 'rake/testtask'
-require 'rdoc/task'
 require 'fileutils'
 require 'tmpdir'
 require File.join(__dir__, 'extra/migrate_settings')
@@ -22,13 +21,19 @@ Rake::TestTask.new(:test) do |t|
   t.ruby_opts = ["-W1"]
 end
 
-desc 'Generate documentation for the Foreman Proxy plugin.'
-Rake::RDocTask.new(:rdoc) do |rdoc|
-  rdoc.rdoc_dir = 'rdoc'
-  rdoc.title    = 'Proxy'
-  rdoc.options << '--line-numbers' << '--inline-source'
-  rdoc.rdoc_files.include('README.md')
-  rdoc.rdoc_files.include('lib/**/*.rb')
+begin
+  require 'rdoc/task'
+rescue LoadError
+  # No rdoc
+else
+  desc 'Generate documentation for the Foreman Proxy plugin.'
+  Rake::RDocTask.new(:rdoc) do |rdoc|
+    rdoc.rdoc_dir = 'rdoc'
+    rdoc.title    = 'Proxy'
+    rdoc.options << '--line-numbers' << '--inline-source'
+    rdoc.rdoc_files.include('README.md')
+    rdoc.rdoc_files.include('lib/**/*.rb')
+  end
 end
 
 desc 'Migrate configuration settings.'

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -8,7 +8,6 @@ group :test do
   gem 'rubocop', '~> 0.80.0'
   gem 'rubocop-performance', '~> 1.5.2'
   gem 'rack-test'
-  gem 'rdoc'
   gem 'rake'
   gem 'rubocop-checkstyle_formatter', '~> 0.2'
   gem 'webmock'

--- a/modules/dhcp/dhcp_api.rb
+++ b/modules/dhcp/dhcp_api.rb
@@ -97,9 +97,9 @@ class Proxy::DhcpApi < ::Sinatra::Base
     server.add_record(params)
   rescue Proxy::DHCP::Collision => e
     log_halt 409, e
-  rescue Proxy::DHCP::AlreadyExists # rubocop:disable Lint/SuppressedException
-  # no need to do anything
-  rescue => e # rubocop:enable Lint/SuppressedException
+  rescue Proxy::DHCP::AlreadyExists
+    # no need to do anything
+  rescue => e
     log_halt 400, e
   end
 
@@ -123,9 +123,9 @@ class Proxy::DhcpApi < ::Sinatra::Base
     server.validate_supported_address(params[:network], params[:ip_address])
     server.del_records_by_ip(params[:network], params[:ip_address])
     nil
-  rescue ::Proxy::DHCP::SubnetNotFound # rubocop:disable Lint/SuppressedException
-  # no need to do anything
-  rescue Exception => e # rubocop:enable Lint/SuppressedException
+  rescue ::Proxy::DHCP::SubnetNotFound
+    # no need to do anything
+  rescue Exception => e
     log_halt 400, e
   end
 
@@ -135,9 +135,9 @@ class Proxy::DhcpApi < ::Sinatra::Base
     validate_mac(params[:mac_address])
     server.del_record_by_mac(params[:network], params[:mac_address].nil? ? nil : params[:mac_address].downcase)
     nil
-  rescue ::Proxy::DHCP::SubnetNotFound # rubocop:disable Lint/SuppressedException
-  # no need to do anything
-  rescue Exception => e # rubocop:enable Lint/SuppressedException
+  rescue ::Proxy::DHCP::SubnetNotFound
+    # no need to do anything
+  rescue Exception => e
     log_halt 400, e
   end
 end

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -23,6 +23,6 @@ begin
       exit($CHILD_STATUS.exitstatus)
     end
   end
-rescue LoadError # rubocop:disable Lint/SuppressedException
+rescue LoadError
   # ci/reporter/rake/rspec not present, skipping this definition
 end

--- a/test/log_buffer/decorator_test.rb
+++ b/test/log_buffer/decorator_test.rb
@@ -60,7 +60,7 @@ class DecoratorTest < Test::Unit::TestCase
     @decorator = ::Proxy::LogBuffer::Decorator.new(@logger, @buffer)
     @logger.expects(:add).with(FATAL, "message")
     @decorator.fatal("message")
-  rescue LoadError # rubocop:disable Lint/SuppressedException
+  rescue LoadError
     # skip the test - syslog isn't available on this platform
   end
 


### PR DESCRIPTION
By allowing the Rakefile to gracefully handle rdoc's absense it can be dropped from the test dependencies.

This also fixes the task so it actually runs in an additional commit. Given that it's been broken for so long it does suggest nobody uses it.