### PR TITLE
Use RUBY_PLATFORM to decide between rb-inotify and rb-kqueue

### DIFF
--- a/bundler.d/dhcp_isc.rb
+++ b/bundler.d/dhcp_isc.rb
@@ -1,9 +1,5 @@
-gem 'rsec', '< 1', groups: [:dhcp_isc_inotify, :dhcp_isc_kqueue]
-
-group :dhcp_isc_inotify do
-  gem 'rb-inotify'
-end
-
-group :dhcp_isc_kqueue do
-  gem 'rb-kqueue'
+group :dhcp_isc do
+  gem 'rb-inotify', install_if: -> { RUBY_PLATFORM.match?(/linux/) }
+  gem 'rb-kqueue', install_if: -> { RUBY_PLATFORM.match?(/bsd/) }
+  gem 'rsec', '< 1', platforms: [:ruby]
 end

--- a/bundler.d/krb5.rb
+++ b/bundler.d/krb5.rb
@@ -1,4 +1,4 @@
 group :krb5 do
-  gem 'rkerberos', '>= 0.1.1'
-  gem 'gssapi'
+  gem 'rkerberos', '>= 0.1.1', platforms: [:ruby]
+  gem 'gssapi', platforms: [:ruby]
 end

--- a/bundler.d/libvirt.rb
+++ b/bundler.d/libvirt.rb
@@ -1,3 +1,3 @@
 group :libvirt do
-  gem 'ruby-libvirt', '>= 0.6.0'
+  gem 'ruby-libvirt', '>= 0.6.0', platforms: [:ruby]
 end

--- a/bundler.d/windows.rb
+++ b/bundler.d/windows.rb
@@ -1,5 +1,5 @@
 group :windows do
-  gem 'highline', :platforms => [:mingw, :x64_mingw]
-  gem 'win32-service', :platforms => [:mingw, :x64_mingw]
+  gem 'highline', platforms: [:windows]
+  gem 'win32-service', platforms: [:windows]
   gem 'dhcpsapi', '>= 0.0.11', '< 1.0.0'
 end


### PR DESCRIPTION
This matches what modules/dhcp_isc/configuration_loader.rb does in load_programmable_settings.

Currently untested.