### PR TITLE
Fixes #37147 - Pass --fail option to curl

### DIFF
--- a/lib/proxy/http_download.rb
+++ b/lib/proxy/http_download.rb
@@ -15,6 +15,8 @@ module Proxy
       args << "--silent"
       # except errors
       args << "--show-error"
+      # force it to set an exit code on failure
+      args << "--fail"
       # timeout (others were supported by wget but not by curl)
       args += ["--connect-timeout", connect_timeout.to_s]
       # try several times


### PR DESCRIPTION
This prevents curl from writing out error pages, for example when the URL returns a HTTP 404.

It still doesn't return any error to Foreman since the TFTP /fetch_boot_file only starts a thread and there's no way to monitor it.

Fixes: 3d87c6feaa8c ("Refs #2412 - use curl for downloads")