### PR TITLE
Expose bmc_default_provider setting via v2/features API

### DIFF
--- a/modules/bmc/bmc_plugin.rb
+++ b/modules/bmc/bmc_plugin.rb
@@ -4,6 +4,7 @@ module Proxy::BMC
 
     default_settings :redfish_verify_ssl => true
     validate :redfish_verify_ssl, :boolean => true
+    expose_setting :bmc_default_provider
     plugin :bmc, ::Proxy::VERSION
 
     # Various installed providers are exposed as capabilties

--- a/test/bmc/integration_test.rb
+++ b/test/bmc/integration_test.rb
@@ -18,7 +18,7 @@ class BmcApiFeaturesTest < SmartProxyRootApiTestCase
     assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:bmc])
     assert_equal(['power_action_v2', 'redfish', 'shell', 'ssh'], mod['capabilities'])
 
-    assert_equal({}, mod['settings'])
+    assert_equal({'bmc_default_provider' => 'freeipmi'}, mod['settings'])
   end
 
   def test_features_with_freeipmi_installed
@@ -34,6 +34,6 @@ class BmcApiFeaturesTest < SmartProxyRootApiTestCase
     assert_equal('running', mod['state'], Proxy::LogBuffer::Buffer.instance.info[:failed_modules][:bmc])
     assert_equal(['freeipmi', 'power_action_v2', 'redfish', 'shell', 'ssh'], mod['capabilities'])
 
-    assert_equal({}, mod['settings'])
+    assert_equal({'bmc_default_provider' => 'freeipmi'}, mod['settings'])
   end
 end


### PR DESCRIPTION
The bmc_default_provider setting is used as a fallback when no bmc_provider param is passed in BMC API requests. Exposing it allows Foreman to discover the configured default provider from the features endpoint.