### PR TITLE
Fixes #35185 - Stub provider check in BmcTest

### DIFF
--- a/test/bmc/bmc_test.rb
+++ b/test/bmc/bmc_test.rb
@@ -3,6 +3,7 @@ require 'bmc/ipmi'
 
 class BmcTest < Test::Unit::TestCase
   def setup
+    Rubyipmi.stubs(:is_provider_installed?).with('ipmitool').returns(true)
     @args = { :username => "user", :password => "pass", :bmc_provider => "ipmitool", :host => "host" }
     @bmc  = Proxy::BMC::IPMI.new(@args)
   end


### PR DESCRIPTION
Rubyipmi checks if ipmitool is installed, but never actually uses it. Stubbing the presence check makes testing easier for developers.