### PR TITLE
Refs #33881 - Add deprecation warnings

### DIFF
--- a/lib/proxy/http_download.rb
+++ b/lib/proxy/http_download.rb
@@ -7,8 +7,8 @@ module Proxy
 
     def initialize(src, dst, read_timeout = nil, connect_timeout = nil, dns_timeout = nil, verify_server_cert = false)
       @dst = dst
-      logger.warn('Deprecated: HttpDownload read_timeout is deprecated and will be removed in 4.0') if read_timeout
-      logger.warn('Deprecated: HttpDownload dns_timeout is deprecated and will be removed in 4.0') if dns_timeout
+      logger.warn('Deprecated: HttpDownload read_timeout is deprecated and will be removed in 3.5') if read_timeout
+      logger.warn('Deprecated: HttpDownload dns_timeout is deprecated and will be removed in 3.5') if dns_timeout
       connect_timeout ||= DEFAULT_CONNECT_TIMEOUT
       args = [which('curl')]
 

--- a/lib/proxy/plugins.rb
+++ b/lib/proxy/plugins.rb
@@ -56,20 +56,24 @@ class ::Proxy::Plugins
   #
 
   def enabled_plugins
+    logger.warn('Proxy::Plugins#enabled_plugins is deprecated and will be removed in 3.5. Please use #select instead')
     loaded.select { |p| p[:state] == :running && p[:class].ancestors.include?(::Proxy::Plugin) }.map { |p| p[:class] }
   end
 
   def plugin_enabled?(plugin_name)
+    logger.warn('Proxy::Plugins#plugin_enabled? is deprecated and will be removed in 3.5. Please use #find instead')
     plugin = loaded.find { |p| p[:name] == plugin_name.to_sym }
     plugin.nil? ? false : plugin[:state] == :running
   end
 
   def find_plugin(plugin_name)
+    logger.warn('Proxy::Plugins#find_plugin is deprecated and will be removed in 3.5. Please use #find instead')
     p = loaded.find { |plugin| plugin[:name] == plugin_name.to_sym }
     return p[:class] if p
   end
 
   def find_provider(provider_name)
+    logger.warn('Proxy::Plugins#find_provider is deprecated and will be removed in 3.5. Please use #find instead')
     provider = loaded.find { |p| p[:name] == provider_name.to_sym }
     raise ::Proxy::PluginProviderNotFound, "Provider '#{provider_name}' could not be found" if provider.nil? || !provider[:class].ancestors.include?(::Proxy::Provider)
     provider[:class]

--- a/lib/proxy/provider_factory.rb
+++ b/lib/proxy/provider_factory.rb
@@ -1,6 +1,8 @@
 class ::Proxy::ProviderFactory
+  extend ::Proxy::Log
   class << self
     def get_provider(provider_name, opts = {})
+      logger.warn('Proxy::ProviderFactory class has been deprecated and will be removed in 3.5')
       provider = ::Proxy::Plugins.instance.find_provider(provider_name.to_sym)
       pf = provider.provider_factory
       pf.is_a?(Proc) ? pf.call(opts) : pf.new.get_provider(opts)


### PR DESCRIPTION
The Proxy::ProviderFactory has been unused since 1.11 (42b958156808eb2a16bd895863b196fca8f2977d) and the plugin methods have been unused since 1.12 (342eeda9a14422a30f08f3ce6539577ea6a740c8). This add deprecation warnings to allow plugin authors to adjust their code so they can be [removed in 3.5](https://github.com/theforeman/smart-proxy/pull/840).