### PR TITLE
Fixes #38914 - Use ETag-aware patch_if_match for Redfish operations

### DIFF
--- a/bundler.d/bmc.rb
+++ b/bundler.d/bmc.rb
@@ -1,4 +1,4 @@
 group :bmc do
   gem 'rubyipmi', '>= 0.12.1'
-  gem 'redfish_client', '>= 0.6.0'
+  gem 'redfish_client', '>= 0.8.0'
 end

--- a/modules/bmc/redfish.rb
+++ b/modules/bmc/redfish.rb
@@ -131,13 +131,12 @@ module Proxy
                    'disk'  => 'Hdd',
                    'pxe'   => 'Pxe' }
 
-        system.patch(
-          payload: {
-            'Boot' => {
-              'BootSourceOverrideTarget' => devmap[args[:device]],
-              'BootSourceOverrideEnabled' => args[:persistent] ? 'Enabled' : 'Once',
-            },
-          })
+        system.patch_if_match({
+                                'Boot' => {
+                                  'BootSourceOverrideTarget' => devmap[args[:device]],
+                                  'BootSourceOverrideEnabled' => args[:persistent] ? 'Enabled' : 'Once',
+                                },
+                              })
         powercycle if args[:reboot]
       end
 

--- a/test/bmc/bmc_redfish_test.rb
+++ b/test/bmc/bmc_redfish_test.rb
@@ -35,4 +35,130 @@ class BmcRedfishTest < Test::Unit::TestCase
       to_return(status: 200, body: JSON.generate({}))
     assert @bmc.powerreboot
   end
+
+  def test_bootdevice_pxe_uses_patch_if_match
+    # Test that bootdevice uses patch_if_match for PXE boot
+    system_mock = mock('system')
+
+    system_mock.expects(:patch_if_match).with(
+      'Boot' => {
+        'BootSourceOverrideTarget' => 'Pxe',
+        'BootSourceOverrideEnabled' => 'Once',
+      }
+    ).returns(true)
+
+    @bmc.expects(:system).returns(system_mock)
+    @bmc.expects(:powercycle).never
+
+    result = @bmc.bootdevice = { :device => 'pxe', :reboot => false, :persistent => false }
+    assert_not_nil result
+  end
+
+  def test_bootdevice_disk_persistent_uses_patch_if_match
+    # Test that bootdevice uses patch_if_match with persistent boot
+    system_mock = mock('system')
+
+    system_mock.expects(:patch_if_match).with(
+      'Boot' => {
+        'BootSourceOverrideTarget' => 'Hdd',
+        'BootSourceOverrideEnabled' => 'Enabled',
+      }
+    ).returns(true)
+
+    @bmc.expects(:system).returns(system_mock)
+    @bmc.expects(:powercycle).never
+
+    result = @bmc.bootdevice = { :device => 'disk', :reboot => false, :persistent => true }
+    assert_not_nil result
+  end
+
+  def test_bootdevice_with_reboot
+    # Test bootdevice with reboot option
+    system_mock = mock('system')
+
+    system_mock.expects(:patch_if_match).with(
+      'Boot' => {
+        'BootSourceOverrideTarget' => 'Pxe',
+        'BootSourceOverrideEnabled' => 'Enabled',
+      }
+    ).returns(true)
+
+    @bmc.expects(:system).returns(system_mock)
+    @bmc.expects(:powercycle).once
+
+    result = @bmc.bootdevice = { :device => 'pxe', :reboot => true, :persistent => true }
+    assert_not_nil result
+  end
+
+  def test_bootpxe_calls_bootdevice
+    # Test that convenience method bootpxe works
+    system_mock = mock('system')
+
+    system_mock.expects(:patch_if_match).with(
+      'Boot' => {
+        'BootSourceOverrideTarget' => 'Pxe',
+        'BootSourceOverrideEnabled' => 'Once',
+      }
+    ).returns(true)
+
+    @bmc.expects(:system).returns(system_mock)
+    @bmc.expects(:powercycle).never
+
+    result = @bmc.bootpxe(false, false)
+    assert_not_nil result
+  end
+
+  def test_bootdisk_calls_bootdevice
+    # Test that convenience method bootdisk works
+    system_mock = mock('system')
+
+    system_mock.expects(:patch_if_match).with(
+      'Boot' => {
+        'BootSourceOverrideTarget' => 'Hdd',
+        'BootSourceOverrideEnabled' => 'Once',
+      }
+    ).returns(true)
+
+    @bmc.expects(:system).returns(system_mock)
+    @bmc.expects(:powercycle).never
+
+    result = @bmc.bootdisk(false, false)
+    assert_not_nil result
+  end
+
+  def test_bootbios_calls_bootdevice
+    # Test that convenience method bootbios works
+    system_mock = mock('system')
+
+    system_mock.expects(:patch_if_match).with(
+      'Boot' => {
+        'BootSourceOverrideTarget' => 'BiosSetup',
+        'BootSourceOverrideEnabled' => 'Once',
+      }
+    ).returns(true)
+
+    @bmc.expects(:system).returns(system_mock)
+    @bmc.expects(:powercycle).never
+
+    result = @bmc.bootbios(false, false)
+    assert_not_nil result
+  end
+
+  def test_bootcdrom_calls_bootdevice
+    # Test that convenience method bootcdrom works
+    system_mock = mock('system')
+
+    system_mock.expects(:patch_if_match).with(
+      'Boot' => {
+        'BootSourceOverrideTarget' => 'Cd',
+        'BootSourceOverrideEnabled' => 'Once',
+      }
+    ).returns(true)
+
+    @bmc.expects(:system).returns(system_mock)
+    @bmc.expects(:powercycle).never
+
+    result = @bmc.bootcdrom(false, false)
+    assert_not_nil result
+  end
 end


### PR DESCRIPTION
### Summary
Some Redfish implementations reject PATCH requests without If-Match.
This change updates boot device operations to use
patch_if_match, enabling ETag-based conditional PATCH when needed.

### Problem
Certain BMC implementations require the `If-Match` header 
with ETag values for PATCH operations. 
The previous implementation using `system.patch` 
did not include this header, causing operations to fail on some hardware.

### Solution
Changed PATCH operations in `modules/bmc/redfish.rb` to use `patch_if_match`, 
which automatically includes the `If-Match` header with the appropriate ETag value when available.