### PR TITLE
Implement a verification API

### DIFF
--- a/lib/proxy/verify_runtime.rb
+++ b/lib/proxy/verify_runtime.rb
@@ -1,0 +1,52 @@
+module Proxy
+  class VerifyRuntime
+    class << self
+      # RFC5737 declares 192.0.2.0/24 as TEST-NET-1
+      MOCK_IP = '192.0.2.42'
+
+      def settings
+        Proxy::SETTINGS
+      end
+
+      def verify
+        {
+          reverse_proxy: verify_reverse_proxy,
+        }
+      end
+
+      def verify_reverse_proxy
+        # It's valid if there is no Foreman URL
+        return true unless settings.foreman_url
+
+        # Only needed for templates / registration
+        # TODO: make this more generic
+        return true unless ::Proxy::Plugins.instance.any? { |p| p[:state] == :running && ['templates', 'registration'].include?(p[:name]) }
+
+        foreman = Proxy::HttpRequest::ForemanRequest.new
+        request = foreman.request_factory.create_get('/api/status', headers: {'X-Forwarded-For': MOCK_IP})
+        response = foreman.send_request(request)
+
+        if response.status != '200'
+          logger.info("Foreman status API returned #{response.status}")
+          return false
+        end
+
+        status = JSON.parse(response.body)
+        unless status.key?('remote_ip')
+          message = if ::Gem::Dependency.new('', '>= 3.5.0').match?('', status['version'])
+                      "Foreman Proxy authentication broken"
+                    else
+                      "Foreman status doesn't have a remote_ip because Foreman is too old"
+                    end
+          logger.info(message)
+          return false
+        end
+
+        status['remote_ip'] == MOCK_IP
+      rescue StandardError => e
+        logger.exception('Failed to verify Foreman reverse proxy setup', e)
+        false
+      end
+    end
+  end
+end

--- a/modules/root/root_api.rb
+++ b/modules/root/root_api.rb
@@ -1,3 +1,5 @@
+require 'proxy/verify_runtime'
+
 class Proxy::RootApi < Sinatra::Base
   helpers ::Proxy::Helpers
 
@@ -17,5 +19,10 @@ class Proxy::RootApi < Sinatra::Base
     {:version => Proxy::VERSION, :modules => modules}.to_json
   rescue => e
     log_halt 400, e
+  end
+
+  get "/verify" do
+    content_type :json
+    Proxy::VerifyRuntime.verify.to_json
   end
 end


### PR DESCRIPTION
The goal of this is to have an end-to-end verification of compatibility or provide concrete pointers to what failed.