### PR TITLE
Fixes #39359 - Add shared Faraday transport for Foreman requests

### DIFF
--- a/config/settings.yml.example
+++ b/config/settings.yml.example
@@ -42,6 +42,17 @@
 #:foreman_ssl_cert: ssl/certs/fqdn.pem
 #:foreman_ssl_key: ssl/private_keys/fqdn.pem
 
+# Timeout in seconds for HTTP requests from smart-proxy to Foreman (e.g. POST /register).
+# Defaults to Ruby's Net::HTTP read timeout (60s) when unset. Consider raising this
+# above your client's timeout to avoid cutting connections the client is still waiting on.
+# subscription-manager's default server_timeout is 180s, so a value above that is recommended.
+#:foreman_request_timeout: 60
+
+# Timeout in seconds for establishing TCP/TLS connections from smart-proxy to Foreman.
+# Maps to the HTTP client open timeout. When unset, smart-proxy uses Net::HTTP's default.
+# Consider raising this if the upstream connection establishment is slower than usual.
+#:foreman_open_timeout: 60
+
 # host and ports configuration
 # an array of interfaces to bind ports to (possible values: *, localhost, 0.0.0.0)
 #:bind_host: ['*']

--- a/lib/proxy/foreman_transport.rb
+++ b/lib/proxy/foreman_transport.rb
@@ -1,0 +1,127 @@
+require 'concurrent/map'
+require 'faraday'
+require 'faraday/net_http_persistent'
+require 'net/http'
+require 'openssl'
+
+module Proxy::HttpRequest
+  class ForemanTransport
+    TRANSPORT_RETRY_EXCEPTIONS = [
+      Faraday::SSLError,
+      Faraday::ConnectionFailed,
+    ].freeze
+
+    class << self
+      def connection_cache
+        @connection_cache ||= Concurrent::Map.new
+      end
+
+      def reset!
+        @connection_cache = Concurrent::Map.new
+      end
+
+      def invalidate!(uri = nil)
+        return reset! if uri.nil?
+
+        connection_cache.delete(connection_cache_key(uri))
+      end
+
+      def connection_for(uri)
+        connection_cache.compute_if_absent(connection_cache_key(uri)) { build_connection(uri) }
+      end
+
+      def run_request(uri, request)
+        attempt = 0
+        begin
+          connection = connection_for(uri)
+          connection.run_request(request.http_method, request.path, request.body, request.headers)
+        rescue *TRANSPORT_RETRY_EXCEPTIONS
+          raise if attempt >= 1
+
+          invalidate!(uri)
+          attempt += 1
+          retry
+        end
+      end
+
+      # Preserve the historical Net::HTTP defaults when no explicit proxy setting is provided.
+      def read_timeout(uri)
+        return Proxy::SETTINGS.foreman_request_timeout.to_i if read_timeout_configured?
+
+        Net::HTTP.new(uri.host, uri.port).read_timeout
+      end
+
+      def open_timeout(uri)
+        return Proxy::SETTINGS.foreman_open_timeout.to_i if open_timeout_configured?
+
+        Net::HTTP.new(uri.host, uri.port).open_timeout
+      end
+
+      private
+
+      def build_connection(uri)
+        Faraday.new(url: uri.to_s, ssl: ssl_options, request: request_options(uri)) do |faraday|
+          faraday.adapter :net_http_persistent
+        end
+      end
+
+      def connection_cache_key(uri)
+        [
+          uri.to_s,
+          ssl_paths.values,
+          read_timeout(uri),
+          open_timeout(uri),
+          read_timeout_configured?,
+        ].freeze
+      end
+
+      def request_options(uri)
+        options = { open_timeout: open_timeout(uri) }
+        options[:timeout] = read_timeout(uri) if read_timeout_configured?
+        options
+      end
+
+      def ssl_options
+        options = { verify: false }
+        paths = ssl_paths
+
+        if paths[:ca_file]
+          options[:ca_file] = paths[:ca_file]
+          options[:verify] = true
+        end
+
+        if paths[:certificate] && paths[:private_key]
+          options[:client_cert] = OpenSSL::X509::Certificate.new(File.read(paths[:certificate]))
+          options[:client_key] = OpenSSL::PKey.read(File.read(paths[:private_key]), nil)
+        end
+
+        options
+      end
+
+      def ssl_paths
+        {
+          ca_file: presence(Proxy::SETTINGS.foreman_ssl_ca || Proxy::SETTINGS.ssl_ca_file),
+          certificate: presence(Proxy::SETTINGS.foreman_ssl_cert || Proxy::SETTINGS.ssl_certificate),
+          private_key: presence(Proxy::SETTINGS.foreman_ssl_key || Proxy::SETTINGS.ssl_private_key),
+        }
+      end
+
+      def read_timeout_configured?
+        Proxy::SETTINGS.foreman_request_timeout.to_i > 0
+      end
+
+      def open_timeout_configured?
+        Proxy::SETTINGS.foreman_open_timeout.to_i > 0
+      end
+
+      def presence(value)
+        return nil if value.nil?
+
+        normalized = value.to_s
+        return nil if normalized.empty?
+
+        normalized
+      end
+    end
+  end
+end

--- a/lib/proxy/request.rb
+++ b/lib/proxy/request.rb
@@ -1,8 +1,7 @@
 require 'cgi'
-require 'faraday'
-require 'net/http'
-require 'openssl'
 require 'uri'
+
+require 'proxy/foreman_transport'
 
 module Proxy::HttpRequest
   Request = Struct.new(:http_method, :path, :body, :headers, keyword_init: true)
@@ -71,8 +70,14 @@ module Proxy::HttpRequest
     # Compatibility shim for existing callers that inspect timeout values via `http`.
     ConnectionInfo = Struct.new(:read_timeout, :open_timeout, :connection, keyword_init: true)
 
+    class << self
+      def reset_connection_cache!
+        ForemanTransport.reset!
+      end
+    end
+
     def send_request(request)
-      response = connection.run_request(request.http_method, request.path, request.body, request.headers)
+      response = ForemanTransport.run_request(uri, request)
       Response.new(status: response.status, body: response.body, headers: response.headers)
     end
 
@@ -85,7 +90,7 @@ module Proxy::HttpRequest
     end
 
     def connection
-      @connection ||= build_connection
+      ForemanTransport.connection_for(uri)
     end
 
     def http
@@ -96,54 +101,12 @@ module Proxy::HttpRequest
 
     private
 
-    def build_connection
-      Faraday.new(url: uri.to_s, ssl: ssl_options, request: request_options)
-    end
-
-    def request_options
-      { timeout: read_timeout, open_timeout: open_timeout }
-    end
-
     def read_timeout
-      # Preserve the historical Net::HTTP defaults when no explicit proxy setting is provided.
-      return Proxy::SETTINGS.foreman_request_timeout.to_i if Proxy::SETTINGS.foreman_request_timeout.to_i > 0
-
-      Net::HTTP.new(uri.host, uri.port).read_timeout
+      ForemanTransport.read_timeout(uri)
     end
 
     def open_timeout
-      # Preserve the historical Net::HTTP defaults when no explicit proxy setting is provided.
-      return Proxy::SETTINGS.foreman_open_timeout.to_i if Proxy::SETTINGS.foreman_open_timeout.to_i > 0
-
-      Net::HTTP.new(uri.host, uri.port).open_timeout
-    end
-
-    def ssl_options
-      options = { verify: false }
-      ca_file = presence(Proxy::SETTINGS.foreman_ssl_ca || Proxy::SETTINGS.ssl_ca_file)
-      certificate = presence(Proxy::SETTINGS.foreman_ssl_cert || Proxy::SETTINGS.ssl_certificate)
-      private_key = presence(Proxy::SETTINGS.foreman_ssl_key || Proxy::SETTINGS.ssl_private_key)
-
-      if ca_file
-        options[:ca_file] = ca_file
-        options[:verify] = true
-      end
-
-      if certificate && private_key
-        options[:client_cert] = OpenSSL::X509::Certificate.new(File.read(certificate))
-        options[:client_key] = OpenSSL::PKey.read(File.read(private_key), nil)
-      end
-
-      options
-    end
-
-    def presence(value)
-      return nil if value.nil?
-
-      normalized = value.to_s
-      return nil if normalized.empty?
-
-      normalized
+      ForemanTransport.open_timeout(uri)
     end
   end
 end

--- a/lib/proxy/request.rb
+++ b/lib/proxy/request.rb
@@ -1,9 +1,30 @@
-require 'net/http'
-require 'net/https'
-require 'uri'
 require 'cgi'
+require 'faraday'
+require 'net/http'
+require 'openssl'
+require 'uri'
 
 module Proxy::HttpRequest
+  Request = Struct.new(:http_method, :path, :body, :headers, keyword_init: true)
+
+  class Response
+    attr_reader :body, :headers, :status
+
+    def initialize(status:, body:, headers:)
+      @status = status
+      @body = body
+      @headers = headers.transform_keys { |key| key.to_s.downcase }
+    end
+
+    def code
+      status.to_s
+    end
+
+    def [](header)
+      headers[header.to_s.downcase]
+    end
+  end
+
   class ForemanRequestFactory
     def initialize(base_uri)
       @base_uri = base_uri
@@ -14,38 +35,45 @@ module Proxy::HttpRequest
     end
 
     def create_get(path, query = {}, headers = {})
-      uri = uri(path)
-      req = Net::HTTP::Get.new("#{uri.path || '/'}?#{query_string(query)}")
-      req = add_headers(req, headers)
-      req
+      Request.new(http_method: :get,
+                  path: request_path(path, query),
+                  headers: add_headers(headers))
     end
 
     def uri(path)
       URI.join(@base_uri.to_s, path)
     end
 
-    def add_headers(req, headers = {})
-      req.add_field('Accept', 'application/json,version=2')
-      req.content_type = headers.delete("Content-Type") || 'application/json'
-      headers.each do |k, v|
-        req.add_field(k, v)
-      end
-      req
+    def add_headers(headers = {})
+      outgoing_headers = headers.dup
+      content_type = outgoing_headers.delete('Content-Type') || 'application/json'
+      { 'Accept' => 'application/json,version=2', 'Content-Type' => content_type }.merge(outgoing_headers)
     end
 
     def create_post(path, body, headers = {}, query = {})
-      uri = uri(path)
-      uri.query = query_string(query)
-      req = Net::HTTP::Post.new(uri)
-      req = add_headers(req, headers)
-      req.body = body
-      req
+      Request.new(http_method: :post,
+                  path: request_path(path, query),
+                  body: body,
+                  headers: add_headers(headers))
+    end
+
+    private
+
+    def request_path(path, query = {})
+      request_uri = uri(path)
+      query = query_string(query)
+      request_uri.query = query unless query.empty?
+      request_uri.request_uri
     end
   end
 
   class ForemanRequest
+    # Compatibility shim for existing callers that inspect timeout values via `http`.
+    ConnectionInfo = Struct.new(:read_timeout, :open_timeout, :connection, keyword_init: true)
+
     def send_request(request)
-      http.request(request)
+      response = connection.run_request(request.http_method, request.path, request.body, request.headers)
+      Response.new(status: response.status, body: response.body, headers: response.headers)
     end
 
     def request_factory
@@ -56,33 +84,66 @@ module Proxy::HttpRequest
       @uri ||= URI.parse(Proxy::SETTINGS.foreman_url.to_s)
     end
 
+    def connection
+      @connection ||= build_connection
+    end
+
     def http
-      @http ||= http_init
+      ConnectionInfo.new(read_timeout: read_timeout,
+                         open_timeout: open_timeout,
+                         connection: connection)
     end
 
     private
 
-    def http_init
-      http             = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl     = uri.scheme == 'https'
-      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    def build_connection
+      Faraday.new(url: uri.to_s, ssl: ssl_options, request: request_options)
+    end
 
-      if http.use_ssl?
-        ca_file = Proxy::SETTINGS.foreman_ssl_ca || Proxy::SETTINGS.ssl_ca_file
-        certificate = Proxy::SETTINGS.foreman_ssl_cert || Proxy::SETTINGS.ssl_certificate
-        private_key = Proxy::SETTINGS.foreman_ssl_key || Proxy::SETTINGS.ssl_private_key
+    def request_options
+      { timeout: read_timeout, open_timeout: open_timeout }
+    end
 
-        if ca_file && !ca_file.to_s.empty?
-          http.ca_file     = ca_file
-          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-        end
+    def read_timeout
+      # Preserve the historical Net::HTTP defaults when no explicit proxy setting is provided.
+      return Proxy::SETTINGS.foreman_request_timeout.to_i if Proxy::SETTINGS.foreman_request_timeout.to_i > 0
 
-        if certificate && !certificate.to_s.empty? && private_key && !private_key.to_s.empty?
-          http.cert = OpenSSL::X509::Certificate.new(File.read(certificate))
-          http.key  = OpenSSL::PKey.read(File.read(private_key), nil)
-        end
+      Net::HTTP.new(uri.host, uri.port).read_timeout
+    end
+
+    def open_timeout
+      # Preserve the historical Net::HTTP defaults when no explicit proxy setting is provided.
+      return Proxy::SETTINGS.foreman_open_timeout.to_i if Proxy::SETTINGS.foreman_open_timeout.to_i > 0
+
+      Net::HTTP.new(uri.host, uri.port).open_timeout
+    end
+
+    def ssl_options
+      options = { verify: false }
+      ca_file = presence(Proxy::SETTINGS.foreman_ssl_ca || Proxy::SETTINGS.ssl_ca_file)
+      certificate = presence(Proxy::SETTINGS.foreman_ssl_cert || Proxy::SETTINGS.ssl_certificate)
+      private_key = presence(Proxy::SETTINGS.foreman_ssl_key || Proxy::SETTINGS.ssl_private_key)
+
+      if ca_file
+        options[:ca_file] = ca_file
+        options[:verify] = true
       end
-      http
+
+      if certificate && private_key
+        options[:client_cert] = OpenSSL::X509::Certificate.new(File.read(certificate))
+        options[:client_key] = OpenSSL::PKey.read(File.read(private_key), nil)
+      end
+
+      options
+    end
+
+    def presence(value)
+      return nil if value.nil?
+
+      normalized = value.to_s
+      return nil if normalized.empty?
+
+      normalized
     end
   end
 end

--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["README.md"]
   s.required_ruby_version = '>= 3.0'
   s.add_dependency 'base64'
+  s.add_dependency 'faraday', '~> 2.0'
   s.add_dependency 'json'
   s.add_dependency 'logging'
   s.add_dependency 'ostruct'

--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 3.0'
   s.add_dependency 'base64'
   s.add_dependency 'faraday', '~> 2.0'
+  s.add_dependency 'faraday-net_http_persistent', '~> 2.0'
   s.add_dependency 'json'
   s.add_dependency 'logging'
   s.add_dependency 'ostruct'

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'faraday'
 require 'uri'
 require 'net/http'
 require 'mocha'
@@ -11,6 +12,14 @@ class RequestTest < Test::Unit::TestCase
   def setup
     @foreman_url = 'https://foreman.example.com'
     Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+    Proxy::SETTINGS.stubs(:foreman_request_timeout).returns(nil)
+    Proxy::SETTINGS.stubs(:foreman_open_timeout).returns(nil)
+    Proxy::SETTINGS.stubs(:foreman_ssl_ca).returns(nil)
+    Proxy::SETTINGS.stubs(:ssl_ca_file).returns(nil)
+    Proxy::SETTINGS.stubs(:foreman_ssl_cert).returns(nil)
+    Proxy::SETTINGS.stubs(:ssl_certificate).returns(nil)
+    Proxy::SETTINGS.stubs(:foreman_ssl_key).returns(nil)
+    Proxy::SETTINGS.stubs(:ssl_private_key).returns(nil)
     @template_url = 'http://proxy.lan:8443'
     Proxy::Templates::Plugin.load_test_settings(:template_url => @template_url)
     @request = Proxy::HttpRequest::ForemanRequest.new
@@ -52,6 +61,43 @@ class RequestTest < Test::Unit::TestCase
     proxy_req = @request.request_factory.create_post("/path", "body")
     result = @request.send_request(proxy_req)
     assert_equal("body", result.body)
+  end
+
+  def test_read_timeout_applied_when_foreman_request_timeout_configured
+    Proxy::SETTINGS.stubs(:foreman_request_timeout).returns(120)
+    request = Proxy::HttpRequest::ForemanRequest.new
+
+    assert_equal 120, request.http.read_timeout
+    assert_equal 120, request.connection.options.timeout
+  end
+
+  def test_read_timeout_uses_default_when_foreman_request_timeout_not_configured
+    default_timeout = Net::HTTP.new('example.com').read_timeout
+    request = Proxy::HttpRequest::ForemanRequest.new
+
+    assert_equal default_timeout, request.http.read_timeout
+  end
+
+  def test_open_timeout_applied_when_foreman_open_timeout_configured
+    Proxy::SETTINGS.stubs(:foreman_open_timeout).returns(30)
+    request = Proxy::HttpRequest::ForemanRequest.new
+
+    assert_equal 30, request.http.open_timeout
+    assert_equal 30, request.connection.options.open_timeout
+  end
+
+  def test_open_timeout_uses_net_http_default_when_foreman_open_timeout_not_configured
+    default_timeout = Net::HTTP.new('example.com').open_timeout
+    request = Proxy::HttpRequest::ForemanRequest.new
+
+    assert_equal default_timeout, request.http.open_timeout
+    assert_equal default_timeout, request.connection.options.open_timeout
+  end
+
+  def test_connection_uses_faraday
+    request = Proxy::HttpRequest::ForemanRequest.new
+
+    assert_kind_of Faraday::Connection, request.connection
   end
 
   def test_post_with_nested_params

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -4,6 +4,8 @@ require 'uri'
 require 'net/http'
 require 'mocha'
 require 'templates/templates_plugin'
+require 'templates/proxy_request'
+require 'registration/proxy_request'
 require "proxy/util"
 require 'proxy/request'
 require 'webmock/test_unit'
@@ -20,6 +22,7 @@ class RequestTest < Test::Unit::TestCase
     Proxy::SETTINGS.stubs(:ssl_certificate).returns(nil)
     Proxy::SETTINGS.stubs(:foreman_ssl_key).returns(nil)
     Proxy::SETTINGS.stubs(:ssl_private_key).returns(nil)
+    Proxy::HttpRequest::ForemanRequest.reset_connection_cache!
     @template_url = 'http://proxy.lan:8443'
     Proxy::Templates::Plugin.load_test_settings(:template_url => @template_url)
     @request = Proxy::HttpRequest::ForemanRequest.new
@@ -98,6 +101,45 @@ class RequestTest < Test::Unit::TestCase
     request = Proxy::HttpRequest::ForemanRequest.new
 
     assert_kind_of Faraday::Connection, request.connection
+  end
+
+  def test_connection_is_shared_across_request_instances
+    request_a = Proxy::HttpRequest::ForemanRequest.new
+    request_b = Proxy::HttpRequest::ForemanRequest.new
+
+    assert_same request_a.connection, request_b.connection
+    assert_kind_of Faraday::Connection, request_a.connection
+  end
+
+  def test_connection_is_shared_across_foreman_request_subclasses
+    registration_request = Proxy::Registration::ProxyRequest.new
+    template_request = Proxy::Templates::ProxyRequest.new
+
+    assert_same registration_request.connection, template_request.connection
+  end
+
+  def test_reset_connection_cache_clears_shared_transport
+    request = Proxy::HttpRequest::ForemanRequest.new
+    cached_connection = request.connection
+
+    Proxy::HttpRequest::ForemanRequest.reset_connection_cache!
+
+    assert_not_same cached_connection, request.connection
+  end
+
+  def test_transport_retries_once_after_ssl_failure
+    uri = URI.parse(@foreman_url)
+    proxy_req = Proxy::HttpRequest::Request.new(http_method: :get, path: '/path', body: nil, headers: {})
+    connection = mock('connection')
+    sequence = sequence('ssl-retry')
+    connection.expects(:run_request).in_sequence(sequence).raises(Faraday::SSLError.new('ssl handshake failed'))
+    connection.expects(:run_request).in_sequence(sequence).returns(
+      stub(status: 200, body: 'body', headers: {})
+    )
+    Proxy::HttpRequest::ForemanTransport.stubs(:connection_for).with(uri).returns(connection)
+
+    response = Proxy::HttpRequest::ForemanTransport.run_request(uri, proxy_req)
+    assert_equal 200, response.status
   end
 
   def test_post_with_nested_params

--- a/test/templates/template_proxy_request_test.rb
+++ b/test/templates/template_proxy_request_test.rb
@@ -10,6 +10,15 @@ class TemplateProxyRequestTest < Test::Unit::TestCase
   def setup
     @foreman_url = 'https://foreman.example.com'
     Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+    Proxy::SETTINGS.stubs(:foreman_request_timeout).returns(nil)
+    Proxy::SETTINGS.stubs(:foreman_open_timeout).returns(nil)
+    Proxy::SETTINGS.stubs(:foreman_ssl_ca).returns(nil)
+    Proxy::SETTINGS.stubs(:ssl_ca_file).returns(nil)
+    Proxy::SETTINGS.stubs(:foreman_ssl_cert).returns(nil)
+    Proxy::SETTINGS.stubs(:ssl_certificate).returns(nil)
+    Proxy::SETTINGS.stubs(:foreman_ssl_key).returns(nil)
+    Proxy::SETTINGS.stubs(:ssl_private_key).returns(nil)
+    Proxy::HttpRequest::ForemanRequest.reset_connection_cache!
     @template_url = 'http://proxy.lan:8443'
     Proxy::Templates::Plugin.settings.stubs(:template_url).returns(@template_url)
     @request_env = {
@@ -50,10 +59,8 @@ class TemplateProxyRequestTest < Test::Unit::TestCase
       with(
         body: "my template",
         headers: {
-          'Accept'          => ['*/*', 'application/json,version=2'],
-          'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Accept'          => 'application/json,version=2',
           'Content-Type'    => 'application/json',
-          'User-Agent'      => 'Ruby',
           'X-Forwarded-For' => '1.2.3.4',
         }).
       to_return(status: 200, body: "", headers: {})


### PR DESCRIPTION
## Summary
- replace the per-request outbound Foreman client path with a shared Faraday transport using faraday-net_http_persistent
- reuse persistent upstream connections on the smart-proxy to Foreman or Satellite leg while keeping the existing request-building API stable
- add layered connect and read timeout support plus a cleaner seam for future TLS and PQC transport changes

## Test plan
- [x] Run ruby -c lib/proxy/foreman_transport.rb
- [x] Run ruby -c lib/proxy/request.rb
- [x] Run ruby -c test/request_test.rb
- [x] Run RuboCop on changed files with Ruby 3.2
- [ ] Run focused request tests in a full project Ruby and Bundler environment
- [ ] Run broader smart-proxy test coverage in CI