### PR TITLE
Fixes #39301 - Add LocationIndicatorActive support for identify LED with IndicatorLED fallback

### DIFF
--- a/modules/bmc/redfish.rb
+++ b/modules/bmc/redfish.rb
@@ -55,15 +55,19 @@ module Proxy
       end
 
       def identifystatus
+        location_active = system.LocationIndicatorActive
+        return location_active ? 'on' : 'off' unless location_active.nil?
+
+        logger.debug('LocationIndicatorActive is nil, falling back to IndicatorLED for identify status')
         system.IndicatorLED&.downcase
       end
 
       def identifyon
-        system.patch_if_match({ 'IndicatorLED' => 'Lit' })
+        patch_identify(:on)
       end
 
       def identifyoff
-        system.patch_if_match({ 'IndicatorLED' => 'Off' })
+        patch_identify(:off)
       end
 
       def poweroff(soft = false)
@@ -216,6 +220,31 @@ module Proxy
 
       def poweraction(action)
         host.post(path: system.Actions&.[]('#ComputerSystem.Reset')&.[]('target'), payload: { 'ResetType' => action })
+      end
+
+      def patch_identify(state)
+        location_active = system.LocationIndicatorActive
+
+        payload = case state
+                  when :on
+                    if location_active.nil?
+                      logger.debug('LocationIndicatorActive is nil, falling back to IndicatorLED for identify on')
+                      { 'IndicatorLED' => 'Lit' }
+                    else
+                      { 'LocationIndicatorActive' => true }
+                    end
+                  when :off
+                    if location_active.nil?
+                      logger.debug('LocationIndicatorActive is nil, falling back to IndicatorLED for identify off')
+                      { 'IndicatorLED' => 'Off' }
+                    else
+                      { 'LocationIndicatorActive' => false }
+                    end
+                  else
+                    raise ArgumentError, "Unsupported identify state: #{state.inspect}"
+                  end
+
+        system.patch_if_match(payload)
       end
 
       # I haven't yet encountered a system (apart from a blade chassis, which I think

--- a/test/bmc/bmc_redfish_test.rb
+++ b/test/bmc/bmc_redfish_test.rb
@@ -162,24 +162,57 @@ class BmcRedfishTest < Test::Unit::TestCase
     assert_not_nil result
   end
 
-  def test_identifyon_sets_indicator_led_lit
+  def test_identifystatus_uses_indicator_led_when_location_indicator_absent
     system_mock = mock('system')
-    system_mock.expects(:patch_if_match).with({ 'IndicatorLED' => 'Lit' }).returns(true)
+    system_mock.expects(:LocationIndicatorActive).returns(nil)
+    system_mock.expects(:IndicatorLED).returns('Lit')
+    @bmc.expects(:system).twice.returns(system_mock)
+    assert_equal 'lit', @bmc.identifystatus
+  end
+
+  def test_identifystatus_uses_location_indicator_active_true
+    system_mock = mock('system')
+    system_mock.expects(:LocationIndicatorActive).returns(true)
     @bmc.expects(:system).returns(system_mock)
+    assert_equal 'on', @bmc.identifystatus
+  end
+
+  def test_identifystatus_uses_location_indicator_active_false
+    system_mock = mock('system')
+    system_mock.expects(:LocationIndicatorActive).returns(false)
+    @bmc.expects(:system).returns(system_mock)
+    assert_equal 'off', @bmc.identifystatus
+  end
+
+  def test_identifyon_uses_location_indicator_active_when_present
+    system_mock = mock('system')
+    system_mock.expects(:LocationIndicatorActive).returns(false)
+    system_mock.expects(:patch_if_match).with({ 'LocationIndicatorActive' => true }).returns(true)
+    @bmc.expects(:system).twice.returns(system_mock)
     @bmc.identifyon
   end
 
-  def test_identifyoff_sets_indicator_led_off
+  def test_identifyon_falls_back_to_indicator_led_when_location_indicator_absent
     system_mock = mock('system')
-    system_mock.expects(:patch_if_match).with({ 'IndicatorLED' => 'Off' }).returns(true)
-    @bmc.expects(:system).returns(system_mock)
+    system_mock.expects(:LocationIndicatorActive).returns(nil)
+    system_mock.expects(:patch_if_match).with({ 'IndicatorLED' => 'Lit' }).returns(true)
+    @bmc.expects(:system).twice.returns(system_mock)
+    @bmc.identifyon
+  end
+
+  def test_identifyoff_uses_location_indicator_active_when_present
+    system_mock = mock('system')
+    system_mock.expects(:LocationIndicatorActive).returns(true)
+    system_mock.expects(:patch_if_match).with({ 'LocationIndicatorActive' => false }).returns(true)
+    @bmc.expects(:system).twice.returns(system_mock)
     @bmc.identifyoff
   end
 
-  def test_identifystatus_returns_downcased_indicator_led
+  def test_identifyoff_falls_back_to_indicator_led_when_location_indicator_absent
     system_mock = mock('system')
-    system_mock.expects(:IndicatorLED).returns('Lit')
-    @bmc.expects(:system).returns(system_mock)
-    assert_equal 'lit', @bmc.identifystatus
+    system_mock.expects(:LocationIndicatorActive).returns(nil)
+    system_mock.expects(:patch_if_match).with({ 'IndicatorLED' => 'Off' }).returns(true)
+    @bmc.expects(:system).twice.returns(system_mock)
+    @bmc.identifyoff
   end
 end

--- a/test/bmc/redfish_test_helper.rb
+++ b/test/bmc/redfish_test_helper.rb
@@ -37,6 +37,11 @@ module RedfishTestHelper
     },
   }.freeze
 
+  # Fixture for systems that support the newer LocationIndicatorActive field
+  SYSTEM_DATA_WITH_LOCATION_INDICATOR = SYSTEM_DATA.merge(
+    "LocationIndicatorActive" => false
+  ).freeze
+
   def mask_redfish_acceess(protocol: "https", host: "host")
     # root
     stub_request(:get, "#{protocol}://#{host}#{ROOT_DATA['@odata.id']}").


### PR DESCRIPTION
## Summary
This PR updates Redfish identify LED handling to prefer `LocationIndicatorActive` when present, while preserving backward compatibility by falling back to `IndicatorLED` when unavailable.

## Depends on
- Base PR: https://github.com/theforeman/smart-proxy/pull/939
  This PR builds upon the `IndicatorLED` value fix (`On` → `Lit`) and the `patch_if_match` usage for identify LED operations introduced in the base PR.

## Changes
- `identifystatus`
  - Uses `LocationIndicatorActive` first (`true => on`, `false => off`).
  - Falls back to `IndicatorLED` when `LocationIndicatorActive` is absent.
- `identifyon` / `identifyoff`
  - Delegate to the new private method `patch_identify`.
  - `patch_identify` selects either a `LocationIndicatorActive` or `IndicatorLED` payload based on availability, then applies it via `patch_if_match`.

## Compatibility
Backward compatible: systems without `LocationIndicatorActive` continue to work via `IndicatorLED`.