### PR TITLE
Fixes #34844 - load SSL keys using OpenSSL::PKey.read

### DIFF
--- a/extra/puppet_sign.rb
+++ b/extra/puppet_sign.rb
@@ -40,7 +40,7 @@ if protocol == 'https'
   res.ca_file      = SETTINGS[:ssl_ca_file]
   res.verify_mode  = OpenSSL::SSL::VERIFY_PEER
   res.cert         = OpenSSL::X509::Certificate.new(File.read(SETTINGS[:ssl_certificate]))
-  res.key          = OpenSSL::PKey::RSA.new(File.read(SETTINGS[:ssl_private_key]), nil)
+  res.key          = OpenSSL::PKey.read(File.read(SETTINGS[:ssl_private_key]), nil)
 end
 res.open_timeout = SETTINGS[:timeout]
 res.read_timeout = SETTINGS[:timeout]

--- a/extra/query.rb
+++ b/extra/query.rb
@@ -91,7 +91,7 @@ puts "#{$PROGRAM_NAME} --verb #{verb} --key #{key} --cert #{cert} --ca #{ca} #{j
 c = RestClient::Resource.new(
   url,
   :ssl_client_cert  =>  OpenSSL::X509::Certificate.new(File.read(cert)),
-  :ssl_client_key   =>  OpenSSL::PKey::RSA.new(File.read(key)),
+  :ssl_client_key   =>  OpenSSL::PKey.read(File.read(key)),
   :ssl_ca_file      =>  ca
 )
 

--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -110,7 +110,7 @@ module Proxy
     end
 
     def load_ssl_private_key(path)
-      OpenSSL::PKey::RSA.new(File.read(path))
+      OpenSSL::PKey.read(File.read(path))
     rescue Exception => e
       logger.error "Unable to load private SSL key. Are the values correct in settings.yml and do permissions allow reading?", e
       raise e

--- a/lib/proxy/request.rb
+++ b/lib/proxy/request.rb
@@ -79,7 +79,7 @@ module Proxy::HttpRequest
 
         if certificate && !certificate.to_s.empty? && private_key && !private_key.to_s.empty?
           http.cert = OpenSSL::X509::Certificate.new(File.read(certificate))
-          http.key  = OpenSSL::PKey::RSA.new(File.read(private_key), nil)
+          http.key  = OpenSSL::PKey.read(File.read(private_key), nil)
         end
       end
       http

--- a/modules/puppet_proxy_common/api_request.rb
+++ b/modules/puppet_proxy_common/api_request.rb
@@ -62,7 +62,7 @@ module Proxy::Puppet
 
         if ssl_cert && !ssl_cert.to_s.empty? && ssl_key && !ssl_key.to_s.empty?
           http.cert = OpenSSL::X509::Certificate.new(File.read(ssl_cert))
-          http.key  = OpenSSL::PKey::RSA.new(File.read(ssl_key), nil)
+          http.key  = OpenSSL::PKey.read(File.read(ssl_key), nil)
         end
       end
       http

--- a/modules/puppetca_token_whitelisting/puppetca_token_whitelisting_autosigner.rb
+++ b/modules/puppetca_token_whitelisting/puppetca_token_whitelisting_autosigner.rb
@@ -18,7 +18,7 @@ module ::Proxy::PuppetCa::TokenWhitelisting
     end
 
     def smartproxy_cert
-      @certificate ||= OpenSSL::PKey::RSA.new File.read cert_file
+      @certificate ||= OpenSSL::PKey.read File.read cert_file
     end
 
     def storage


### PR DESCRIPTION
This allows using non-RSA keys as PKey.read can figure out the type of key automatically