### PR TITLE
Fixes #39368 Fix race during concurrent autosign requests

### DIFF
--- a/modules/puppetca_token_whitelisting/puppetca_token_whitelisting_autosigner.rb
+++ b/modules/puppetca_token_whitelisting/puppetca_token_whitelisting_autosigner.rb
@@ -106,12 +106,12 @@ module ::Proxy::PuppetCa::TokenWhitelisting
         logger.warn "Failed to decode token."
         return false
       end
-      # token in our list?
-      unless storage.read.include? token
+
+      # token in our list? Remove it atomically so it can only be used once.
+      unless storage.remove token
         logger.warn "Certname not valid."
         return false
       end
-      storage.remove token
       true
     end
   end

--- a/modules/puppetca_token_whitelisting/puppetca_token_whitelisting_token_storage.rb
+++ b/modules/puppetca_token_whitelisting/puppetca_token_whitelisting_token_storage.rb
@@ -8,47 +8,76 @@ module ::Proxy::PuppetCa::TokenWhitelisting
       ensure_file
     end
 
-    def ensure_file
-      return if File.exist?(@tokens_file)
-      FileUtils.mkdir_p File.dirname(@tokens_file)
-      FileUtils.touch @tokens_file
-      write []
-    end
-
     def read
-      YAML.safe_load File.read @tokens_file
-    end
-
-    def write(content)
-      lock do
-        unsafe_write content
+      lock File::LOCK_SH do |file|
+        unsafe_read file
       end
     end
 
-    def unsafe_write(content)
-      File.write @tokens_file, content.to_yaml
-    end
-
-    def lock(&block)
-      File.open(@tokens_file, "r+") do |f|
-        f.flock File::LOCK_EX
-        yield
-      ensure
-        f.flock File::LOCK_UN
+    def write(content)
+      lock do |file|
+        unsafe_write file, content
       end
     end
 
     def add(entry)
-      write read.push entry
+      lock do |file|
+        content = unsafe_read file
+        content << entry
+        unsafe_write file, content
+      end
     end
 
     def remove(entry)
-      write read.delete_if { |data| data == entry }
+      remove_if { |data| data == entry }
     end
 
-    def remove_if(&block)
-      lock do
-        unsafe_write read.delete_if { |token| yield(token) }
+    def remove_if
+      raise ArgumentError, 'TokenStorage#remove_if requires a block' unless block_given?
+
+      lock do |file|
+        content = unsafe_read file
+
+        if content.reject! { |token| yield(token) }
+          unsafe_write file, content
+          true
+        else
+          false
+        end
+      end
+    end
+
+    private
+
+    def ensure_file
+      FileUtils.mkdir_p File.dirname(@tokens_file)
+
+      lock do |file|
+        unsafe_write file, [] if file.size.zero? # rubocop:disable Style/ZeroLengthPredicate
+      end
+    end
+
+    # These helpers must only be called with a locked file handle from #lock.
+    def unsafe_read(file)
+      file.rewind
+      YAML.safe_load(file.read, fallback: [])
+    end
+
+    def unsafe_write(file, content)
+      file.rewind
+      file.truncate 0
+      file.write content.to_yaml
+      file.flush
+    end
+
+    def lock(locking_constant = File::LOCK_EX)
+      raise ArgumentError, 'TokenStorage#lock requires a block' unless block_given?
+
+      File.open(@tokens_file, File::RDWR | File::CREAT, 0o644) do |file|
+        file.flock locking_constant
+        yield file
+      ensure
+        file&.flock File::LOCK_UN
       end
     end
   end

--- a/test/puppetca_token_whitelisting/puppetca_token_whitelisting_token_storage_test.rb
+++ b/test/puppetca_token_whitelisting/puppetca_token_whitelisting_token_storage_test.rb
@@ -45,7 +45,7 @@ class PuppetCaTokenWhitelistingTokenStorageTest < Test::Unit::TestCase
   end
 
   def test_should_queue_writes_when_locked
-    @storage.lock do
+    @storage.send(:lock) do
       assert_raise Timeout::Error do
         Timeout.timeout(3) do
           @storage.write ['test']
@@ -59,5 +59,46 @@ class PuppetCaTokenWhitelistingTokenStorageTest < Test::Unit::TestCase
       token.start_with? 'foo'
     end
     assert_equal ['test.bar.example.com'], @storage.read
+  end
+
+  def test_should_initialize_existing_empty_file
+    file = Tempfile.new('autosign_empty_test')
+    storage = Proxy::PuppetCa::TokenWhitelisting::TokenStorage.new file.path
+
+    assert_equal [], storage.read
+    storage.add 'foo.example.com'
+    assert_equal ['foo.example.com'], storage.read
+  ensure
+    file.close
+    file.unlink
+  end
+
+  def test_remove_returns_whether_entry_was_removed
+    assert_true @storage.remove 'foo.example.com'
+    assert_false @storage.remove 'does-not-exist.example.com'
+  end
+
+  def test_should_not_lose_concurrent_adds
+    @storage.write []
+
+    entries = Array.new(50) { |i| "host#{i}.example.com" }
+    threads = entries.map do |entry|
+      Thread.new { @storage.add entry }
+    end
+    threads.each(&:join)
+
+    assert_equal entries.sort, @storage.read.sort
+  end
+
+  def test_concurrent_remove_only_succeeds_once
+    @storage.write ['foo.example.com']
+
+    results = Array.new(50) do
+      Thread.new { @storage.remove 'foo.example.com' }
+    end.map(&:value)
+
+    assert_equal 1, results.count(true)
+    assert_equal 49, results.count(false)
+    assert_equal [], @storage.read
   end
 end


### PR DESCRIPTION
Concurrent autosign requests could race while updating the token whitelist.  Although writes were locked, the read and modification happened before the write lock was taken, so one request could observe an empty file or overwrite another request's update.