### PR TITLE
Refs #36833 - Correct File.join call on bootloader-universe

### DIFF
--- a/modules/tftp/server.rb
+++ b/modules/tftp/server.rb
@@ -110,7 +110,7 @@ module Proxy::TFTP
   class Pxegrub2 < Server
     def bootloader_path(os, release, arch)
       [release, "default"].each do |version|
-        bootloader_path = File.join(path, 'bootloader-universe/pxegrub2', os, version, arch)
+        bootloader_path = File.join(path, 'bootloader-universe', 'pxegrub2', os, version, arch)
 
         logger.debug "TFTP: Checking if bootloader universe is configured for OS '#{os}' version '#{version}' (#{arch})."
 

--- a/test/tftp/tftp_server_test.rb
+++ b/test/tftp/tftp_server_test.rb
@@ -141,14 +141,14 @@ class TftpPxegrub2ServerTest < Test::Unit::TestCase
   end
 
   def test_release_specific_bootloader_path
-    release_specific_bootloader_path = File.join(@subject.path, "bootloader-universe/pxegrub2", @os, @release, @arch)
+    release_specific_bootloader_path = File.join(@subject.path, "bootloader-universe", "pxegrub2", @os, @release, @arch)
     Dir.stubs(:exist?).with(release_specific_bootloader_path).returns(true).once
     assert_equal release_specific_bootloader_path, @subject.bootloader_path(@os, @release, @arch)
   end
 
   def test_default_bootloader_path
-    release_specific_bootloader_path = File.join(@subject.path, "bootloader-universe/pxegrub2", @os, @release, @arch)
-    default_bootloader_path = File.join(@subject.path, "bootloader-universe/pxegrub2", @os, "default", @arch)
+    release_specific_bootloader_path = File.join(@subject.path, "bootloader-universe", "pxegrub2", @os, @release, @arch)
+    default_bootloader_path = File.join(@subject.path, "bootloader-universe", "pxegrub2", @os, "default", @arch)
     Dir.stubs(:exist?).with(release_specific_bootloader_path).returns(false).once
     Dir.stubs(:exist?).with(default_bootloader_path).returns(true).once
     assert_equal default_bootloader_path, @subject.bootloader_path(@os, @release, @arch)


### PR DESCRIPTION
When using File.join, all components should be separate arguments.

Fixes: 1345bb430e2e ("Fixes #36833 - Add SecureBoot support for arbitrary operating systems to "Grub2 UEFI" PXE loaders")