### PR TITLE
Fixes #39118 - Support generating registration command via REST API in isolated networks managed by external capsules

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -218,6 +218,7 @@ Naming/VariableNumber:
     - 'test/plugins/plugin_initializer_test.rb'
     - 'test/puppetca_http_api/puppetca_http_impl_test.rb'
     - 'test/registration/registration_api_test.rb'
+    - 'test/registration/registration_commands_api_test.rb'
     - 'test/sinatra/default_not_found_page_test.rb'
     - 'test/templates/templates_unattended_api_test.rb'
     - 'test/util_test.rb'

--- a/modules/registration/http_config.ru
+++ b/modules/registration/http_config.ru
@@ -1,5 +1,10 @@
 require 'registration/registration_api'
+require 'registration/registration_commands_api'
 
 map '/register' do
   run Proxy::Registration::Api
+end
+
+map '/registration_commands' do
+  run Proxy::Registration::CommandsApi
 end

--- a/modules/registration/proxy_request.rb
+++ b/modules/registration/proxy_request.rb
@@ -2,6 +2,14 @@ require 'proxy/request'
 
 module Proxy::Registration
   class ProxyRequest < ::Proxy::HttpRequest::ForemanRequest
+    def registration_command(request)
+      proxy_req = request_factory.create_post '/api/registration_commands',
+                                              request.body.read,
+                                              headers(request)
+
+      send_request(proxy_req)
+    end
+
     def global_register(request)
       proxy_req = request_factory.create_get '/register',
                                              request_params(request),

--- a/modules/registration/registration_commands_api.rb
+++ b/modules/registration/registration_commands_api.rb
@@ -1,0 +1,27 @@
+require 'registration/proxy_request'
+
+class Proxy::Registration::CommandsApi < ::Sinatra::Base
+  post '/' do
+    content_type :json
+    response = Proxy::Registration::ProxyRequest.new.registration_command(request)
+    handle_response(response)
+  rescue StandardError => e
+    logger.exception "Error when proxying registration command", e
+    render_error('Failed to generate registration command')
+  end
+
+  private
+
+  def handle_response(response)
+    if response.code.start_with? '2'
+      response.body
+    else
+      render_error(response.body, code: response.code)
+    end
+  end
+
+  def render_error(message, code: 500)
+    status code
+    message
+  end
+end

--- a/test/registration/registration_commands_api_test.rb
+++ b/test/registration/registration_commands_api_test.rb
@@ -1,0 +1,53 @@
+require 'test_helper'
+require 'registration/registration_commands_api'
+
+class RegistrationCommandsApiTest < Test::Unit::TestCase
+  include Rack::Test::Methods
+
+  def app
+    Proxy::Registration::CommandsApi.new
+  end
+
+  def setup
+    @foreman_url = 'http://foreman.example.com'
+    Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+  end
+
+  def test_registration_command
+    expected_body = '{"registration_command":"curl ... | bash"}'
+    stub_request(:post, "#{@foreman_url}/api/registration_commands")
+      .to_return(body: expected_body, headers: { 'Content-Type' => 'application/json' })
+
+    post '/'
+    assert last_response.ok?
+    assert_equal expected_body, last_response.body
+  end
+
+  def test_registration_command_with_json_body
+    request_body = '{"registration_command":{"organization_id":1,"hostgroup_id":2}}'
+    expected_body = '{"registration_command":"curl ... | bash"}'
+    stub_request(:post, "#{@foreman_url}/api/registration_commands")
+      .with(body: request_body)
+      .to_return(body: expected_body, headers: { 'Content-Type' => 'application/json' })
+
+    post '/', request_body, { 'CONTENT_TYPE' => 'application/json' }
+    assert last_response.ok?
+    assert_equal expected_body, last_response.body
+  end
+
+  def test_registration_command_401
+    stub_request(:post, "#{@foreman_url}/api/registration_commands")
+      .to_return(body: 'Unauthorized', status: 401)
+
+    post '/'
+    assert last_response.unauthorized?
+  end
+
+  def test_registration_command_500
+    Rack::NullLogger.any_instance.stubs(:exception)
+    stub_request(:post, "#{@foreman_url}/api/registration_commands").to_timeout
+
+    post '/'
+    assert last_response.server_error?
+  end
+end


### PR DESCRIPTION
Related to https://github.com/theforeman/foreman/pull/10887.