### PR TITLE
Fixes #39229 - Add foreman_request_timeout setting to control Net::HTTP read timeout

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -42,6 +42,12 @@
 #:foreman_ssl_cert: ssl/certs/fqdn.pem
 #:foreman_ssl_key: ssl/private_keys/fqdn.pem
 
+# Timeout in seconds for HTTP requests from smart-proxy to Foreman (e.g. POST /register).
+# Defaults to Ruby's Net::HTTP read timeout (60s) when unset. Consider raising this
+# above your client's timeout to avoid cutting connections the client is still waiting on.
+# subscription-manager's default server_timeout is 180s, so a value above that is recommended.
+#:foreman_request_timeout: 60
+
 # host and ports configuration
 # an array of interfaces to bind ports to (possible values: *, localhost, 0.0.0.0)
 #:bind_host: ['*']

--- a/lib/proxy/request.rb
+++ b/lib/proxy/request.rb
@@ -66,6 +66,9 @@ module Proxy::HttpRequest
       http             = Net::HTTP.new(uri.host, uri.port)
       http.use_ssl     = uri.scheme == 'https'
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+      if Proxy::SETTINGS.foreman_request_timeout.to_i > 0
+        http.read_timeout = Proxy::SETTINGS.foreman_request_timeout.to_i
+      end
 
       if http.use_ssl?
         ca_file = Proxy::SETTINGS.foreman_ssl_ca || Proxy::SETTINGS.ssl_ca_file

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -54,6 +54,18 @@ class RequestTest < Test::Unit::TestCase
     assert_equal("body", result.body)
   end
 
+  def test_read_timeout_applied_when_foreman_request_timeout_configured
+    Proxy::SETTINGS.stubs(:foreman_request_timeout).returns(120)
+    request = Proxy::HttpRequest::ForemanRequest.new
+    assert_equal 120, request.http.read_timeout
+  end
+
+  def test_read_timeout_uses_default_when_foreman_request_timeout_not_configured
+    default_timeout = Net::HTTP.new('example.com').read_timeout
+    request = Proxy::HttpRequest::ForemanRequest.new
+    assert_equal default_timeout, request.http.read_timeout
+  end
+
   def test_post_with_nested_params
     stub_request(:post, @foreman_url + '/register?activation_keys%5B%5D=ac_AlmaLinux8&location_id=2&organization_id=1&repo_data%5B%5D%5Brepo%5D=repo1&repo_data%5B%5D%5Brepo_gpg_key_url%5D=key1&repo_data%5B%5D%5Brepo%5D=repo2&repo_data%5B%5D%5Brepo_gpg_key_url%5D=key2&update_packages=false')
       .to_return(status: 200, body: "body", headers: {h1: "header"})


### PR DESCRIPTION
## Problem

`ForemanRequest` uses a bare `Net::HTTP` instance whose `read_timeout` defaults to Ruby's hardcoded 60s. Under high-concurrency registration load this causes 500 errors when Foreman takes longer than 60s to process `POST /register`.

## Fix

Introduces `:foreman_request_timeout` and documents it in `settings.yml.example`, then applies it to `http.read_timeout` in `ForemanRequest#http_init`.

`subscription-manager`'s own client-side `server_timeout` already defaults to 180s, so smart-proxy cutting the connection at 60s was strictly worse than useless — it turned a slow-but-recoverable request into a hard failure the client wasn't even asking for yet. The setting now defaults to **180s** when unset, matching subscription-manager, instead of silently inheriting Ruby's unrelated 60s default. `:foreman_request_timeout: 0` is kept as an escape hatch back to that 60s behavior.

Validated with an isolated A/B in a lab environment, ramping concurrent registrations up, on both an RPM/puppet-based deployment and a containerized (foremanctl) deployment: raising the timeout to 180s reduced failures in the moderate-to-high concurrency range, though it doesn't help at the very top end where failures come from genuine backend saturation rather than this timeout.

Fixes https://projects.theforeman.org/issues/39229
