### PR TITLE
Fixes #35510 - Depend on webrick for Ruby 3

### DIFF
--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rack', '>= 1.3'
   s.add_dependency 'sd_notify', '~> 0.1'
   s.add_dependency 'sinatra', '~> 2.0'
+  s.add_dependency 'webrick', '~> 1.0'
   s.description = <<~EOF
     Foreman Proxy is used via The Foreman Project, it allows Foreman to manage
     Remote DHCP, DNS, TFTP and Puppet servers via a REST API


### PR DESCRIPTION
This has always been a dependency, but Ruby 3 has dropped the code. It's now a regular gem.

It is set in the gemspec since that allows plugins to also benefit from it. That does mean that it's also required on older Ruby versions and should be packaged.