### PR TITLE
Use smart-proxy mTLS auth for container registry

### DIFF
--- a/lib/proxy/container_registry/podman_auth.rb
+++ b/lib/proxy/container_registry/podman_auth.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'shellwords'
+require 'tmpdir'
+
+module Proxy
+  module ContainerRegistry
+    # Provides mTLS certificate setup for authenticating podman CLI commands
+    # against a Katello container registry using the smart-proxy's existing
+    # foreman SSL client certificate (foreman_ssl_cert / foreman_ssl_key).
+    #
+    # Usage in an async runner (initialize_command pattern):
+    #
+    #   def start
+    #     @cert_dir = Proxy::ContainerRegistry::PodmanAuth.setup_cert_dir
+    #     cmd = "podman push #{Proxy::ContainerRegistry::PodmanAuth.tls_args(@cert_dir)} ..."
+    #     initialize_command('bash', '-c', cmd)
+    #   end
+    #
+    #   def close
+    #     Proxy::ContainerRegistry::PodmanAuth.cleanup(@cert_dir)
+    #   end
+    module PodmanAuth
+      # Creates a temporary directory with symlinks named as podman expects
+      # (client.cert, client.key, ca.crt) pointing at the smart-proxy's
+      # existing SSL certificate files. Symlinks are used rather than copies
+      # to avoid duplicating the private key on disk.
+      # Call cleanup when done.
+      def self.setup_cert_dir
+        cert_file = Proxy::SETTINGS.foreman_ssl_cert || Proxy::SETTINGS.ssl_certificate
+        key_file  = Proxy::SETTINGS.foreman_ssl_key  || Proxy::SETTINGS.ssl_private_key
+        ca_file   = Proxy::SETTINGS.foreman_ssl_ca   || Proxy::SETTINGS.ssl_ca_file
+
+        dir = Dir.mktmpdir('podman_registry_cert')
+        File.symlink(cert_file, File.join(dir, 'client.cert')) if cert_file.to_s != ''
+        File.symlink(key_file,  File.join(dir, 'client.key'))  if key_file.to_s != ''
+        File.symlink(ca_file,   File.join(dir, 'ca.crt'))      if ca_file.to_s != ''
+        dir
+      end
+
+      # Removes the temporary cert directory created by setup_cert_dir.
+      def self.cleanup(cert_dir)
+        FileUtils.rm_rf(cert_dir) if cert_dir
+      end
+
+      # Returns the podman TLS arguments string for use in shell commands.
+      def self.tls_args(cert_dir)
+        "--tls-verify=true --cert-dir #{Shellwords.escape(cert_dir)}"
+      end
+    end
+  end
+end

--- a/test/container_registry/podman_auth_test.rb
+++ b/test/container_registry/podman_auth_test.rb
@@ -1,0 +1,95 @@
+require 'test_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'proxy/container_registry/podman_auth'
+
+class PodmanAuthTest < Test::Unit::TestCase
+  def setup
+    @tmpdir = Dir.mktmpdir
+
+    @cert_file = File.join(@tmpdir, 'client.crt')
+    @key_file  = File.join(@tmpdir, 'client.key')
+    @ca_file   = File.join(@tmpdir, 'ca.crt')
+
+    File.write(@cert_file, 'CERT')
+    File.write(@key_file,  'KEY')
+    File.write(@ca_file,   'CA')
+
+    Proxy::SETTINGS.stubs(:foreman_ssl_cert).returns(@cert_file)
+    Proxy::SETTINGS.stubs(:foreman_ssl_key).returns(@key_file)
+    Proxy::SETTINGS.stubs(:foreman_ssl_ca).returns(@ca_file)
+    Proxy::SETTINGS.stubs(:ssl_certificate).returns(nil)
+    Proxy::SETTINGS.stubs(:ssl_private_key).returns(nil)
+    Proxy::SETTINGS.stubs(:ssl_ca_file).returns(nil)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_setup_cert_dir_creates_temp_dir
+    dir = Proxy::ContainerRegistry::PodmanAuth.setup_cert_dir
+    assert Dir.exist?(dir)
+  ensure
+    Proxy::ContainerRegistry::PodmanAuth.cleanup(dir)
+  end
+
+  def test_setup_cert_dir_symlinks_cert_files
+    dir = Proxy::ContainerRegistry::PodmanAuth.setup_cert_dir
+    assert File.symlink?(File.join(dir, 'client.cert'))
+    assert File.symlink?(File.join(dir, 'client.key'))
+    assert File.symlink?(File.join(dir, 'ca.crt'))
+    assert_equal 'CERT', File.read(File.join(dir, 'client.cert'))
+    assert_equal 'KEY',  File.read(File.join(dir, 'client.key'))
+    assert_equal 'CA',   File.read(File.join(dir, 'ca.crt'))
+  ensure
+    Proxy::ContainerRegistry::PodmanAuth.cleanup(dir)
+  end
+
+  def test_setup_cert_dir_falls_back_to_ssl_settings
+    Proxy::SETTINGS.stubs(:foreman_ssl_cert).returns(nil)
+    Proxy::SETTINGS.stubs(:foreman_ssl_key).returns(nil)
+    Proxy::SETTINGS.stubs(:foreman_ssl_ca).returns(nil)
+    Proxy::SETTINGS.stubs(:ssl_certificate).returns(@cert_file)
+    Proxy::SETTINGS.stubs(:ssl_private_key).returns(@key_file)
+    Proxy::SETTINGS.stubs(:ssl_ca_file).returns(@ca_file)
+
+    dir = Proxy::ContainerRegistry::PodmanAuth.setup_cert_dir
+    assert_equal 'CERT', File.read(File.join(dir, 'client.cert'))
+    assert_equal 'KEY',  File.read(File.join(dir, 'client.key'))
+  ensure
+    Proxy::ContainerRegistry::PodmanAuth.cleanup(dir)
+  end
+
+  def test_setup_cert_dir_skips_missing_ca
+    Proxy::SETTINGS.stubs(:foreman_ssl_ca).returns(nil)
+    Proxy::SETTINGS.stubs(:ssl_ca_file).returns(nil)
+
+    dir = Proxy::ContainerRegistry::PodmanAuth.setup_cert_dir
+    refute File.exist?(File.join(dir, 'ca.crt'))
+  ensure
+    Proxy::ContainerRegistry::PodmanAuth.cleanup(dir)
+  end
+
+  def test_cleanup_removes_cert_dir
+    dir = Proxy::ContainerRegistry::PodmanAuth.setup_cert_dir
+    Proxy::ContainerRegistry::PodmanAuth.cleanup(dir)
+    refute Dir.exist?(dir)
+  end
+
+  def test_cleanup_ignores_nil
+    assert_nothing_raised { Proxy::ContainerRegistry::PodmanAuth.cleanup(nil) }
+  end
+
+  def test_tls_args_includes_cert_dir
+    args = Proxy::ContainerRegistry::PodmanAuth.tls_args('/some/path')
+    assert_match %r{--tls-verify=true}, args
+    assert_match %r{--cert-dir /some/path}, args
+  end
+
+  def test_tls_args_escapes_spaces_in_path
+    args = Proxy::ContainerRegistry::PodmanAuth.tls_args('/some/path with spaces')
+    assert_match %r{--cert-dir }, args
+    refute_match %r{--cert-dir /some/path with spaces}, args
+  end
+end


### PR DESCRIPTION
Allow smart-proxies to pull/push container images against Katello's registry using their existing Foreman SSL client certificate. Adds a reusable `Proxy::ContainerRegistry::PodmanAuth` module to smart-proxy for podman cert-dir setup and cleanup.

Katello PR: https://github.com/Katello/katello/pull/11776
Smart Proxy PR: https://github.com/theforeman/smart-proxy/pull/948
Smart Proxy Ansible Director: https://github.com/ATIX-AG/smart_proxy_ansible_director/pull/24

Note: I have created this PRs to discuss how to use the katello container registry with smart-proxies.