### PR TITLE
Fixes #36833 - Add SecureBoot support for arbitrary operating systems to "Grub2 UEFI" PXE loaders

### DIFF
--- a/modules/tftp/tftp_api.rb
+++ b/modules/tftp/tftp_api.rb
@@ -18,8 +18,9 @@ module Proxy::TFTP
         Object.const_get("Proxy").const_get('TFTP').const_get(variant.capitalize).new
       end
 
-      def create(variant, mac)
+      def create(variant, mac, os: nil, release: nil, arch: nil, bootfile_suffix: nil)
         tftp = instantiate variant, mac
+        log_halt(400, "TFTP: Failed to setup host specific bootloader directory: ") { tftp.setup_bootloader(mac: mac, os: os, release: release, arch: arch, bootfile_suffix: bootfile_suffix) }
         log_halt(400, "TFTP: Failed to create pxe config file: ") { tftp.set(mac, (params[:pxeconfig] || params[:syslinux_config])) }
       end
 
@@ -48,7 +49,7 @@ module Proxy::TFTP
     end
 
     post "/:variant/:mac" do |variant, mac|
-      create variant, mac
+      create variant, mac, os: params[:targetos], release: params[:release], arch: params[:arch], bootfile_suffix: params[:bootfile_suffix]
     end
 
     delete "/:variant/:mac" do |variant, mac|

--- a/modules/tftp/tftp_plugin.rb
+++ b/modules/tftp/tftp_plugin.rb
@@ -2,6 +2,8 @@ module Proxy::TFTP
   class Plugin < ::Proxy::Plugin
     plugin :tftp, ::Proxy::VERSION
 
+    capability :bootloader_universe
+
     rackup_path File.expand_path("http_config.ru", __dir__)
 
     default_settings :tftproot => '/var/lib/tftpboot',

--- a/test/tftp/integration_test.rb
+++ b/test/tftp/integration_test.rb
@@ -14,7 +14,7 @@ class TftpApiFeaturesTest < SmartProxyRootApiTestCase
     mod = response['tftp']
     refute_nil(mod)
     assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:tftp])
-    assert_equal([], mod['capabilities'])
+    assert_equal(["bootloader_universe"], mod['capabilities'])
 
     expected_settings = { 'tftp_servername' => 'tftp.example.com' }
     assert_equal(expected_settings, mod['settings'])

--- a/test/tftp/tftp_server_test.rb
+++ b/test/tftp/tftp_server_test.rb
@@ -46,6 +46,10 @@ module TftpGenericServerSuite
     end
     @subject.create_default @content
   end
+
+  def test_dashed_mac
+    assert "aa-bb-cc-dd-ee-ff", @subject.dashed_mac(@mac)
+  end
 end
 
 class HelperServerTest < Test::Unit::TestCase
@@ -111,10 +115,89 @@ end
 class TftpPxegrub2ServerTest < Test::Unit::TestCase
   include TftpGenericServerSuite
 
+  def setup
+    @arch = "x86_64"
+    @bootfile_suffix = "x64"
+    @os = "redhat"
+    @release = "9.4"
+    super
+  end
+
   def setup_paths
     @subject = Proxy::TFTP::Pxegrub2.new
-    @pxe_config_files = ["grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff", "grub2/grub.cfg-aa:bb:cc:dd:ee:ff"]
+    @pxe_config_files = [
+      "host-config/aa-bb-cc-dd-ee-ff/grub2/grub.cfg",
+      "host-config/aa-bb-cc-dd-ee-ff/grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff",
+      "host-config/aa-bb-cc-dd-ee-ff/grub2/grub.cfg-aa:bb:cc:dd:ee:ff",
+      "grub2/grub.cfg-01-aa-bb-cc-dd-ee-ff",
+      "grub2/grub.cfg-aa:bb:cc:dd:ee:ff",
+    ]
     @pxe_default_files = ["grub2/grub.cfg"]
+  end
+
+  def test_pxeconfig_dir
+    assert_equal File.join(@subject.path, "host-config", @subject.dashed_mac(@mac).downcase, "grub2"), @subject.pxeconfig_dir(@mac)
+    assert_equal File.join(@subject.path, "grub2"), @subject.pxeconfig_dir()
+  end
+
+  def test_release_specific_bootloader_path
+    release_specific_bootloader_path = File.join(@subject.path, "bootloader-universe/pxegrub2", @os, @release, @arch)
+    Dir.stubs(:exist?).with(release_specific_bootloader_path).returns(true).once
+    assert_equal release_specific_bootloader_path, @subject.bootloader_path(@os, @release, @arch)
+  end
+
+  def test_default_bootloader_path
+    release_specific_bootloader_path = File.join(@subject.path, "bootloader-universe/pxegrub2", @os, @release, @arch)
+    default_bootloader_path = File.join(@subject.path, "bootloader-universe/pxegrub2", @os, "default", @arch)
+    Dir.stubs(:exist?).with(release_specific_bootloader_path).returns(false).once
+    Dir.stubs(:exist?).with(default_bootloader_path).returns(true).once
+    assert_equal default_bootloader_path, @subject.bootloader_path(@os, @release, @arch)
+  end
+
+  def test_bootloader_universe_symlinks
+    temp_dir = Dir.mktmpdir()
+    pxeconfig_dir_mac = @subject.pxeconfig_dir(@mac)
+    symlinks = [
+      { source: File.join(temp_dir, "dummy1.efi"), symlink: File.join(pxeconfig_dir_mac, "dummy1.efi") },
+      { source: File.join(temp_dir, "dummy2.efi"), symlink: File.join(pxeconfig_dir_mac, "dummy2.efi") },
+    ]
+    symlinks.each do |entry|
+      FileUtils.touch(entry[:source])
+    end
+    assert_equal(
+      symlinks.sort_by { |entry| entry[:source] },
+      @subject.bootloader_universe_symlinks(temp_dir, pxeconfig_dir_mac).sort_by { |entry| entry[:source] }
+    )
+  end
+
+  def test_default_symlinks
+    pxeconfig_dir = @subject.pxeconfig_dir
+    pxeconfig_dir_mac = @subject.pxeconfig_dir(@mac)
+    symlinks = [
+      { source: File.join(pxeconfig_dir, "grub#{@bootfile_suffix}.efi"), symlink: File.join(pxeconfig_dir_mac, "boot.efi") },
+      { source: File.join(pxeconfig_dir, "grub#{@bootfile_suffix}.efi"), symlink: File.join(pxeconfig_dir_mac, "grub#{@bootfile_suffix}.efi") },
+      { source: File.join(pxeconfig_dir, "shim#{@bootfile_suffix}.efi"), symlink: File.join(pxeconfig_dir_mac, "boot-sb.efi") },
+      { source: File.join(pxeconfig_dir, "shim#{@bootfile_suffix}.efi"), symlink: File.join(pxeconfig_dir_mac, "shim#{@bootfile_suffix}.efi") },
+    ]
+    assert_equal symlinks, @subject.default_symlinks(@bootfile_suffix, @subject.pxeconfig_dir(@mac))
+  end
+
+  def test_create_symlinks
+    symlinks = [
+      { source: "/path/to/source1", symlink: "/path/to/symlink1" },
+      { source: "/path/to/source2", symlink: "/another/path/to/symlink2" },
+    ]
+    FileUtils.expects(:ln_s).with("source1", "/path/to/symlink1", {:force => true}).once
+    FileUtils.expects(:ln_s).with("../../../path/to/source2", "/another/path/to/symlink2", {:force => true}).once
+    @subject.create_symlinks(symlinks)
+  end
+
+  def test_del
+    pxe_config_files.each do |file|
+      @subject.expects(:delete_file).with(file).once
+    end
+    @subject.expects(:delete_host_dir).with(@mac).once
+    @subject.del @mac
   end
 end
 


### PR DESCRIPTION
This feature consists of two patches, one for foreman and one for smart-proxy.

This patch introduces a new loader of kind `:PXEGrub2TargetOS` which allows to provide host-specific Network Bootstrap Programs (NPB) in order to enable network based installations for SecureBoot-enabled hosts.

SecureBoot expects to follow a chain of trust from the start of the host to the loading of Linux kernel modules. The very first shim that is loaded basically determines which distribution is allowed to be booted or kexec'ed until next reboot.

The existing "Grub2 UEFI SecureBoot" is not sufficiant as it limits the possible installations to the vendor of the Foreman (Smart Proxy) host system.

Providing shim and GRUB2 by the vendor of the to-be-installed operating system allows Foreman to install any operating system on SecureBoot-enabled hosts over network.

To achieve this, the host's DHCP filename option is set to a shim path in a directory that is host-specific (contains MAC address). Corresponding shim and GRUB2 binaries are copied into that directory along with the generated GRUB2 configuration files as we know from "Grub2 UEFI".

The required binaries must be provided once in the so called "bootloader universe". This directory can be configured via the settings file `/etc/foreman-proxy/settings.d/tftp.yml` and defaults to `/usr/local/share/bootloader-universe/<os>/`. These binaries can be manually retrieved from the installation media and is not part of this patchset.

Full example:
-------------
```console
[root@vm ~]# hammer host info --id 241 | grep -E "(MAC address|Operating System)"
    MAC address:  00:50:56:b4:75:5e
    Operating System:       Ubuntu 22.04 LTS

[root@vm ~]# tree /usr/local/share/bootloader-universe/ /usr/local/share/bootloader-universe/
|-- centos
|   |-- grubx64.efi
|   `-- shimx64.efi
`-- ubuntu
    |-- grubx64.efi
    `-- shimx64.efi

[root@vm ~]# hammer host update --id 241 --build true

[root@vm ~]# tree /var/lib/tftpboot/grub2/00-50-56-b4-75-5e/ /var/lib/tftpboot/grub2/00-50-56-b4-75-5e/
|-- grub.cfg
|-- grub.cfg-00:50:56:b4:75:5e
|-- grub.cfg-01-00-50-56-b4-75-5e
|-- grubx64.efi
|-- shimx64.efi
`-- targetos

[root@vm ~]# grep -B2 00-50-56-b4-75-5e /var/lib/dhcpd/dhcpd.leases
  hardware ethernet 00:50:56:b4:75:5e;
  fixed-address 192.168.145.84;
        supersede server.filename = "grub2/00-50-56-b4-75-5e/shimx64.efi";

[root@vm ~]# pesign -S -i /var/lib/tftpboot/grub2/00-50-56-b4-75-5e/grubx64.efi | grep Canonical The signer's common name is Canonical Ltd. Secure Boot Signing (2021 v1)
```