### PR TITLE
Fixes #39315 - Change rake task 'verbose' parameter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'lib'
   t.libs << 'test'
   t.test_files = FileList['test/**/*_test.rb']
-  t.verbose = true
+  t.options = '--verbose'
   t.ruby_opts = ["-W1"]
 end
 


### PR DESCRIPTION
The verbose option does not work anymore, so we have to explicitly pass
the '--verbose' option now.

(cherry picked from commit 4a468d730426ca561f9e2f088589427ae2f96843)
