### PR TITLE
Add HSTS middleware

### DIFF
--- a/lib/proxy/hsts_middleware.rb
+++ b/lib/proxy/hsts_middleware.rb
@@ -1,0 +1,19 @@
+module Proxy
+  # Add the HSTS header if not present. This header is entirely useless for us
+  # because the header is aimed at browsers, but some scanners still think this
+  # is needed.
+  # https://www.tenable.com/plugins/nessus/142960
+  class HstsMiddleware
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = @app.call(env)
+      if env['HTTPS'] == 'on' && !headers.include?('Strict-Transport-Security')
+        headers['Strict-Transport-Security'] = 'max-age=31536000'
+      end
+      [status, headers, body]
+    end
+  end
+end

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -25,6 +25,7 @@ require 'proxy/provider'
 require 'proxy/error'
 require 'proxy/request'
 require 'proxy/request_id_middleware'
+require 'proxy/hsts_middleware'
 
 require 'bundler_helper'
 Proxy::BundlerHelper.require_groups(:default)
@@ -44,6 +45,7 @@ module Proxy
   ::Sinatra::Base.set :logging, false
   ::Sinatra::Base.use ::Proxy::RequestIdMiddleware
   ::Sinatra::Base.use ::Proxy::LoggerMiddleware
+  ::Sinatra::Base.use ::Proxy::HstsMiddleware
   ::Sinatra::Base.set :env, :production
   ::Sinatra::Base.register ::Sinatra::Authorization
 


### PR DESCRIPTION
This header is entirely useless for us because the header is aimed at browsers, but some scanners still think this is needed.

This PR is not intended to be merged, but only serve as an example for how it could be implemented.

Link: https://www.tenable.com/plugins/nessus/142960