### PR TITLE
fixes #37486 - Request BMC using Redfish without reaching sessions limit

### DIFF
--- a/bundler.d/bmc.rb
+++ b/bundler.d/bmc.rb
@@ -1,4 +1,4 @@
 group :bmc do
   gem 'rubyipmi', '>= 0.10.0'
-  gem 'redfish_client', '>= 0.5.1'
+  gem 'redfish_client', '>= 0.6.0'
 end

--- a/modules/bmc/redfish.rb
+++ b/modules/bmc/redfish.rb
@@ -16,7 +16,7 @@ module Proxy
       end
 
       def connect(args = { })
-        connection = RedfishClient.new("https://#{args[:host]}/", verify: @redfish_verify_ssl)
+        connection = RedfishClient.new("https://#{args[:host]}/", verify: @redfish_verify_ssl, use_session: false)
         connection.login(args[:username], args[:password])
         connection
       end


### PR DESCRIPTION
As described in issue, sessions limit is reach quickly when using current _Redfish_ implementation.

Here, redefining the `RedfishClient::Root#session_path` allow us to change the way `redfish_client` process the authentication in order to force to use only `basic_auth` and never retrieve a session that Foreman never closes.

Issue: https://projects.theforeman.org/issues/37486