### PR TITLE
Fixes #37631 - Allow nested data structures as request parameters

### DIFF
--- a/lib/proxy/request.rb
+++ b/lib/proxy/request.rb
@@ -10,7 +10,7 @@ module Proxy::HttpRequest
     end
 
     def query_string(input = {})
-      input.compact.map { |k, v| "#{CGI.escape(k.to_s)}=#{CGI.escape(v)}" }.join("&")
+      Rack::Utils.build_nested_query(input.compact)
     end
 
     def create_get(path, query = {}, headers = {})

--- a/test/registration/registration_api_test.rb
+++ b/test/registration/registration_api_test.rb
@@ -53,6 +53,14 @@ class RegistrationRegisterApiTest < Test::Unit::TestCase
     assert_match('template', last_response.body)
   end
 
+  def test_host_register_template_with_array_args
+    stub_request(:post, "#{@foreman_url}/register").to_return(body: 'template')
+
+    post '/', { host: { name: 'test.example.com', build: false, repo_data: [{repo: 'repo1', repo_gpg_key_url: 'url1'}, {repo: 'repo2', repo_gpg_key_url: 'url2'}] } }, { 'CONTENT_TYPE' => 'application/json' }
+    assert last_response.ok?
+    assert_match('template', last_response.body)
+  end
+
   def test_global_401
     stub_request(:get, "#{@foreman_url}/register").to_return(body: '401', status: 401, headers: { "Content-Type" => 'text/plain; charset=UTF-8' })
 

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -25,7 +25,24 @@ class RequestTest < Test::Unit::TestCase
 
   def test_get_with_headers
     stub_request(:get, @foreman_url + '/path?a=b').with(:headers => {"h1" => "header"}).to_return(:status => [200, 'OK'], :body => "body")
-    proxy_req = @request.request_factory.create_get "/path", {"a" => "b"}, "h1" => "header"
+    proxy_req = @request.request_factory.create_get("/path", {"a" => "b"}, "h1" => "header")
+    result = @request.send_request(proxy_req)
+    assert_equal("body", result.body)
+  end
+
+  def test_get_with_nested_params
+    stub_request(:get, @foreman_url + '/register?activation_keys%5B%5D=ac_AlmaLinux8&location_id=2&organization_id=1&repo_data%5B%5D%5Brepo%5D=repo1&repo_data%5B%5D%5Brepo_gpg_key_url%5D=key1&repo_data%5B%5D%5Brepo%5D=repo2&repo_data%5B%5D%5Brepo_gpg_key_url%5D=key2&update_packages=false')
+      .with(:headers => {"h1" => "header"}).to_return(status: 200, body: "body", headers: {})
+    request_params =
+      { "activation_keys" => ["ac_AlmaLinux8"],
+        "location_id" => "2",
+        "organization_id" => "1",
+        "repo_data" => [
+          {"repo" => "repo1", "repo_gpg_key_url" => "key1"},
+          {"repo" => "repo2", "repo_gpg_key_url" => "key2"},
+        ],
+        "update_packages" => "false" }
+    proxy_req = @request.request_factory.create_get("/register", request_params, "h1" => "header")
     result = @request.send_request(proxy_req)
     assert_equal("body", result.body)
   end
@@ -33,6 +50,23 @@ class RequestTest < Test::Unit::TestCase
   def test_post
     stub_request(:post, @foreman_url + '/path').with(:body => "body").to_return(:status => [200, 'OK'], :body => "body")
     proxy_req = @request.request_factory.create_post("/path", "body")
+    result = @request.send_request(proxy_req)
+    assert_equal("body", result.body)
+  end
+
+  def test_post_with_nested_params
+    stub_request(:post, @foreman_url + '/register?activation_keys%5B%5D=ac_AlmaLinux8&location_id=2&organization_id=1&repo_data%5B%5D%5Brepo%5D=repo1&repo_data%5B%5D%5Brepo_gpg_key_url%5D=key1&repo_data%5B%5D%5Brepo%5D=repo2&repo_data%5B%5D%5Brepo_gpg_key_url%5D=key2&update_packages=false')
+      .to_return(status: 200, body: "body", headers: {h1: "header"})
+    request_params =
+      { "activation_keys" => ["ac_AlmaLinux8"],
+        "location_id" => "2",
+        "organization_id" => "1",
+        "repo_data" => [
+          {"repo" => "repo1", "repo_gpg_key_url" => "key1"},
+          {"repo" => "repo2", "repo_gpg_key_url" => "key2"},
+        ],
+        "update_packages" => "false" }
+    proxy_req = @request.request_factory.create_post "/register", {"body" => "body"}, {"h1" => "header"}, request_params
     result = @request.send_request(proxy_req)
     assert_equal("body", result.body)
   end


### PR DESCRIPTION
If you go to the Host Registration form in foreman and choose a smart-proxy and multiple repositories, the registration fails with an internal server error. This is due to the new format of the repo_data in the API which supports an array of repository and corresponding gpg key pairs (https://github.com/theforeman/foreman/blob/develop/app/controllers/api/v2/registration_controller.rb#L29).