### PR TITLE
Fixes #37355 - Explicitly query for IPv4 address in omapi code

### DIFF
--- a/modules/dhcp_common/isc/omapi_provider.rb
+++ b/modules/dhcp_common/isc/omapi_provider.rb
@@ -205,9 +205,9 @@ module Proxy::DHCP::CommonISC
     rescue
       begin
         logger.info "Next-server option not IPv4, trying to resolve '#{server}'"
-        ip2hex(dns_resolv.getaddress(server))
+        ip2hex(dns_resolv.getresource(server, Resolv::DNS::Resource::IN::A))
       rescue Resolv::ResolvError => e
-        logger.warn "Unable to resolve PTR query for '#{server}', will use the hostname"
+        logger.warn "Unable to resolve DNS A query for '#{server}', will use the hostname"
         logger.debug "Reason: #{e}"
         # use hostname as the next-server entry
         "\\\"#{server}\\\""

--- a/test/dhcp/isc_omapi_provider_test.rb
+++ b/test/dhcp/isc_omapi_provider_test.rb
@@ -142,7 +142,7 @@ class IscOmapiProviderTest < Test::Unit::TestCase
   end
 
   def test_boot_server_hostname
-    ::Proxy::LoggingResolv.any_instance.expects(:getaddress).with("ptr-doesnotexist.example.com").returns("127.0.0.2")
+    ::Proxy::LoggingResolv.any_instance.expects(:getresource).with("ptr-doesnotexist.example.com", Resolv::DNS::Resource::IN::A).returns("127.0.0.2")
     assert_equal "7f:00:00:02", @dhcp.bootServer("ptr-doesnotexist.example.com")
   end
 


### PR DESCRIPTION
The omapi API is IPv4-only so the DNS lookup should also only ask for IPv4 addresses. Otherwise it may return an IPv6 address which ip2hex can't deal with.