### PR TITLE
Fixes #38241 - Extend userdata API by MAC address endpoint

### DIFF
--- a/modules/templates/templates_userdata_api.rb
+++ b/modules/templates/templates_userdata_api.rb
@@ -8,4 +8,10 @@ class Proxy::TemplatesUserdataApi < Sinatra::Base
       Proxy::Templates::UserdataProxyRequest.new.get(kind, request.env, params)
     end
   end
+
+  get "/:mac/:kind" do |mac, kind|
+    log_halt(500, "Failed to retrieve #{kind} userdata template for #{params.inspect}: ") do
+      Proxy::Templates::UserdataProxyRequest.new.get([mac, kind], request.env, params)
+    end
+  end
 end

--- a/test/templates/templates_userdata_api_test.rb
+++ b/test/templates/templates_userdata_api_test.rb
@@ -25,4 +25,13 @@ class TemplatesApiTest < Test::Unit::TestCase
     assert last_response.ok?, "Last response was ok"
     assert_match("A user-data template", last_response.body)
   end
+
+  def test_api_can_ask_for_a_cloud_init_template_by_mac
+    stub_request(:get, "#{@foreman_url}/userdata/00:a1:b2:c3:d4:f5/user-data")
+      .with(query: {"url" => @template_url, "mac" => "00:a1:b2:c3:d4:f5"})
+      .to_return(:body => 'A user-data template')
+    get "/00:a1:b2:c3:d4:f5/user-data"
+    assert last_response.ok?, "Last response was ok"
+    assert_equal("A user-data template", last_response.body)
+  end
 end


### PR DESCRIPTION
Extend the proxy API to match the userdata API of foreman: https://github.com/theforeman/foreman/pull/9213