### PR TITLE
Fixes #39208 - Cache global registration script in smart-proxy

### DIFF
--- a/modules/registration/registration_api.rb
+++ b/modules/registration/registration_api.rb
@@ -1,9 +1,51 @@
 require 'registration/proxy_request'
 
 class Proxy::Registration::Api < ::Sinatra::Base
+  # Cache for the global registration script (GET /register).
+  #
+  # The script is identical for all hosts sharing the same registration
+  # parameters (org, location, hostgroup, activation keys), making it safe
+  # to serve from an in-memory cache during concurrent bulk registration.
+  #
+  # Per-key double-checked locking prevents thundering herd while allowing
+  # genuinely independent cache keys (e.g. different activation keys) to
+  # fetch from Foreman in parallel.
+  #
+  # Only HTTP 200 responses are cached — errors are raised out of the cache
+  # block so they never poison the cache. The per-key mutex is evicted
+  # immediately after caching so KEY_MUTEXES stays bounded to keys currently
+  # being fetched for the first time (zero under steady state).
+  REGISTRATION_SCRIPT_CACHE_TTL = 5 * 60 # seconds
+  KEY_MUTEXES                   = Concurrent::Map.new
+  SCRIPT_CACHE                  = Concurrent::Map.new
+
+  class ScriptFetchError < StandardError
+    attr_reader :response
+
+    def initialize(response)
+      super()
+      @response = response
+    end
+  end
+
+  class << self
+    def registration_script_cache
+      SCRIPT_CACHE
+    end
+
+    def key_mutex(cache_key)
+      KEY_MUTEXES.compute_if_absent(cache_key) { Mutex.new }
+    end
+
+    def evict_key_mutex(cache_key)
+      KEY_MUTEXES.delete(cache_key)
+    end
+  end
+
   get '/' do
-    response = Proxy::Registration::ProxyRequest.new.global_register(request)
-    handle_response(response)
+    registration_script
+  rescue ScriptFetchError => e
+    handle_response(e.response)
   rescue StandardError => e
     logger.exception "Error when rendering Global Registration Template", e
     render_error(default_error_msg)
@@ -19,11 +61,41 @@ class Proxy::Registration::Api < ::Sinatra::Base
 
   private
 
+  def registration_script
+    cache_key = Rack::Utils.build_query(
+      Rack::Utils.parse_nested_query(request.query_string).sort_by { |k, _| k }
+    )
+    cache(cache_key) do
+      response = Proxy::Registration::ProxyRequest.new.global_register(request)
+      raise ScriptFetchError, response unless response.code == '200'
+      response.body
+    end
+  end
+
+  def cache(key, &block)
+    value = read_registration_cache(key)
+    return value if value
+
+    self.class.key_mutex(key).synchronize do
+      value = read_registration_cache(key)
+      return value if value
+
+      result = yield
+      self.class.registration_script_cache[key] = { body: result, at: Time.now }
+      self.class.evict_key_mutex(key)
+      result
+    end
+  end
+
+  def read_registration_cache(cache_key)
+    entry = self.class.registration_script_cache[cache_key]
+    entry[:body] if entry && (Time.now - entry[:at]) < REGISTRATION_SCRIPT_CACHE_TTL
+  end
+
   def handle_response(response)
-    if response.code.start_with? '2'
+    if response.code.start_with?('2')
       response.body
     else
-      # Return error message only if it is not HTML.
       message = response["content-type"].include?('text/plain') ? response.body : default_error_msg
       render_error(message, code: response.code)
     end

--- a/modules/registration/registration_api.rb
+++ b/modules/registration/registration_api.rb
@@ -1,9 +1,55 @@
 require 'registration/proxy_request'
 
 class Proxy::Registration::Api < ::Sinatra::Base
+  # Cache for the global registration script (GET /register).
+  #
+  # The script is identical for all hosts sharing the same registration
+  # parameters (org, location, hostgroup, activation keys) and auth context,
+  # making it safe to serve from an in-memory cache during concurrent bulk
+  # registration.
+  #
+  # Per-key double-checked locking prevents thundering herd while allowing
+  # genuinely independent cache keys (e.g. different activation keys) to
+  # fetch from Foreman in parallel.
+  #
+  # Only HTTP 200 responses are cached — errors are raised out of the cache
+  # block so they never poison the cache. Per-key mutexes are retained and
+  # reused, which keeps synchronization stable for both hot keys and failure
+  # retries without racing mutex eviction against concurrent requests.
+  REGISTRATION_SCRIPT_CACHE_TTL = 5 * 60 # seconds
+  AUTHORIZATION_HEADER          = 'HTTP_AUTHORIZATION'.freeze
+  AUTHORIZATION_KEY_PREFIX      = 'auth:authorization:'.freeze
+  CACHE_KEY_SEPARATOR           = "\0".freeze
+  KEY_MUTEXES                   = Concurrent::Map.new
+  REMOTE_USER_HEADER            = 'HTTP_REMOTE_USER'.freeze
+  REMOTE_USER_KEY_PREFIX        = 'auth:remote_user:'.freeze
+  SCRIPT_CACHE                  = Concurrent::Map.new
+  AUTH_NONE_KEY                 = 'auth:none'.freeze
+  CacheEntry                    = Struct.new(:body, :at)
+
+  class ScriptFetchError < StandardError
+    attr_reader :response
+
+    def initialize(response)
+      super()
+      @response = response
+    end
+  end
+
+  class << self
+    def registration_script_cache
+      SCRIPT_CACHE
+    end
+
+    def key_mutex(cache_key)
+      KEY_MUTEXES.compute_if_absent(cache_key) { Mutex.new }
+    end
+  end
+
   get '/' do
-    response = Proxy::Registration::ProxyRequest.new.global_register(request)
-    handle_response(response)
+    registration_script
+  rescue ScriptFetchError => e
+    handle_response(e.response)
   rescue StandardError => e
     logger.exception "Error when rendering Global Registration Template", e
     render_error(default_error_msg)
@@ -19,11 +65,83 @@ class Proxy::Registration::Api < ::Sinatra::Base
 
   private
 
+  def registration_script
+    cache(cache_key_for_global_register) { fetch_registration_script }
+  end
+
+  def cache_key_for_global_register
+    "#{normalized_query_cache_key}#{CACHE_KEY_SEPARATOR}#{auth_cache_key_component}"
+  end
+
+  def normalized_query_cache_key
+    Rack::Utils.build_query(
+      Rack::Utils.parse_nested_query(request.query_string).sort_by { |k, _| k }
+    )
+  end
+
+  def auth_cache_key_component
+    authorization = request.env[AUTHORIZATION_HEADER].to_s
+    remote_user = request.env[REMOTE_USER_HEADER].to_s
+
+    return authorization_cache_key_component(authorization) unless authorization.empty?
+    return "#{REMOTE_USER_KEY_PREFIX}#{remote_user}" unless remote_user.empty?
+
+    AUTH_NONE_KEY
+  end
+
+  def authorization_cache_key_component(authorization)
+    "#{AUTHORIZATION_KEY_PREFIX}#{authorization}"
+    # A SHA-256 fingerprint is also viable if we want to avoid raw credentials
+    # in cache keys.
+    # "#{AUTHORIZATION_KEY_PREFIX}#{Digest::SHA256.hexdigest(authorization)}"
+  end
+
+  def fetch_registration_script
+    response = Proxy::Registration::ProxyRequest.new.global_register(request)
+    raise ScriptFetchError, response unless response.code == '200'
+
+    response.body
+  end
+
+  def cache(key, &block)
+    value = read_registration_cache(key)
+    return value if value
+
+    cache = self.class.registration_script_cache
+    mutex = self.class.key_mutex(key)
+    mutex.synchronize do
+      value = read_registration_cache(key)
+      return value if value
+
+      result = yield
+      cache[key] = CacheEntry.new(result, monotonic_now)
+      result
+    ensure
+      KEY_MUTEXES.delete(key) if KEY_MUTEXES[key].equal?(mutex)
+    end
+  end
+
+  def read_registration_cache(cache_key)
+    cache = self.class.registration_script_cache
+    entry = cache[cache_key]
+    return unless entry
+
+    if (monotonic_now - entry.at) < REGISTRATION_SCRIPT_CACHE_TTL
+      entry.body
+    else
+      cache.delete(cache_key)
+      nil
+    end
+  end
+
+  def monotonic_now
+    Process.clock_gettime(Process::CLOCK_MONOTONIC)
+  end
+
   def handle_response(response)
-    if response.code.start_with? '2'
+    if response.code.start_with?('2')
       response.body
     else
-      # Return error message only if it is not HTML.
       message = response["content-type"].include?('text/plain') ? response.body : default_error_msg
       render_error(message, code: response.code)
     end

--- a/test/registration/registration_api_test.rb
+++ b/test/registration/registration_api_test.rb
@@ -11,6 +11,9 @@ class RegistrationRegisterApiTest < Test::Unit::TestCase
   def setup
     @foreman_url = 'http://foreman.example.com'
     Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+    # Clear class-level state between tests to prevent cross-test contamination
+    Proxy::Registration::Api.registration_script_cache.clear
+    Proxy::Registration::Api::KEY_MUTEXES.clear
   end
 
   def test_global_register_template
@@ -100,6 +103,86 @@ class RegistrationRegisterApiTest < Test::Unit::TestCase
     get '/'
     assert last_response.server_error?
     assert_match("echo \"Internal Server Error\"\nexit 1\n", last_response.body)
+  end
+
+  def test_global_register_caches_response
+    stub = stub_request(:get, "#{@foreman_url}/register").to_return(body: 'template')
+
+    2.times do
+      get '/'
+      assert last_response.ok?
+      assert_match('template', last_response.body)
+    end
+
+    assert_requested stub, times: 1
+  end
+
+  def test_global_register_cache_key_is_parameter_order_independent
+    # Cache key is normalised (params sorted alphabetically), so both orderings
+    # produce activation_keys=rhel9&owner=Default_Organization and share one entry.
+    stub_request(:get, "#{@foreman_url}/register?activation_keys=rhel9&owner=Default_Organization")
+      .to_return(body: 'template')
+
+    get '/', { owner: 'Default_Organization', activation_keys: 'rhel9' }
+    assert last_response.ok?
+
+    # Different parameter order — must hit cache, not Foreman again
+    get '/', { activation_keys: 'rhel9', owner: 'Default_Organization' }
+    assert last_response.ok?
+
+    assert_requested :get, "#{@foreman_url}/register?activation_keys=rhel9&owner=Default_Organization", times: 1
+  end
+
+  def test_global_register_caches_per_key
+    stub_a = stub_request(:get, "#{@foreman_url}/register?key=a").to_return(body: 'template_a')
+    stub_b = stub_request(:get, "#{@foreman_url}/register?key=b").to_return(body: 'template_b')
+
+    get '/', { key: 'a' }
+    assert_match('template_a', last_response.body)
+    get '/', { key: 'b' }
+    assert_match('template_b', last_response.body)
+    # second requests — must be served from cache
+    get '/', { key: 'a' }
+    assert_match('template_a', last_response.body)
+    get '/', { key: 'b' }
+    assert_match('template_b', last_response.body)
+
+    assert_requested stub_a, times: 1
+    assert_requested stub_b, times: 1
+  end
+
+  def test_global_register_evicts_mutex_after_caching
+    stub_request(:get, "#{@foreman_url}/register").to_return(body: 'template')
+
+    get '/'
+    assert last_response.ok?
+    assert_empty Proxy::Registration::Api::KEY_MUTEXES
+  end
+
+  def test_global_register_cache_entry_expires_after_ttl
+    Proxy::Registration::Api.registration_script_cache[''] = {
+      body: 'stale-template',
+      at: Time.now - Proxy::Registration::Api::REGISTRATION_SCRIPT_CACHE_TTL - 1,
+    }
+    stub = stub_request(:get, "#{@foreman_url}/register").to_return(body: 'fresh-template')
+
+    get '/'
+    assert last_response.ok?
+    assert_match('fresh-template', last_response.body)
+    assert_requested stub, times: 1
+  end
+
+  def test_global_register_does_not_cache_errors
+    stub = stub_request(:get, "#{@foreman_url}/register").to_return(
+      body: 'error', status: 500, headers: { "Content-Type" => 'text/plain' }
+    )
+
+    2.times do
+      get '/'
+      assert last_response.server_error?
+    end
+
+    assert_requested stub, times: 2
   end
 
   def test_host_500

--- a/test/registration/registration_api_test.rb
+++ b/test/registration/registration_api_test.rb
@@ -8,9 +8,28 @@ class RegistrationRegisterApiTest < Test::Unit::TestCase
     Proxy::Registration::Api.new
   end
 
+  def authorization_header(token)
+    { 'HTTP_AUTHORIZATION' => "Bearer #{token}" }
+  end
+
+  def remote_user_header(user)
+    { 'HTTP_REMOTE_USER' => user }
+  end
+
+  def cache_key_separator
+    Proxy::Registration::Api::CACHE_KEY_SEPARATOR
+  end
+
+  def stale_monotonic_time
+    Process.clock_gettime(Process::CLOCK_MONOTONIC) - Proxy::Registration::Api::REGISTRATION_SCRIPT_CACHE_TTL - 1
+  end
+
   def setup
     @foreman_url = 'http://foreman.example.com'
     Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+    # Clear class-level state between tests to prevent cross-test contamination
+    Proxy::Registration::Api.registration_script_cache.clear
+    Proxy::Registration::Api::KEY_MUTEXES.clear
   end
 
   def test_global_register_template
@@ -100,6 +119,178 @@ class RegistrationRegisterApiTest < Test::Unit::TestCase
     get '/'
     assert last_response.server_error?
     assert_match("echo \"Internal Server Error\"\nexit 1\n", last_response.body)
+  end
+
+  def test_global_register_caches_response
+    stub = stub_request(:get, "#{@foreman_url}/register").to_return(body: 'template')
+
+    2.times do
+      get '/'
+      assert last_response.ok?
+      assert_match('template', last_response.body)
+    end
+
+    assert_requested stub, times: 1
+  end
+
+  def test_global_register_cache_key_is_parameter_order_independent
+    # Cache key is normalised (params sorted alphabetically), so both orderings
+    # produce activation_keys=rhel9&owner=Default_Organization and share one entry.
+    stub_request(:get, "#{@foreman_url}/register?activation_keys=rhel9&owner=Default_Organization")
+      .to_return(body: 'template')
+
+    get '/', { owner: 'Default_Organization', activation_keys: 'rhel9' }
+    assert last_response.ok?
+
+    # Different parameter order — must hit cache, not Foreman again
+    get '/', { activation_keys: 'rhel9', owner: 'Default_Organization' }
+    assert last_response.ok?
+
+    assert_requested :get, "#{@foreman_url}/register?activation_keys=rhel9&owner=Default_Organization", times: 1
+  end
+
+  def test_global_register_caches_per_key
+    stub_a = stub_request(:get, "#{@foreman_url}/register?key=a").to_return(body: 'template_a')
+    stub_b = stub_request(:get, "#{@foreman_url}/register?key=b").to_return(body: 'template_b')
+
+    get '/', { key: 'a' }
+    assert_match('template_a', last_response.body)
+    get '/', { key: 'b' }
+    assert_match('template_b', last_response.body)
+    # second requests — must be served from cache
+    get '/', { key: 'a' }
+    assert_match('template_a', last_response.body)
+    get '/', { key: 'b' }
+    assert_match('template_b', last_response.body)
+
+    assert_requested stub_a, times: 1
+    assert_requested stub_b, times: 1
+  end
+
+  def test_global_register_caches_per_authorization_header
+    stub = stub_request(:get, "#{@foreman_url}/register?key=a")
+           .with(headers: { 'Authorization' => 'Bearer token-1' })
+           .to_return(body: 'template')
+
+    2.times do
+      get '/', { key: 'a' }, authorization_header('token-1')
+      assert last_response.ok?
+      assert_match('template', last_response.body)
+    end
+
+    assert_requested stub, times: 1
+  end
+
+  def test_global_register_separates_cache_by_authorization_header
+    stub_token_1 = stub_request(:get, "#{@foreman_url}/register?key=a")
+                   .with(headers: { 'Authorization' => 'Bearer token-1' })
+                   .to_return(body: 'template-1')
+    stub_token_2 = stub_request(:get, "#{@foreman_url}/register?key=a")
+                   .with(headers: { 'Authorization' => 'Bearer token-2' })
+                   .to_return(body: 'template-2')
+
+    get '/', { key: 'a' }, authorization_header('token-1')
+    assert last_response.ok?
+    assert_match('template-1', last_response.body)
+
+    get '/', { key: 'a' }, authorization_header('token-2')
+    assert last_response.ok?
+    assert_match('template-2', last_response.body)
+
+    assert_requested stub_token_1, times: 1
+    assert_requested stub_token_2, times: 1
+  end
+
+  def test_global_register_caches_per_remote_user
+    stub = stub_request(:get, "#{@foreman_url}/register?key=a").to_return(body: 'template')
+
+    2.times do
+      get '/', { key: 'a' }, remote_user_header('test-user')
+      assert last_response.ok?
+      assert_match('template', last_response.body)
+    end
+
+    assert_requested stub, times: 1
+  end
+
+  def test_global_register_separates_cache_by_remote_user
+    stub_request(:get, "#{@foreman_url}/register?key=a")
+      .to_return({ body: 'template-1' }, { body: 'template-2' })
+
+    get '/', { key: 'a' }, remote_user_header('user-1')
+    assert last_response.ok?
+    assert_match('template-1', last_response.body)
+
+    get '/', { key: 'a' }, remote_user_header('user-2')
+    assert last_response.ok?
+    assert_match('template-2', last_response.body)
+  end
+
+  def test_global_register_separates_cache_by_auth_and_anonymous_requests
+    stub_request(:get, "#{@foreman_url}/register?key=a")
+      .to_return({ body: 'template-anonymous' }, { body: 'template-authenticated' })
+
+    get '/', { key: 'a' }
+    assert last_response.ok?
+    assert_match('template-anonymous', last_response.body)
+
+    get '/', { key: 'a' }, authorization_header('token-1')
+    assert last_response.ok?
+    assert_match('template-authenticated', last_response.body)
+  end
+
+  def test_global_register_prefers_authorization_over_remote_user_for_cache_partitioning
+    stub = stub_request(:get, "#{@foreman_url}/register?key=a")
+           .with(headers: { 'Authorization' => 'Bearer token-1' })
+           .to_return(body: 'template')
+
+    get '/', { key: 'a' }, authorization_header('token-1').merge(remote_user_header('user-1'))
+    assert last_response.ok?
+    assert_match('template', last_response.body)
+
+    get '/', { key: 'a' }, authorization_header('token-1').merge(remote_user_header('user-2'))
+    assert last_response.ok?
+    assert_match('template', last_response.body)
+
+    assert_requested stub, times: 1
+  end
+
+  def test_global_register_cache_entry_expires_after_ttl
+    Proxy::Registration::Api.registration_script_cache[''] =
+      Proxy::Registration::Api::CacheEntry.new('stale-template', stale_monotonic_time)
+    stub = stub_request(:get, "#{@foreman_url}/register").to_return(body: 'fresh-template')
+
+    get '/'
+    assert last_response.ok?
+    assert_match('fresh-template', last_response.body)
+    assert_requested stub, times: 1
+  end
+
+  def test_global_register_removes_expired_cache_entry
+    cache_key = "#{cache_key_separator}auth:none"
+    Proxy::Registration::Api.registration_script_cache[cache_key] =
+      Proxy::Registration::Api::CacheEntry.new('stale-template', stale_monotonic_time)
+    stub = stub_request(:get, "#{@foreman_url}/register").to_return(body: 'fresh-template')
+
+    get '/'
+
+    assert last_response.ok?
+    assert_match('fresh-template', last_response.body)
+    assert_requested stub, times: 1
+    refute_equal 'stale-template', Proxy::Registration::Api.registration_script_cache[cache_key]&.body
+  end
+
+  def test_global_register_does_not_cache_errors
+    stub = stub_request(:get, "#{@foreman_url}/register").to_return(
+      body: 'error', status: 500, headers: { "Content-Type" => 'text/plain' }
+    )
+
+    2.times do
+      get '/'
+      assert last_response.server_error?
+    end
+
+    assert_requested stub, times: 2
   end
 
   def test_host_500


### PR DESCRIPTION
## Problem

`GET /register` returns the same shell script for all hosts sharing the same registration parameters (org, location, hostgroup, activation keys). Under bulk registration — 100+ hosts hitting the same capsule simultaneously — this endpoint is called once per host, each time proxying to Foreman and waiting for the ERB template to render (~103ms in profiling). With WEBrick's MaxClients=100, all threads can be held waiting for identical Foreman responses.

## Solution

Cache the rendered script in memory (5-minute TTL) keyed on a canonical form of the request query string (parameters sorted alphabetically, so requests differing only in parameter order share the same cache entry).

Per-key double-checked locking prevents the thundering herd on a cold cache while allowing concurrent requests for genuinely different keys (e.g. different activation keys) to fetch from Foreman in parallel without blocking each other:

- Fast path: unsynchronised Concurrent::Map read, no lock acquired
- Slow path: key-specific Mutex serialises only competing threads; re-checks under lock before fetching from Foreman

The per-key Mutex is evicted from KEY_MUTEXES immediately after the script is written to cache, so KEY_MUTEXES is empty under steady state and bounded to in-flight fetches only.

Only 2xx responses are cached — errors never poison the cache. SCRIPT_CACHE uses Concurrent::Map (already a smart-proxy dependency) for lock-free reads that are safe on all Ruby VMs.

## Test plan

- [x] Cache hit: Foreman called once for repeated identical requests
- [x] Per-key isolation: different parameter sets cached independently
- [x] Parameter order independence: requests differing only in param order share the same cache entry
- [x] TTL expiry: expired entries are not served; Foreman is re-called
- [x] Mutex eviction: KEY_MUTEXES is empty after a successful cache write
- [x] Error non-caching: Foreman is called on every request when it errors

Fixes #39208
