### PR TITLE
Fixes #38498 - Fix incorrect Cycle power operation in Redfish provider

### DIFF
--- a/modules/bmc/redfish.rb
+++ b/modules/bmc/redfish.rb
@@ -71,7 +71,7 @@ module Proxy
       end
 
       def powercycle
-        poweraction('ForceRestart')
+        poweraction('PowerCycle')
       end
 
       def poweron

--- a/test/bmc/bmc_api_test.rb
+++ b/test/bmc/bmc_api_test.rb
@@ -2,6 +2,8 @@ require 'test_helper'
 require 'json'
 require 'bmc/bmc_plugin'
 require 'bmc/bmc_api'
+require 'bmc/redfish'
+require 'test/bmc/redfish_test_helper'
 
 ENV['RACK_ENV'] = 'test'
 
@@ -13,6 +15,7 @@ ENV['RACK_ENV'] = 'test'
 
 class BmcApiTest < Test::Unit::TestCase
   include Rack::Test::Methods
+  include RedfishTestHelper
 
   def app
     Proxy::BMC::Api.new
@@ -25,6 +28,7 @@ class BmcApiTest < Test::Unit::TestCase
     provider ||= ENV["ipmiprovider"] || "ipmitool"
     @args = { 'bmc_provider' => provider, 'blah' => 'test' }
     authorize user, pass
+    mask_redfish_acceess
   end
 
   def test_api_throws_401_error_when_auth_is_not_provided
@@ -570,6 +574,13 @@ class BmcApiTest < Test::Unit::TestCase
     get "/#{@host}/sensors/list", args
     assert_equal "StandardError", last_response.body
     assert_equal 400, last_response.status
+  end
+
+  def test_api_calls_redfish_provider_cycle
+    expect = Proxy::BMC::Redfish.any_instance.stubs(:powercycle)
+    test_args = { 'bmc_provider' => 'redfish' }
+    put "/#{@host}/chassis/power/cycle", test_args
+    assert expect.once
   end
 
   def test_api_can_pass_options_in_body

--- a/test/bmc/bmc_redfish_test.rb
+++ b/test/bmc/bmc_redfish_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+require 'bmc/bmc_plugin'
+require 'bmc/redfish'
+require 'test/bmc/redfish_test_helper'
+require 'json'
+
+class BmcRedfishTest < Test::Unit::TestCase
+  include RedfishTestHelper
+
+  def setup
+    @host = "host"
+    @protocol = "https"
+    mask_redfish_acceess(protocol: @protocol, host: @host)
+    @args = { :username => "user", :password => "pass", :host => @host }
+    @bmc  = Proxy::BMC::Redfish.new(@args)
+  end
+
+  def test_redfish_provider_cycle
+    stub_request(:post, "#{@protocol}://#{@host}#{SYSTEM_DATA['Actions']['#ComputerSystem.Reset']['target']}").
+      with(body: JSON.generate({"ResetType" => "PowerCycle"})).
+      to_return(status: 200, body: JSON.generate({}))
+    assert @bmc.powercycle
+  end
+end

--- a/test/bmc/redfish_test_helper.rb
+++ b/test/bmc/redfish_test_helper.rb
@@ -1,0 +1,51 @@
+require 'json'
+
+module RedfishTestHelper
+  ROOT_DATA = {
+    "Name" => "Redfish Server Test Mock",
+    "Systems" => {
+      "@odata.id" => "/redfish/v1/Systems",
+    },
+    "Managers" => {
+      "@odata.id" => "/redfish/v1/Managers",
+    },
+    "@odata.id" => "/redfish/v1",
+  }.freeze
+
+  SYSTEMS_DATA = {
+    "@odata.id" => "/redfish/v1/Systems",
+    "Members" => [
+      { "@odata.id" => "/redfish/v1/Systems/TESTSYSTEM" },
+    ],
+  }.freeze
+
+  SYSTEM_DATA = {
+    "@odata.id" => "/redfish/v1/Systems/TESTSYSTEM",
+    "Manufacture" => "Server Vendor",
+    "IndicatorLED" => "Off",
+    "PowerState" => "On",
+    "Boot" => {
+      "BootSourceOverrideTarget" => "Pxe",
+    },
+    "Model" => "TestServer A",
+    "SerialNumber" => "AA645",
+    "AssetTag" => "ax",
+    "Actions" => {
+      "#ComputerSystem.Reset" => {
+        "target" => "/redfish/v1/Systems/TESTSYSTEM/Actions/ComputerSystem.Reset",
+      },
+    },
+  }.freeze
+
+  def mask_redfish_acceess(protocol: "https", host: "host")
+    # root
+    stub_request(:get, "#{protocol}://#{host}#{ROOT_DATA['@odata.id']}").
+      to_return(status: 200, body: JSON.generate(ROOT_DATA))
+    # root.systems
+    stub_request(:get, "#{protocol}://#{host}#{SYSTEMS_DATA['@odata.id']}").
+      to_return(status: 200, body: JSON.generate(SYSTEMS_DATA))
+    # root.system
+    stub_request(:get, "#{protocol}://#{host}#{SYSTEM_DATA['@odata.id']}").
+      to_return(status: 200, body: JSON.generate(SYSTEM_DATA))
+  end
+end


### PR DESCRIPTION
Bug #38498 mentions 3 power operation bugs in Redfish provider. This PR fixes wrong implementation of Cycle power operatoin: When user pushes Cycle button, Redfish provider does ForceRestart instead of PowerCycle.

## Modifications in this PR
### Fix incorrect "Cycle" power operation implementation in Redfish provider
The powercycle method defined in `modules/bmc/redfish.rb` of smart-proxy does 'ForceRestart' instead of 'PowerCycle'. This PR makes powercycle method does 'PowerCycle'.