### PR TITLE
Refs #35738 - Add a git mailmap

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,3 @@
+Paul Kelly <paul.ian.kelly@googlemail.com> Paul kelly <paul.ian.kelly@googlemail.com> <paul.ian.kelly@gmail.com> <pikelly@blueyonder.co.uk>
+Leos Stejskal <lstejska@redhat.com> <github@stejskalleos.cz>
+Lukáš Zapletal <lzap@redhat.com> <lzap+git@redhat.com>


### PR DESCRIPTION
This allows mapping various variations on names back to a single name.
That helps in properly crediting the right people in our release notes.

I didn't go through the historical authors too much. Instead I focused on the authors since 3.0.0 and did a quick look through all authors and noticed Paul. As one of the founders I thought it was nice to include him too.