### PR TITLE
Fixes #35467 - Use rackup_path helper in registration

### DIFF
--- a/modules/registration/registration_plugin.rb
+++ b/modules/registration/registration_plugin.rb
@@ -1,7 +1,6 @@
 module Proxy::Registration
   class Plugin < ::Proxy::Plugin
-    http_rackup_path  File.expand_path("http_config.ru", File.expand_path(__dir__))
-    https_rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
+    rackup_path File.expand_path("http_config.ru", File.expand_path(__dir__))
 
     plugin :registration, ::Proxy::VERSION
     requires :templates, ::Proxy::VERSION


### PR DESCRIPTION
Since 88fbc8e67d665e2c3b19acb53b31ff30acf078b7 there is a rackup_path helper that's equivalent to calling http_rackup_path and https_rackup_path with the same arguments.