### PR TITLE
Fixes #39300 - Fix Redfish identify LED handling

### DIFF
--- a/modules/bmc/redfish.rb
+++ b/modules/bmc/redfish.rb
@@ -59,11 +59,11 @@ module Proxy
       end
 
       def identifyon
-        system.patch(payload: { 'IndicatorLED' => 'On' })
+        system.patch_if_match({ 'IndicatorLED' => 'Lit' })
       end
 
       def identifyoff
-        system.patch(payload: { 'IndicatorLED' => 'Off' })
+        system.patch_if_match({ 'IndicatorLED' => 'Off' })
       end
 
       def poweroff(soft = false)

--- a/test/bmc/bmc_redfish_test.rb
+++ b/test/bmc/bmc_redfish_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'bmc/bmc_plugin'
 require 'bmc/redfish'
-require 'test/bmc/redfish_test_helper'
+require 'bmc/redfish_test_helper'
 require 'json'
 
 class BmcRedfishTest < Test::Unit::TestCase
@@ -160,5 +160,26 @@ class BmcRedfishTest < Test::Unit::TestCase
 
     result = @bmc.bootcdrom(false, false)
     assert_not_nil result
+  end
+
+  def test_identifyon_sets_indicator_led_lit
+    system_mock = mock('system')
+    system_mock.expects(:patch_if_match).with({ 'IndicatorLED' => 'Lit' }).returns(true)
+    @bmc.expects(:system).returns(system_mock)
+    @bmc.identifyon
+  end
+
+  def test_identifyoff_sets_indicator_led_off
+    system_mock = mock('system')
+    system_mock.expects(:patch_if_match).with({ 'IndicatorLED' => 'Off' }).returns(true)
+    @bmc.expects(:system).returns(system_mock)
+    @bmc.identifyoff
+  end
+
+  def test_identifystatus_returns_downcased_indicator_led
+    system_mock = mock('system')
+    system_mock.expects(:IndicatorLED).returns('Lit')
+    @bmc.expects(:system).returns(system_mock)
+    assert_equal 'lit', @bmc.identifystatus
   end
 end


### PR DESCRIPTION
## Summary

Fix incorrect `IndicatorLED` value and use ETag-aware PATCH for identify LED operations in the Redfish BMC provider.

## Changes

### Bug fix: IndicatorLED value
The [Redfish specification (DSP0266_1.23.1.pdf)](https://www.dmtf.org/sites/default/files/standards/documents/DSP0266_1.23.1.pdf) defines `IndicatorLED` accepted values as `Lit`, `Off`, and `Blinking`.
The previous implementation used `'On'` in `identifyon`, which is **not a valid Redfish value** and would be rejected by spec-compliant BMCs.

This PR changes it to the correct value `'Lit'`.

### Improvement: use `patch_if_match` for identify operations
`identifyon` and `identifyoff` previously used `system.patch(payload: ...)`, which does not include ETag concurrency control.
Other state-changing operations like `bootdevice` already use `patch_if_match`.
This PR aligns the identify LED operations to also use `patch_if_match` for consistency and to avoid potential race conditions.