### PR TITLE
fixes #27290 - allow foreman to delete host having service certificate

### DIFF
--- a/sbin/foreman-prepare-realm
+++ b/sbin/foreman-prepare-realm
@@ -59,7 +59,8 @@ else
     --permission='System: Manage Host Certificates' --permission='System: Modify Hosts' --permission='System: Remove Hosts' \
     --permission='System: Manage Host Keytab' --permission='Retrieve Certificates from the CA' --permission='System: Modify Services' \
     --permission='System: Manage Service Keytab' --permission='System: Add DNS Entries' --permission='System: Update DNS Entries' \
-    --permission='System: Remove DNS Entries' --permission='System: Read DNS Entries' --permission='Add Host Enrollment Password'
+    --permission='System: Remove DNS Entries' --permission='System: Read DNS Entries' --permission='Add Host Enrollment Password' \
+    --permission='Revoke Certificate' --permission='System: Remove Services'
 fi
 
 ipa role-add 'Smart Proxy Host Manager' --desc='Smart Proxy management'


### PR DESCRIPTION
Hello guys, 

We just identified this error that we likely have for a long time but never cause issue before.

Foreman is not able to clean host entries from freeIPA when the host have a service certificate. There is no error on the web interface, but host, service , certificate, dns, entries are still present in freeIPA.

First,  Foreman can't revoke certificate
```
$ less /var/log/foreman-proxy/proxy.log
2023-12-07T15:06:09 38ee19ed [I] Started DELETE /realm/EXAMPLE.COM/pan91.sandbox.example.com
2023-12-07T15:06:10 38ee19ed [E] Insufficient access: not allowed to perform operation: revoke certificate
2023-12-07T15:06:10 38ee19ed [W] Error details for Insufficient access: not allowed to perform operation: revoke certificate: <XMLRPC::FaultException>: Insufficient access: not allowed to perform operation: revoke certificate  2023-12-07T15:06:10 38ee19ed [W] Insufficient access: not allowed to perform operation: revoke certificate: <XMLRPC::FaultException>: Insufficient access: not allowed to perform operation: revoke certificate`
```
=> so i added perms 'Revoke Certificate'


Then Foreman can't delete the 'HTTP service'
```
$ less /var/log/foreman-proxy/proxy.log
2023-12-07T16:37:25 385d6cda [I] Started DELETE /realm/EXAMPLE.COM/pan91.sandbox.example.com
2023-12-07T16:37:26 385d6cda [E] Insufficient access: Insufficient 'delete' privilege to delete the entry 'krbprincipalname=HTTP/pan91.sandbox.example.com@EXAMPLE.COM,cn=services,cn=accounts,dc=example,dc=com'.
2023-12-07T16:37:26 385d6cda [W] Error details for Insufficient access: Insufficient 'delete' privilege to delete the entry 'krbprincipalname=HTTP/pan91.sandbox.example.com@EXAMPLE.COM,cn=services,cn=accounts,dc=example,dc=com'.: <XMLRPC::FaultException>: Insufficient access: Insufficient 'delete' privilege to delete the entry 'krbprincipalname=HTTP/pan91.sandbox.example.com@EXAMPLE.COM,cn=services,cn=accounts,dc=example,dc=com'.
2023-12-07T16:37:26 385d6cda [W] Insufficient access: Insufficient 'delete' privilege to delete the entry 'krbprincipalname=HTTP/pan91.sandbox.example.com@EXAMPLE.COM,cn=services,cn=accounts,dc=example,dc=com'.: <XMLRPC::FaultException>: Insufficient access: Insufficient 'delete' privilege to delete the entry 'krbprincipalname=HTTP/pan91.sandbox.example.com@EXAMPLE.COM,cn=services,cn=accounts,dc=example,dc=com'.
/
```
=> so i added perms 'System: Remove Services'

then it cleans freeIPA entries.

Let me know if you need any further details on this matter
cc @bagasse ;)