### PR TITLE
Fixes #38157 - Declare rexml as dependency

### DIFF
--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'json'
   s.add_dependency 'logging'
   s.add_dependency 'rack', '>= 1.3'
+  s.add_dependency 'rexml', '~> 3.2'
   s.add_dependency 'sd_notify', '~> 0.1'
   s.add_dependency 'sinatra', '~> 2.0'
   s.add_dependency 'webrick', '~> 1.0'


### PR DESCRIPTION
Apparently rexml (used in the realm module) used to be a default gem up until ruby 3. Starting with ruby 3, it has to be treated as any other dependency.