### PR TITLE
Revert "Templates - Return Foreman's API status code instead of 500"

### DIFF
--- a/lib/proxy/helpers.rb
+++ b/lib/proxy/helpers.rb
@@ -20,7 +20,7 @@ module Proxy::Helpers
     rescue => e
       exception = e
       message += e.message
-      code ||= e.status_code
+      code ||= 400
     end
     content_type :json if request.accept?("application/json")
     logger.error message, exception

--- a/modules/templates/proxy_request.rb
+++ b/modules/templates/proxy_request.rb
@@ -48,7 +48,7 @@ module Proxy::Templates
       logger.debug "HTTP headers: #{proxy_headers.inspect}"
       res = send_request(proxy_req)
       # You get a 201 from the 'built' URL
-      raise ::Proxy::Error::HttpError.new(res.code.to_i, nil, "Error retrieving #{path} for #{opts.inspect} from #{uri.host}: #{res.class}") unless ["200", "201"].include?(res.code)
+      raise "Error retrieving #{path} for #{opts.inspect} from #{uri.host}: #{res.class}" unless ["200", "201"].include?(res.code)
       res.body
     end
   end

--- a/modules/templates/templates_unattended_api.rb
+++ b/modules/templates/templates_unattended_api.rb
@@ -13,19 +13,19 @@ class Proxy::TemplatesUnattendedApi < Sinatra::Base
   end
 
   get "/:kind/:template/:hostgroup" do |kind, template, hostgroup|
-    log_halt(nil, "Failed to retrieve #{kind} hostgroup template for #{params.inspect}: ") do
+    log_halt(500, "Failed to retrieve #{kind} hostgroup template for #{params.inspect}: ") do
       Proxy::Templates::TemplateProxyRequest.new.get([kind, template, hostgroup], request.env, params)
     end
   end
 
   get "/:kind" do |kind|
-    log_halt(nil, "Failed to proxy /#{kind} for #{params.inspect}: ") do
+    log_halt(500, "Failed to proxy /#{kind} for #{params.inspect}: ") do
       Proxy::Templates::TemplateProxyRequest.new.get([kind], request.env, params)
     end
   end
 
   post "/:kind" do |kind|
-    log_halt(nil, "Failed to proxy /#{kind} for #{params.inspect}: ") do
+    log_halt(500, "Failed to proxy /#{kind} for #{params.inspect}: ") do
       params["Content-Type"] = "text/plain"
       Proxy::Templates::TemplateProxyRequest.new.post([kind], request.env, params, request.body.read)
     end

--- a/test/templates/template_proxy_request_test.rb
+++ b/test/templates/template_proxy_request_test.rb
@@ -86,22 +86,4 @@ class TemplateProxyRequestTest < Test::Unit::TestCase
     result = Proxy::Templates::TemplateProxyRequest.new.get('provision', @request_env, args)
     assert_equal(@expected_body, result)
   end
-
-  def test_post_status_code_from_foreman
-    stub_request(:post, @foreman_url + '/unattended/built?token=test-token&url=' + @template_url).to_return(status: 401)
-    error = assert_raises ::Proxy::Error::HttpError do
-      Proxy::Templates::TemplateProxyRequest.new.post('built', @request_env, { :token => "test-token" }, "")
-    end
-
-    assert_equal error.status_code, 401
-  end
-
-  def test_get_status_code_from_foreman
-    stub_request(:get, @foreman_url + '/unattended/built?token=test-token&url=' + @template_url).to_return(status: 401)
-    error = assert_raises ::Proxy::Error::HttpError do
-      Proxy::Templates::TemplateProxyRequest.new.get('built', @request_env, { :token => "test-token" })
-    end
-
-    assert_equal error.status_code, 401
-  end
 end


### PR DESCRIPTION
Reverts theforeman/smart-proxy#864