### PR TITLE
Fixes #39518 - Fall back safely when tls_ciphers 'PROFILE=SYSTEM' is unsupported

### DIFF
--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -118,13 +118,46 @@ module Proxy
       return nil if configured&.empty?
       return configured unless configured.nil?
 
-      if File.exist?(CRYPTO_POLICIES_CONFIG)
-        logger.info "Crypto-policies detected, using PROFILE=SYSTEM for TLS ciphers."
-        'PROFILE=SYSTEM'
-      else
+      unless File.exist?(CRYPTO_POLICIES_CONFIG)
         logger.debug "No crypto-policies detected, using HIGH cipher string as default."
-        'HIGH'
+        return 'HIGH'
       end
+
+      if cipher_string_supported?('PROFILE=SYSTEM')
+        logger.info "Crypto-policies detected, using PROFILE=SYSTEM for TLS ciphers."
+        return 'PROFILE=SYSTEM'
+      end
+
+      cipher_string = crypto_policies_cipher_string
+      if cipher_string && cipher_string_supported?(cipher_string)
+        logger.info "Crypto-policies detected, but this OpenSSL build does not support the " \
+                    "'PROFILE=SYSTEM' cipher-list alias. Using the CipherString resolved from " \
+                    "#{CRYPTO_POLICIES_CONFIG} directly instead."
+        return cipher_string
+      end
+
+      logger.warn "Crypto-policies detected but could not be applied on this Ruby/OpenSSL build; " \
+                  "falling back to the 'HIGH' cipher string."
+      'HIGH'
+    end
+
+    # Extracted so resolve_tls_ciphers can probe candidate cipher strings before
+    # committing to them, instead of only discovering they're unusable at startup.
+    def cipher_string_supported?(ciphers)
+      OpenSSL::SSL::SSLContext.new.ciphers = ciphers
+      true
+    rescue OpenSSL::SSL::SSLError
+      false
+    end
+
+    def crypto_policies_cipher_string
+      File.foreach(CRYPTO_POLICIES_CONFIG) do |line|
+        return Regexp.last_match(1).strip if line =~ /^CipherString\s*=\s*(.+)$/
+      end
+      nil
+    rescue SystemCallError => e
+      logger.warn "Unable to read #{CRYPTO_POLICIES_CONFIG}: #{e.message}"
+      nil
     end
 
     def validate_tls_ciphers!(ciphers)
@@ -135,12 +168,7 @@ module Proxy
                     "The system crypto policy minimum TLS version may be overridden by this setting."
       end
 
-      cipher_list = begin
-        OpenSSL::SSL::SSLContext.new.ciphers = ciphers
-        ciphers
-      rescue OpenSSL::SSL::SSLError
-        nil
-      end
+      cipher_list = cipher_string_supported?(ciphers) ? ciphers : nil
 
       if OpenSSL::SSL::SSLContext.method_defined?(:ciphersuites=)
         ciphersuites = begin

--- a/test/launcher_test.rb
+++ b/test/launcher_test.rb
@@ -53,6 +53,7 @@ class LauncherTlsCiphersTest < Test::Unit::TestCase
   def test_resolve_tls_ciphers_autodetects_profile_system_when_crypto_policies_present
     launcher = launcher_with({})
     File.expects(:exist?).with(CRYPTO_POLICIES_CONFIG).returns(true)
+    launcher.stubs(:cipher_string_supported?).with('PROFILE=SYSTEM').returns(true)
     launcher.logger.stubs(:info)
     assert_equal 'PROFILE=SYSTEM', launcher.resolve_tls_ciphers
   end
@@ -61,6 +62,35 @@ class LauncherTlsCiphersTest < Test::Unit::TestCase
     launcher = launcher_with({})
     File.expects(:exist?).with(CRYPTO_POLICIES_CONFIG).returns(false)
     launcher.logger.stubs(:debug)
+    assert_equal 'HIGH', launcher.resolve_tls_ciphers
+  end
+
+  def test_resolve_tls_ciphers_falls_back_to_parsed_cipher_string_when_profile_system_unsupported
+    launcher = launcher_with({})
+    File.expects(:exist?).with(CRYPTO_POLICIES_CONFIG).returns(true)
+    launcher.stubs(:cipher_string_supported?).with('PROFILE=SYSTEM').returns(false)
+    launcher.stubs(:crypto_policies_cipher_string).returns('HIGH:!aNULL')
+    launcher.stubs(:cipher_string_supported?).with('HIGH:!aNULL').returns(true)
+    launcher.logger.stubs(:info)
+    assert_equal 'HIGH:!aNULL', launcher.resolve_tls_ciphers
+  end
+
+  def test_resolve_tls_ciphers_falls_back_to_high_when_crypto_policies_unparseable
+    launcher = launcher_with({})
+    File.expects(:exist?).with(CRYPTO_POLICIES_CONFIG).returns(true)
+    launcher.stubs(:cipher_string_supported?).with('PROFILE=SYSTEM').returns(false)
+    launcher.stubs(:crypto_policies_cipher_string).returns(nil)
+    launcher.logger.stubs(:warn)
+    assert_equal 'HIGH', launcher.resolve_tls_ciphers
+  end
+
+  def test_resolve_tls_ciphers_falls_back_to_high_when_parsed_cipher_string_also_unsupported
+    launcher = launcher_with({})
+    File.expects(:exist?).with(CRYPTO_POLICIES_CONFIG).returns(true)
+    launcher.stubs(:cipher_string_supported?).with('PROFILE=SYSTEM').returns(false)
+    launcher.stubs(:crypto_policies_cipher_string).returns('BOGUS')
+    launcher.stubs(:cipher_string_supported?).with('BOGUS').returns(false)
+    launcher.logger.stubs(:warn)
     assert_equal 'HIGH', launcher.resolve_tls_ciphers
   end
 


### PR DESCRIPTION
## Problem

`resolve_tls_ciphers` (added in #947 / #39405) defaults `tls_ciphers` to the literal string `'PROFILE=SYSTEM'` whenever `/etc/crypto-policies/back-ends/opensslcnf.config` exists, on the assumption that presence of that file means the currently-linked OpenSSL understands `PROFILE=SYSTEM` (a Red Hat/Fedora-only OpenSSL patch keyword).

This breaks on a nominally-RHEL host whose Ruby is linked against a vendored, non-RHEL-patched OpenSSL. Concretely: `smart-proxy-develop-source-release`'s `ruby=3.0.4` CI leg runs on RHEL/CentOS Stream 9 (crypto-policies present, correctly detected), but `rbenv`/`ruby-build` vendors a plain `openssl-1.1.1w` built from `openssl.org` source for that specific Ruby version (its `needs_openssl` gate requires `1.0.1-1.x.x`; CentOS9's system OpenSSL 3.5.x falls outside that range). That vendored OpenSSL rejects `'PROFILE=SYSTEM'` outright:

```
Invalid tls_ciphers value 'PROFILE=SYSTEM': SSL_CTX_set_cipher_list: no cipher match (RuntimeError)
```

...and the proxy never starts. Reproduced this exact failure directly by compiling `openssl-1.1.1w` from source in a real `centos:stream9` container and confirming the byte-identical error. Full root-cause writeup: https://projects.theforeman.org/issues/39518

## Fix

`opensslcnf.config` isn't just a "RHEL detected" signal file — it contains the actual resolved cipher spec in plain, portable OpenSSL syntax (`CipherString = @SECLEVEL=2:kEECDH:...`), independent of the `PROFILE=` keyword. `resolve_tls_ciphers` now:

1. Probes `'PROFILE=SYSTEM'` before committing to it (via a live `OpenSSL::SSL::SSLContext#ciphers=` check).
2. If unsupported, parses and uses the `CipherString` from `opensslcnf.config` directly — same security intent as the active crypto policy, but works on any OpenSSL build.
3. Falls back to `'HIGH'` only if that also fails, so the auto-detected default can never crash startup.

`validate_tls_ciphers!` is refactored to share the same probe helper (`cipher_string_supported?`) — pure dedup, no behavior change for explicitly-configured `tls_ciphers` values.

## Testing

- `bundle exec rake test TEST=test/launcher_test.rb` — 25/25 pass, including 3 new tests covering the fallback chain.
- Full suite (`bundle exec rake test`, excluding `bmc`/`libvirt` modules which need unrelated native system libs) — 872/872 pass.
- Verified live end-to-end on a machine where `PROFILE=SYSTEM` is also rejected by the local OpenSSL build: `resolve_tls_ciphers` correctly falls through to the parsed `CipherString` instead of returning an unusable value.
- Reproduced the original failure and the fix directly on real CentOS Stream 9 via podman (see issue #39518 for full transcript).

Marked as draft pending maintainer input — opening for early visibility/feedback.