### PR TITLE
Fixes #36890 - Use PrivateTmp in systemd service

### DIFF
--- a/extra/systemd/foreman-proxy.service
+++ b/extra/systemd/foreman-proxy.service
@@ -8,6 +8,7 @@ Type=notify
 User=foreman-proxy
 ExecStart=/usr/share/foreman-proxy/bin/smart-proxy
 Environment=MALLOC_ARENA_MAX=2
+PrivateTmp=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This allows for better isolation and addresses issues raised by `fapolicyd` (https://github.com/theforeman/foreman-fapolicyd/issues/8).