### PR TITLE
Fixes #38357 - add base64 runtime dependency

### DIFF
--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.license = 'GPL-3.0'
   s.extra_rdoc_files = ["README.md"]
   s.required_ruby_version = '>= 2.7'
+  s.add_dependency 'base64'
   s.add_dependency 'json'
   s.add_dependency 'logging'
   s.add_dependency 'rack', '>= 1.3'


### PR DESCRIPTION
lib/proxy/util.rb does a `require 'base64'`. This gem won't be part of Ruby core with Ruby 3.4. It needs to be listed explicitly in the gemspec.