### PR TITLE
Fixes #37413 - Refactor ssl verification tests

### DIFF
--- a/test/sinatra/ssl_client_verification_integration_test.rb
+++ b/test/sinatra/ssl_client_verification_integration_test.rb
@@ -1,43 +1,64 @@
 require 'test_helper'
 require 'net/http'
 
-class SSLClientVerificationIntegrationTest < Test::Unit::TestCase
-  include Proxy::IntegrationTestCase
-
-  class TestAPIWithSSLClientAuth < ::Sinatra::Base
-    helpers ::Proxy::Helpers
-    authorize_with_ssl_client
-    get('/') { 'Success' }
+class ClientVerificationIntegrationTest < Test::Unit::TestCase
+  def setup
+    WebMock.disable_net_connect!(allow_localhost: true)
+    @server = WEBrick::HTTPServer.new(Port: 0,
+                                      Logger: WEBrick::Log.new("/dev/null"))
+    @server.mount_proc '/' do |req, res|
+      res.body = 'Success'
+    end
+    @thread = Thread.new { @server.start }
   end
 
-  class TestPluginWithSSLClientAuth < ::Proxy::Plugin
-    class << self
-      def http_rackup
-        'run SSLClientVerificationIntegrationTest::TestAPIWithSSLClientAuth'
-      end
-      alias_method :https_rackup, :http_rackup
-    end
+  def teardown
+    @thread.exit
+    @thread.join
   end
 
   def test_http
-    launch protocol: 'http', plugins: [TestPluginWithSSLClientAuth]
-    res = Net::HTTP.get_response('localhost', '/', @settings.http_port)
+    res = Net::HTTP.get_response('localhost', '/', @server.config[:Port])
     assert_kind_of Net::HTTPSuccess, res
     assert_equal 'Success', res.body
   end
+end
+
+class SSLClientVerificationIntegrationTest < Test::Unit::TestCase
+  def setup
+    WebMock.disable_net_connect!(allow_localhost: true)
+    @ssl_private_key = OpenSSL::PKey::RSA.new(File.read(File.join(fixtures, 'private_keys', 'server.example.com.pem')))
+    @ssl_certificate = OpenSSL::X509::Certificate.new(File.read(File.join(fixtures, 'certs', 'server.example.com.pem')))
+    @ssl_ca_file = File.join(fixtures, 'certs', 'ca.pem')
+    @server = WEBrick::HTTPServer.new(Port: 0,
+                                      SSLEnable: true,
+                                      SSLCertificate: @ssl_certificate,
+                                      SSLPrivateKey: @ssl_private_key,
+                                      SSLCACertificateFile: @ssl_ca_file,
+                                      SSLVerifyClient: OpenSSL::SSL::VERIFY_PEER,
+                                      Logger: WEBrick::Log.new("/dev/null"))
+    @server.mount_proc '/' do |req, res|
+      res.body = 'Success'
+    end
+    @thread = Thread.new { @server.start }
+  end
+
+  def teardown
+    @thread.exit
+    @thread.join
+  end
 
   def test_https_no_cert
-    launch_https
-    http = Net::HTTP.new('localhost', @settings.https_port)
+    http = Net::HTTP.new('localhost', @server.config[:Port])
     http.use_ssl = true
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE
-    res = http.get('/')
-    assert_kind_of Net::HTTPForbidden, res
+    http.verify_mode = OpenSSL::SSL::VERIFY_PEER
+    assert_raise OpenSSL::SSL::SSLError do
+      http.get('/')
+    end
   end
 
   def test_https_cert_from_different_authority
-    launch_https
-    http = Net::HTTP.new('localhost', @settings.https_port)
+    http = Net::HTTP.new('localhost', @server.config[:Port])
     http.use_ssl = true
     http.ca_file = File.join(fixtures, 'certs', 'ca.pem')
     http.cert    = OpenSSL::X509::Certificate.new(File.read(File.join(fixtures, 'certs', 'badclient.example.com.pem')))
@@ -49,12 +70,11 @@ class SSLClientVerificationIntegrationTest < Test::Unit::TestCase
   end
 
   def test_https_cert
-    launch_https
-    http = Net::HTTP.new('localhost', @settings.https_port)
+    http = Net::HTTP.new('localhost', @server.config[:Port])
     http.use_ssl = true
-    http.ca_file = File.join(fixtures, 'certs', 'ca.pem')
-    http.cert    = OpenSSL::X509::Certificate.new(File.read(File.join(fixtures, 'certs', 'client.example.com.pem')))
-    http.key     = OpenSSL::PKey::RSA.new(File.read(File.join(fixtures, 'private_keys', 'client.example.com.pem')))
+    http.ca_file = @ssl_ca_file
+    http.cert = @ssl_certificate
+    http.key = @ssl_private_key
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
     res = http.get('/')
     assert_kind_of Net::HTTPSuccess, res
@@ -62,15 +82,6 @@ class SSLClientVerificationIntegrationTest < Test::Unit::TestCase
   end
 
   private
-
-  def launch_https
-    launch protocol: 'https', plugins: [TestPluginWithSSLClientAuth],
-           settings: {
-             ssl_private_key: File.join(fixtures, 'private_keys', 'server.example.com.pem'),
-             ssl_certificate: File.join(fixtures, 'certs', 'server.example.com.pem'),
-             ssl_ca_file:     File.join(fixtures, 'certs', 'ca.pem'),
-           }
-  end
 
   def fixtures
     File.expand_path(File.join(__dir__, '..', 'fixtures', 'ssl'))


### PR DESCRIPTION
by using webrick instead of custom proxy launcher

possible replacement for https://github.com/theforeman/smart-proxy/pull/891