### PR TITLE
Fixes #35468 - Verify boolean settings in modules

### DIFF
--- a/modules/dhcp/dhcp_plugin.rb
+++ b/modules/dhcp/dhcp_plugin.rb
@@ -3,6 +3,7 @@ class Proxy::DhcpPlugin < ::Proxy::Plugin
 
   uses_provider
   default_settings :use_provider => 'dhcp_isc', :server => '127.0.0.1', :subnets => [], :ping_free_ip => true
+  validate :ping_free_ip, boolean: true
   plugin :dhcp, ::Proxy::VERSION
 
   load_classes ::Proxy::DHCP::ConfigurationLoader

--- a/modules/dhcp_native_ms/dhcp_native_ms_plugin.rb
+++ b/modules/dhcp_native_ms/dhcp_native_ms_plugin.rb
@@ -3,6 +3,7 @@ module ::Proxy::DHCP::NativeMS
     plugin :dhcp_native_ms, ::Proxy::VERSION
 
     default_settings :disable_ddns => true, :blacklist_duration_minutes => 30 * 60
+    validate :disable_ddns, boolean: true
 
     requires :dhcp, ::Proxy::VERSION
 

--- a/modules/puppetca_token_whitelisting/puppetca_token_whitelisting_plugin.rb
+++ b/modules/puppetca_token_whitelisting/puppetca_token_whitelisting_plugin.rb
@@ -4,6 +4,7 @@ module ::Proxy::PuppetCa::TokenWhitelisting
 
     requires :puppetca, ::Proxy::VERSION
     default_settings :sign_all => false, :tokens_file => '/var/lib/foreman-proxy/tokens.yml', :token_ttl => 360
+    validate :sign_all, boolean: true
 
     load_classes ::Proxy::PuppetCa::TokenWhitelisting::PluginConfiguration
     load_dependency_injection_wirings ::Proxy::PuppetCa::TokenWhitelisting::PluginConfiguration

--- a/modules/realm_freeipa/realm_freeipa_plugin.rb
+++ b/modules/realm_freeipa/realm_freeipa_plugin.rb
@@ -3,6 +3,7 @@ module Proxy::FreeIPARealm
     default_settings :ipa_config => '/etc/ipa/default.conf',
       :remove_dns => true,
       :verify_ca => true
+    validate :remove_dns, :verify_ca, boolean: true
 
     load_classes ::Proxy::FreeIPARealm::ConfigurationLoader
     load_dependency_injection_wirings ::Proxy::FreeIPARealm::ConfigurationLoader

--- a/modules/tftp/tftp_plugin.rb
+++ b/modules/tftp/tftp_plugin.rb
@@ -7,6 +7,7 @@ module Proxy::TFTP
     default_settings :tftproot => '/var/lib/tftpboot',
                      :tftp_connect_timeout => 10,
                      :verify_server_cert => true
+    validate :verify_server_cert, boolean: true
 
     expose_setting :tftp_servername
   end


### PR DESCRIPTION
Since debffb85b60a5dfc2d5347075d8f2089573f289f it's possible to validate boolean settings. Validating settings makes it harder to misconfigure modules.