### PR TITLE
Fixes #35384 - Add missing require 'timeout'

### DIFF
--- a/modules/dns_dnscmd/dns_dnscmd_main.rb
+++ b/modules/dns_dnscmd/dns_dnscmd_main.rb
@@ -1,4 +1,5 @@
 require 'open3'
+require 'timeout'
 
 module Proxy::Dns::Dnscmd
   class Record < ::Proxy::Dns::Record


### PR DESCRIPTION
This explicitly requires timeout rather than depending on it implicitly.

Replaces https://github.com/theforeman/smart-proxy/pull/829.

Fixes: aa25357d4404908d5e5707e767ecd798b754d7d1