### PR TITLE
Fixes #38973 - SSH API of BMC now resolves FQDN to IP

### DIFF
--- a/modules/bmc/ssh.rb
+++ b/modules/bmc/ssh.rb
@@ -1,3 +1,6 @@
+require 'ipaddr'
+require 'resolv'
+
 module Proxy
   module BMC
     class SSH < Base
@@ -62,7 +65,15 @@ module Proxy
       end
 
       def ip
-        host
+        IPAddr.new(host).to_s
+      rescue IPAddr::InvalidAddressError
+        begin
+          logger.debug("Host '#{host}' is not an IP address, attempting to resolve as FQDN.")
+          Resolv.getaddress(host)
+        rescue Resolv::ResolvError => e
+          logger.warn("Failed to resolve FQDN '#{host}': #{e.class} - #{e.message}")
+          ''
+        end
       end
 
       # the following are dummy implementations

--- a/test/bmc/bmc_api_ssh_test.rb
+++ b/test/bmc/bmc_api_ssh_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 require 'json'
 require 'bmc/bmc_api'
 require 'bmc/ssh'
+require 'bmc/bmc_plugin'
 
 ENV['RACK_ENV'] = 'test'
 
@@ -47,10 +48,35 @@ class BmcApiShellTest < Test::Unit::TestCase
     assert_equal 200, last_response.status
   end
 
-  def test_lan_ip
-    Proxy::BMC::SSH.any_instance.expects(:ip).returns('')
-    get "/#{@host}/lan/ip", @args
+  def test_lan_ip_when_host_is_ip
+    host = "192.168.1.1"
+    get "/#{host}/lan/ip", @args
     assert_equal 200, last_response.status
+    assert_equal host, JSON.parse(last_response.body)["result"]
+  end
+
+  def test_lan_ip_when_host_is_ipv6
+    host = '2001:db8::1'
+    get "/#{host}/lan/ip", @args
+    assert_equal 200, last_response.status
+    assert_equal host, JSON.parse(last_response.body)['result']
+  end
+
+  def test_lan_ip_when_host_is_resolvable_fqdn
+    host = "resolvable.example.com"
+    resolved_ip = "192.168.1.2"
+    Resolv.expects(:getaddress).with(host).returns(resolved_ip)
+    get "/#{host}/lan/ip", @args
+    assert_equal 200, last_response.status
+    assert_equal resolved_ip, JSON.parse(last_response.body)["result"]
+  end
+
+  def test_lan_ip_when_host_is_unresolvable_fqdn
+    host = "unresolvable.example.com"
+    Resolv.expects(:getaddress).with(host).raises(Resolv::ResolvError.new("no address for #{host}"))
+    get "/#{host}/lan/ip", @args
+    assert_equal 200, last_response.status
+    assert_equal "", JSON.parse(last_response.body)["result"]
   end
 
   def test_lan_mac


### PR DESCRIPTION
Description:
This PR is a prerequisite for Foreman PR [#10842](https://github.com/theforeman/foreman/pull/10842) which fixes [#38972](https://projects.theforeman.org/issues/38972). Applying  [#10842](https://github.com/theforeman/foreman/pull/10842)  without this accompanying PR will lead to issue [#38973](https://projects.theforeman.org/issues/38973). Therefore, both PRs must be applied simultaneously.
Bug [#38973](https://projects.theforeman.org/issues/38973) is caused by the following:

When Foreman specified an FQDN in the :host parameter for the Smart Proxy's BMC API, the smart-proxy's SSH API of BMC returned the FQDN itself directly to Foreman during IP address acquisition.
This resulted in a bug where the FQDN was displayed in the "IP" field within the Foreman UI.

This PR fixes this item.

Modifications in this PR
Fixed an issue where IP addresses could not be obtained when using SSH API of BMC if an FQDN was specified for the :host parameter in the BMC API.
When Foreman uses Fixed an issue where IP addresses could not be obtained when using SSH API of BMC if an FQDN was specified for the :host parameter in the BMC API. 
To obtain an IP address, the `ip()` method in `modules/bmc/ssh.rb`, executed by smart-proxy, was implemented to directly return the `:host` specified in the BMC API's `:host` parameter to Foreman.
This has been corrected. Now, `:host` is returned directly to Foreman only if it is an IP address. Otherwise, `:host` is treated as an FQDN, resolved to an IP address, and then returned to Foreman.

Verification Contents:
After configuring the FQDN and SSH in the BMC interface settings via the Foreman Web UI, I verified that the IP address was displayed in the IP field by accessing the BMC tab in the Host Details (Legacy UI).
