### PR TITLE
Fixes #36138 - Invalid syntax for curl --time-cond

### DIFF
--- a/lib/proxy/http_download.rb
+++ b/lib/proxy/http_download.rb
@@ -26,7 +26,7 @@ module Proxy
       # keep last changed file attribute
       args << "--remote-time"
       # only download newer files
-      args += ["--time-cond", dst.to_s]
+      args += ["--time-cond", "file", dst.to_s]
       # print stats in the end
       args += [
         "--write-out",

--- a/test/http_download_test.rb
+++ b/test/http_download_test.rb
@@ -17,7 +17,7 @@ class HttpDownloadsTest < Test::Unit::TestCase
       "--retry-delay", "10",
       "--max-time", "3600",
       "--remote-time",
-      "--time-cond", "dst",
+      "--time-cond", "file", "dst",
       "--write-out", "Task done, result: %{http_code}, size downloaded: %{size_download}b, speed: %{speed_download}b/s, time: %{time_total}ms",
       "--output", "dst",
       "--location", "src"
@@ -34,7 +34,7 @@ class HttpDownloadsTest < Test::Unit::TestCase
       "--retry-delay", "10",
       "--max-time", "3600",
       "--remote-time",
-      "--time-cond", "dst",
+      "--time-cond", "file", "dst",
       "--write-out", "Task done, result: %{http_code}, size downloaded: %{size_download}b, speed: %{speed_download}b/s, time: %{time_total}ms",
       "--output", "dst",
       "--location", "src"


### PR DESCRIPTION
Fixes: 3d87c6f
According to Curl man page, syntax for `--time-cond` attribute should be `--time-cond file <path>`, not `--time-cond <path>`.

This can cause issues with outdated vmlinuz and initrd.img files,
once the files are downloaded, they are never replaced with never versions.

**How to test**
* Provision host (baremetal, networking)
* `touch -a -m -t 201512180130.09 initrd.img & vmlinuz` in `/var/lib/tftpboot/boot`
* Provision another host with same OS
* Check that files have been updated

[0] https://curl.se/docs/manpage.html