### PR TITLE
Fixes #34564 - Drop single_test gem dependency

### DIFF
--- a/bundler.d/development.rb
+++ b/bundler.d/development.rb
@@ -1,6 +1,5 @@
 group :development do
   # To use debugger
-  gem 'single_test'
   gem 'pry'
   gem 'rdoc'
 end

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,6 +1,5 @@
 group :test do
   gem 'mocha', '~> 1.10', :require => false
-  gem 'single_test'
   gem 'ci_reporter', '>= 1.6.3', "< 2.0.0", :require => false
   gem 'test-unit'
   gem 'benchmark-ips'


### PR DESCRIPTION
This gem is unmaintained and doesn't appear to be used.

It was added in 1112ca8ae2c96a50f32322760c968ffdd9354eeb but nothing else refers to it.