### PR TITLE
Fixes #35183 - Correctly call Timeout.timeout()

### DIFF
--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -37,7 +37,7 @@ module Proxy::Dns::Dnscmd
       std_in = std_out = std_err = nil
       real_cmd = ['c:\Windows\System32\dnscmd.exe', @server] + args
       begin
-        timeout(tsecs) do
+        Timeout.timeout(tsecs) do
           logger.debug { "executing: #{real_cmd}" }
           std_in, std_out, std_err = popen3(*real_cmd)
           response = [std_out&.readlines, std_err&.readlines].flatten.compact


### PR DESCRIPTION
At least in Ruby 3.1 calling timeout() as a global method is no longer allowed and Timetout.timeout is the correct way of calling it.