### PR TITLE
Fixes #38498 - Add support for Reset (powerreset) via Redfish provider

### DIFF
--- a/modules/bmc/base.rb
+++ b/modules/bmc/base.rb
@@ -46,6 +46,10 @@ module Proxy
         raise NotImplementedError.new
       end
 
+      def powerreset
+        raise NotImplementedError.new
+      end
+
       def bootdevice
         raise NotImplementedError.new
       end

--- a/modules/bmc/bmc_plugin.rb
+++ b/modules/bmc/bmc_plugin.rb
@@ -11,6 +11,7 @@ module Proxy::BMC
     capability 'shell'
     capability 'ssh'
     capability -> { Proxy::BMC::IPMI.providers_installed }
+    capability 'power_action_v2'
 
     # Load IPMI to ensure the capabilities can be determined
     load_classes do

--- a/modules/bmc/redfish.rb
+++ b/modules/bmc/redfish.rb
@@ -74,6 +74,10 @@ module Proxy
         poweraction('PowerCycle')
       end
 
+      def powerreset
+        poweraction('ForceRestart')
+      end
+
       def poweron
         poweraction('On')
       end

--- a/test/bmc/bmc_api_test.rb
+++ b/test/bmc/bmc_api_test.rb
@@ -583,6 +583,25 @@ class BmcApiTest < Test::Unit::TestCase
     assert expect.once
   end
 
+  def test_api_calls_ipmi_provider_reset
+    Rubyipmi.stubs(:is_provider_installed?).returns(true)
+    Proxy::BMC::IPMI.any_instance.stubs(:powerreset).returns(true)
+    Rack::Auth::Basic::Request.any_instance.stubs(:provided?).returns(true)
+    Rack::Auth::Basic::Request.any_instance.stubs(:basic?).returns(true)
+    Rack::Auth::Basic::Request.any_instance.stubs(:credentials).returns(['user', 'pass'])
+    put "/#{@host}/chassis/power/reset", { 'bmc_provider' => 'ipmitool' }
+    assert last_response.ok?, "Last response was not ok: #{last_response.body}"
+    data = JSON.parse(last_response.body)
+    assert_equal true, data["result"]
+  end
+
+  def test_api_calls_redfish_provider_reset
+    expect = Proxy::BMC::Redfish.any_instance.stubs(:powerreset)
+    test_args = { 'bmc_provider' => 'redfish' }
+    put "/#{@host}/chassis/power/reset", test_args
+    assert expect.once
+  end
+
   def test_api_can_pass_options_in_body
     Rubyipmi.stubs(:is_provider_installed?).returns(true)
     args = { 'bmc_provider' => 'freeipmi', :options => {:driver => 'lan20', :privilege => 'USER'} }.to_json

--- a/test/bmc/bmc_redfish_test.rb
+++ b/test/bmc/bmc_redfish_test.rb
@@ -21,4 +21,11 @@ class BmcRedfishTest < Test::Unit::TestCase
       to_return(status: 200, body: JSON.generate({}))
     assert @bmc.powercycle
   end
+
+  def test_redfish_provider_reset
+    stub_request(:post, "#{@protocol}://#{@host}#{SYSTEM_DATA['Actions']['#ComputerSystem.Reset']['target']}").
+      with(body: JSON.generate({"ResetType" => "ForceRestart"})).
+      to_return(status: 200, body: JSON.generate({}))
+    assert @bmc.powerreset
+  end
 end

--- a/test/bmc/integration_test.rb
+++ b/test/bmc/integration_test.rb
@@ -16,7 +16,7 @@ class BmcApiFeaturesTest < SmartProxyRootApiTestCase
     mod = response['bmc']
     refute_nil(mod)
     assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:bmc])
-    assert_equal(['redfish', 'shell', 'ssh'], mod['capabilities'])
+    assert_equal(['power_action_v2', 'redfish', 'shell', 'ssh'], mod['capabilities'])
 
     assert_equal({}, mod['settings'])
   end
@@ -32,7 +32,7 @@ class BmcApiFeaturesTest < SmartProxyRootApiTestCase
     mod = response['bmc']
     refute_nil(mod)
     assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:bmc])
-    assert_equal(['freeipmi', 'redfish', 'shell', 'ssh'], mod['capabilities'])
+    assert_equal(['freeipmi', 'power_action_v2', 'redfish', 'shell', 'ssh'], mod['capabilities'])
 
     assert_equal({}, mod['settings'])
   end


### PR DESCRIPTION
Bug [#3073](https://projects.theforeman.org/issues/3073?tab=history) is caused by 3 things:
1. Foreman core doesn't call BMC proxy's API correctly
   - Changing power state to 'Reboot' via Web GUI calls BMC proxy's 'soft'
     power action
   - Changing power state to 'Reset' via Web GUI calls BMC proxy's 'cycle'
     power action
2. Foreman BMC proxy doesn't support reboot at all BMC provider
3. Foreman BMC proxy doesn't support reset(powerreset) at Redfish provider
 
2nd & 3rd item are mentioned in [#38498](https://projects.theforeman.org/issues/38498). And this PR fixes 3rd item.

## Modifications in this PR

### Enable proper handling of "Reset" power action via Redfish

This PR enables the powerreset operation to be processed correctly by the Smart Proxy when using the Redfish provider.
Internally, this maps the "Reset" request from Foreman core to the appropriate Redfish ForceRestart operation, aligning the behavior with user expectations in the Web UI. 
To support this, a new powerreset API endpoint is introduced, and the Redfish BMC class is extended to implement the corresponding logic.