### PR TITLE
Add logger as a dependency

### DIFF
--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
   s.add_dependency 'base64'
   s.add_dependency 'json'
+  s.add_dependency 'logger'
   s.add_dependency 'logging'
   s.add_dependency 'ostruct'
   s.add_dependency 'rack', '>= 1.3'


### PR DESCRIPTION
This gem was vendored in Ruby until version 4.

```
$ git grep require.*logger
lib/proxy/log.rb:require 'logger'
lib/proxy/log.rb:      require 'syslog/logger'
test/log_buffer/decorator_test.rb:    require 'syslog/logger'
```