### PR TITLE
Fixes #36729 - Implement pruning outdated TFTP files

### DIFF
--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -63,6 +63,13 @@ module Proxy::TFTP
         logger.debug "TFTP: Skipping a request to delete a file which doesn't exists"
       end
     end
+
+    def self.outdated_files(age)
+      delete_before = Time.now - age
+      Dir.glob(File.join(Proxy::TFTP::Plugin.settings.tftproot, "boot", "*-{vmlinuz,initrd.img}")).filter do |file|
+        File.file?(file) && File.mtime(file) < delete_before
+      end
+    end
   end
 
   class Syslinux < Server


### PR DESCRIPTION
This is about replacing [foreman_maintain's check_tftp_storage](https://github.com/theforeman/foreman_maintain/blob/1e20bbd9f32a4f47193c4833fbd4012772b34dc4/definitions/checks/foreman_proxy/check_tftp_storage.rb) with a native implementation. It is implemented by a /tftp/prune API endpoint which accepts the duration as a parameter.

There is no plugin capability defined since Foreman can just call the endpoint and process HTTP 404 as Not Implemented.

A follow up in Foreman would implement a way to call this endpoint for all Smart Proxies with the TFTP feature present. Foreman does not depend on foreman-tasks natively, but it could be implemented in some cron-style way to make the system handle it automatically instead of putting the burden on the admin.