### PR TITLE
Fixes #36209 - tftp initrd/vmlinux generation: curl malformed

### DIFF
--- a/lib/proxy/http_download.rb
+++ b/lib/proxy/http_download.rb
@@ -26,7 +26,7 @@ module Proxy
       # keep last changed file attribute
       args << "--remote-time"
       # only download newer files
-      args += ["--time-cond", "file", dst.to_s]
+      args += ["--time-cond", dst.to_s]
       # print stats in the end
       args += [
         "--write-out",

--- a/test/http_download_test.rb
+++ b/test/http_download_test.rb
@@ -17,7 +17,7 @@ class HttpDownloadsTest < Test::Unit::TestCase
       "--retry-delay", "10",
       "--max-time", "3600",
       "--remote-time",
-      "--time-cond", "file", "dst",
+      "--time-cond", "dst",
       "--write-out", "Task done, result: %{http_code}, size downloaded: %{size_download}b, speed: %{speed_download}b/s, time: %{time_total}ms",
       "--output", "dst",
       "--location", "src"
@@ -34,7 +34,7 @@ class HttpDownloadsTest < Test::Unit::TestCase
       "--retry-delay", "10",
       "--max-time", "3600",
       "--remote-time",
-      "--time-cond", "file", "dst",
+      "--time-cond", "dst",
       "--write-out", "Task done, result: %{http_code}, size downloaded: %{size_download}b, speed: %{speed_download}b/s, time: %{time_total}ms",
       "--output", "dst",
       "--location", "src"


### PR DESCRIPTION
This reverts commit fba49ab1eb9bbe383572575309558ff628f5de60.

https://github.com/theforeman/smart-proxy/pull/856 was fixing invalid curl `--time-cont` condition, but it actually break it and now files are not downloaded at all.

I'm still looking into the details what happened and why I didn't catch it during development and reviews.
Revert tested on Fedora 37 & RHEL 8 and it works correctly as before did.

https://community.theforeman.org/t/curl-url-malformed-during-initrd-and-vmlinux-tftp-copy/32850/4