### PR TITLE
Wait for TFTP downloads

### DIFF
--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -165,10 +165,11 @@ module Proxy::TFTP
   def self.choose_protocol_and_fetch(src, destination)
     case URI(src).scheme
     when 'http', 'https', 'ftp'
-      ::Proxy::HttpDownload.new(src.to_s, destination.to_s,
-                                connect_timeout: Proxy::TFTP::Plugin.settings.tftp_connect_timeout,
-                                verify_server_cert: Proxy::TFTP::Plugin.settings.verify_server_cert).start
-
+      thread = ::Proxy::HttpDownload.new(src.to_s, destination.to_s,
+                                         connect_timeout: Proxy::TFTP::Plugin.settings.tftp_connect_timeout,
+                                         verify_server_cert: Proxy::TFTP::Plugin.settings.verify_server_cert)
+      thread.start
+      thread
     when 'nfs'
       logger.debug "NFS as a protocol for installation medium detected."
     else


### PR DESCRIPTION
The /fetch_boot_file API is used to download TFTP files. The HttpDownload task is implemented as a thread. Previously it was fired off and there was no way to see the result. This implements code that waits for some time before telling the client the task is still running. There is no way for the client to find out if it really did finish.

Currently untested, but this at least shows the principle.