### PR TITLE
Fixes #34589 - Remove duplicate rsec gem definition

### DIFF
--- a/bundler.d/dhcp_isc.rb
+++ b/bundler.d/dhcp_isc.rb
@@ -1,9 +1,9 @@
+gem 'rsec', '< 1', groups: [:dhcp_isc_inotify, :dhcp_isc_kqueue]
+
 group :dhcp_isc_inotify do
-  gem 'rsec', '< 1'
   gem 'rb-inotify'
 end
 
 group :dhcp_isc_kqueue do
-  gem 'rsec', '< 1'
   gem 'rb-kqueue'
 end


### PR DESCRIPTION
This fixes the duplicate gem warning that bundler generates.