### PR TITLE
Fixes #37624 - Pin FFI to < 1.17 on Ruby 2.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,9 @@ gemspec
 
 gem 'concurrent-ruby', '~> 1.0', require: 'concurrent'
 
+# FFI 1.17 needs rubygems 3.3.22+, which is Ruby 3.0+ only
+gem "ffi", "<1.17" if RUBY_VERSION < '3.0'
+
 Dir[File.join(__dir__, 'bundler.d', '*.rb')].each do |bundle|
   eval_gemfile(bundle)
 end


### PR DESCRIPTION
Version 1.17 no longer works on Ruby 2 and Bundler isn't smart enough to figure this out.