### PR TITLE
Fixes #36779 - Set minimum Ruby version to 2.7

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ require:
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 
 Bundler/OrderedGems:
   Enabled: false

--- a/modules/puppet_proxy_common/puppet_class.rb
+++ b/modules/puppet_proxy_common/puppet_class.rb
@@ -16,7 +16,7 @@ module Proxy::Puppet
 
     # returns class name (excluding of the module name)
     def name
-      has_module?(klass) ? klass[(klass.index("::") + 2)..-1] : klass
+      has_module?(klass) ? klass[(klass.index("::") + 2)..] : klass
     end
 
     attr_reader :params

--- a/modules/registration/proxy_request.rb
+++ b/modules/registration/proxy_request.rb
@@ -46,7 +46,7 @@ module Proxy::Registration
     end
 
     def headers(request)
-      Hash[request.env.select { |k, v| k =~ /^HTTP_/ && k !~ /^HTTP_(VERSION|HOST)$/ }.map { |k, v| [k[5..-1], v] }]
+      Hash[request.env.select { |k, v| k =~ /^HTTP_/ && k !~ /^HTTP_(VERSION|HOST)$/ }.map { |k, v| [k[5..], v] }]
     rescue Exception => e
       logger.warn "Unable to extract request headers: #{e}"
       {}

--- a/modules/templates/proxy_request.rb
+++ b/modules/templates/proxy_request.rb
@@ -17,7 +17,7 @@ module Proxy::Templates
     end
 
     def extract_request_headers(env)
-      Hash[env.select { |k, v| k =~ /^HTTP_/ && k !~ /^HTTP_(VERSION|HOST)$/ }.map { |k, v| [k[5..-1], v] }]
+      Hash[env.select { |k, v| k =~ /^HTTP_/ && k !~ /^HTTP_(VERSION|HOST)$/ }.map { |k, v| [k[5..], v] }]
     rescue Exception => e
       logger.warn "Unable to extract request headers: #{e}"
       {}

--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir.glob("{test}/**/*test.rb")
   s.license = 'GPL-3.0'
   s.extra_rdoc_files = ["README.md"]
-  s.required_ruby_version = '>= 2.5'
+  s.required_ruby_version = '>= 2.7'
   s.add_dependency 'json'
   s.add_dependency 'logging'
   s.add_dependency 'rack', '>= 1.3'


### PR DESCRIPTION
In practice we only test with Ruby 2.7, so this formalizes it. There is one cop I needed to fix.