### PR TITLE
Fixes #36325 - Support key-algorithm in omshell

### DIFF
--- a/config/settings.d/dhcp_isc.yml.example
+++ b/config/settings.d/dhcp_isc.yml.example
@@ -18,6 +18,8 @@
 # Specifies TSIG key name and secret
 #:key_name: secret_key_name
 #:key_secret: secret_key
+# This needs to match the server configuration
+#:key_algorithm: HMAC-MD5
 
 #:omapi_port: 7911
 

--- a/modules/dhcp_common/isc/omapi_provider.rb
+++ b/modules/dhcp_common/isc/omapi_provider.rb
@@ -6,11 +6,12 @@ module Proxy::DHCP::CommonISC
     include Proxy::Util
     attr_reader :omapi_port, :key_name, :key_secret
 
-    def initialize(server, omapi_port, subnets = nil, key_name = nil, key_secret = nil, service = nil, free_ips_service = nil)
+    def initialize(server, omapi_port, subnets = nil, key_name = nil, key_secret = nil, service = nil, free_ips_service = nil, key_algorithm = nil)
       super(server, subnets, service, free_ips_service)
       # TODO: verify key name and secret
       @key_name = key_name
       @key_secret = key_secret
+      @key_algorithm = key_algorithm
       @omapi_port = omapi_port
     end
 
@@ -67,6 +68,7 @@ module Proxy::DHCP::CommonISC
     end
 
     def om_connect
+      omcmd("key-algorithm #{@key_algorithm}") if @key_algorithm
       omcmd("key #{@key_name} \"#{@key_secret}\"", true) if @key_name && @key_secret
       omcmd "server #{name}"
       omcmd "port #{@omapi_port}"

--- a/modules/dhcp_isc/configuration_loader.rb
+++ b/modules/dhcp_isc/configuration_loader.rb
@@ -42,7 +42,7 @@ module Proxy::DHCP::ISC
       container.dependency :dhcp_provider, (lambda do
         Proxy::DHCP::CommonISC::IscOmapiProvider.new(
           settings[:server], settings[:omapi_port], settings[:subnets], settings[:key_name], settings[:key_secret],
-          container.get_dependency(:subnet_service), container.get_dependency(:free_ips))
+          container.get_dependency(:subnet_service), container.get_dependency(:free_ips), settings[:key_algorithm])
       end)
     end
 


### PR DESCRIPTION
EL 8.2 [introduced support](https://access.redhat.com/errata/RHBA-2021:1623) for specifying key-algorithm in omshell and Debian stable also supports this. If unspecified, it defaults to the insecure HMAC-MD5. Especially on FIPS (where MD5 is forbidden) this is problematic.