### PR TITLE
Support reading SSL credentials from default locations

### DIFF
--- a/lib/proxy/settings/global.rb
+++ b/lib/proxy/settings/global.rb
@@ -47,5 +47,40 @@ module ::Proxy::Settings
       return value unless how_to.has_key?(key)
       how_to[key].call(value)
     end
+
+    def ssl_private_key
+      credential(:ssl_private_key, 'server-key')
+    end
+
+    def ssl_certificate
+      credential(:ssl_certificate, 'server-certificate')
+    end
+
+    def ssl_ca_file
+      credential(:ssl_ca_file, 'server-client-ca')
+    end
+
+    def foreman_ssl_key
+      credential(:foreman_ssl_key, 'client-key')
+    end
+
+    def foreman_ssl_cert
+      credential(:foreman_ssl_cert, 'client-certificate')
+    end
+
+    def foreman_ssl_key
+      credential(:foreman_ssl_ca, 'client-ca')
+    end
+
+    private
+
+    def credential(setting, cred)
+      value = self[cred]
+      if !value && ENV.key?('CREDENTIALS_DIRECTORY')
+        path = File.join(ENV['CREDENTIALS_DIRECTORY'], cred)
+        value = path if File.exist?(path)
+      end
+      value
+    end
   end
 end

--- a/test/global_settings_test.rb
+++ b/test/global_settings_test.rb
@@ -26,4 +26,34 @@ class GlobalSettingsTest < Test::Unit::TestCase
     assert_equal ['127.0.0.1'], ::Proxy::Settings::Global.new(:bind_host => '127.0.0.1').bind_host
     assert_equal ['127.0.0.1'], ::Proxy::Settings::Global.new(:bind_host => ['127.0.0.1']).bind_host
   end
+
+  def test_ssl_private_key_default_without_credential
+    settings = ::Proxy::Settings::Global.new({})
+    Dir.mktmpdir do |tmpdir|
+      ENV['CREDENTIALS_DIRECTORY'] = tmpdir
+      assert_nil settings.ssl_private_key
+    end
+  end
+
+  def test_ssl_private_key_default_with_credential
+    settings = ::Proxy::Settings::Global.new({})
+    Dir.mktmpdir do |tmpdir|
+      ENV['CREDENTIALS_DIRECTORY'] = tmpdir
+      path = File.join(tmpdir, 'server-key')
+      FileUtils.touch(path)
+
+      assert_equal path, settings.ssl_private_key
+    end
+  end
+
+  def test_ssl_private_key_with_value
+    settings = ::Proxy::Settings::Global.new({ssl_private_key: 'mykey'})
+    Dir.mktmpdir do |tmpdir|
+      ENV['CREDENTIALS_DIRECTORY'] = tmpdir
+      path = File.join(tmpdir, 'server-key')
+      FileUtils.touch(path)
+
+      assert_equal 'mykey', settings.ssl_private_key
+    end
+  end
 end


### PR DESCRIPTION
When CREDENTIALS_DIRECTORY is present, it tries fixed locations for these values. This allows using systemd CREDENTIALS or other similar mechanism without having to specify the locations in the settings file.

It goes with https://github.com/ekohl/foreman-credentials and https://partial.solutions/2024/understanding-systemd-credentials.html.

Still TODO: The Puppet module can also use certificates as credentials.  Should this also be exposed to plugins?