### PR TITLE
Fixes #37621 - Correctly resolve the IPv4 address

### DIFF
--- a/modules/dhcp_common/isc/omapi_provider.rb
+++ b/modules/dhcp_common/isc/omapi_provider.rb
@@ -205,7 +205,7 @@ module Proxy::DHCP::CommonISC
     rescue
       begin
         logger.info "Next-server option not IPv4, trying to resolve '#{server}'"
-        ip2hex(dns_resolv.getresource(server, Resolv::DNS::Resource::IN::A))
+        ip2hex(dns_resolv.getresource(server, Resolv::DNS::Resource::IN::A).address.to_s)
       rescue Resolv::ResolvError => e
         logger.warn "Unable to resolve DNS A query for '#{server}', will use the hostname"
         logger.debug "Reason: #{e}"

--- a/test/dhcp/isc_omapi_provider_test.rb
+++ b/test/dhcp/isc_omapi_provider_test.rb
@@ -142,7 +142,7 @@ class IscOmapiProviderTest < Test::Unit::TestCase
   end
 
   def test_boot_server_hostname
-    ::Proxy::LoggingResolv.any_instance.expects(:getresource).with("ptr-doesnotexist.example.com", Resolv::DNS::Resource::IN::A).returns("127.0.0.2")
+    ::Proxy::LoggingResolv.any_instance.expects(:getresource).with("ptr-doesnotexist.example.com", Resolv::DNS::Resource::IN::A).returns(Resolv::DNS::Resource::IN::A.new("127.0.0.2"))
     assert_equal "7f:00:00:02", @dhcp.bootServer("ptr-doesnotexist.example.com")
   end
 


### PR DESCRIPTION
In 3f079df67820053dcf626f0dd4f908cfc3bc9830 the lookup code was changed to explicitly query IPv4, but it assumed a string was returned instead of a Resolv::DNS::Resource::IN::A instance.

Fixes: 3f079df67820 ("Fixes #37355 - Explicitly query for IPv4 address in omapi code")

Currently untested, but it was reported on Matrix.