### PR TITLE
Fixes #38498 - Add Reboot power operation to Redfish provider

### DIFF
--- a/modules/bmc/base.rb
+++ b/modules/bmc/base.rb
@@ -50,6 +50,10 @@ module Proxy
         raise NotImplementedError.new
       end
 
+      def powerreboot
+        raise NotImplementedError.new
+      end
+
       def bootdevice
         raise NotImplementedError.new
       end

--- a/modules/bmc/bmc_api.rb
+++ b/modules/bmc/bmc_api.rb
@@ -163,7 +163,7 @@ module Proxy::BMC
     put "/:host/chassis/power/?:action?" do
       # return hint on valid options
       if params[:action].nil?
-        return { :actions => ["on", "off", "cycle", "soft", "reset"] }.to_json
+        return { :actions => ["on", "off", "cycle", "soft", "reset", "reboot"] }.to_json
       end
       bmc_setup
       begin
@@ -178,6 +178,8 @@ module Proxy::BMC
             { :action => params[:action], :result => @bmc.poweroff(true) }.to_json
           when "reset"
             { :action => params[:action], :result => @bmc.powerreset }.to_json
+          when "reboot"
+            { :action => params[:action], :result => @bmc.powerreboot }.to_json
           else
             { :error => "The action: #{params[:action]} is not a valid action" }.to_json
         end

--- a/modules/bmc/redfish.rb
+++ b/modules/bmc/redfish.rb
@@ -78,6 +78,10 @@ module Proxy
         poweraction('ForceRestart')
       end
 
+      def powerreboot
+        poweraction('GracefulRestart')
+      end
+
       def poweron
         poweraction('On')
       end

--- a/test/bmc/bmc_api_test.rb
+++ b/test/bmc/bmc_api_test.rb
@@ -602,6 +602,13 @@ class BmcApiTest < Test::Unit::TestCase
     assert expect.once
   end
 
+  def test_api_calls_redfish_provider_reboot
+    expect = Proxy::BMC::Redfish.any_instance.stubs(:powerreboot)
+    test_args = { 'bmc_provider' => 'redfish' }
+    put "/#{@host}/chassis/power/reboot", test_args
+    assert expect.once
+  end
+
   def test_api_can_pass_options_in_body
     Rubyipmi.stubs(:is_provider_installed?).returns(true)
     args = { 'bmc_provider' => 'freeipmi', :options => {:driver => 'lan20', :privilege => 'USER'} }.to_json

--- a/test/bmc/bmc_redfish_test.rb
+++ b/test/bmc/bmc_redfish_test.rb
@@ -28,4 +28,11 @@ class BmcRedfishTest < Test::Unit::TestCase
       to_return(status: 200, body: JSON.generate({}))
     assert @bmc.powerreset
   end
+
+  def test_redfish_provider_reboot
+    stub_request(:post, "#{@protocol}://#{@host}#{SYSTEM_DATA['Actions']['#ComputerSystem.Reset']['target']}").
+      with(body: JSON.generate({ "ResetType" => "GracefulRestart" })).
+      to_return(status: 200, body: JSON.generate({}))
+    assert @bmc.powerreboot
+  end
 end

--- a/test/bmc/bmc_test.rb
+++ b/test/bmc/bmc_test.rb
@@ -56,6 +56,12 @@ class BmcTest < Test::Unit::TestCase
     assert bmc.powerreset
   end
 
+  def test_should_power_reboot
+    assert_raise(NotImplementedError) do
+      bmc.powerreboot
+    end
+  end
+
   def test_should_bootpxe
     Rubyipmi::Ipmitool::Chassis.any_instance.expects(:bootpxe).returns(true)
     bmc.bootpxe


### PR DESCRIPTION
Bug #3073 is caused by 3 things:
1. Foreman core doesn't call BMC proxy's API correctly
   - Changing power state to 'Reboot' via Web GUI calls BMC proxy's 'soft' power action
   - Changing power state to 'Reset' via Web GUI calls BMC proxy's 'cycle' power action
2. Foreman BMC proxy doesn't support reboot at all BMC provider
3. Foreman BMC proxy doesn't support reset(powerreset) at Redfish provider

2nd & 3rd item are mentioned in #38498. And this PR fixes 2nd item.

## Modifications in this PR

This PR does 2 things to make BMC smart proxy support reboot power action:

* Modify BMC smart proxy API to accept `reboot` power action and call BMC provider's `powerreboot` method
* Add `powerreboot` method to Redfish provider class which makes Redfish server do `GracefulRestart` reset action
  (According to IPMI v2.0 specification, IPMI doesn't support Reboot)

