### PR TITLE
Refs #39518 - Pin tls_ciphers to OpenSSL defaults in HTTPS integration tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -40,7 +40,11 @@ module Proxy::IntegrationTestCase
 
   def launch(protocol: 'https', plugins: [], settings: {})
     port = 0
-    @settings = Proxy::Settings::Global.new(settings.merge("#{protocol}_port" => port))
+    # Pin tls_ciphers to OpenSSL defaults unless a test overrides it, so HTTPS
+    # integration tests don't depend on the host's crypto-policies/OpenSSL
+    # combination (tests shouldn't rely on where they happen to run).
+    default_settings = (protocol == 'https') ? { tls_ciphers: '' } : {}
+    @settings = Proxy::Settings::Global.new(default_settings.merge(settings).merge("#{protocol}_port" => port))
     @t = Thread.new do
       launcher = Proxy::Launcher.new(@settings)
       app = launcher.public_send("#{protocol}_app", port, plugins)


### PR DESCRIPTION
## Problem

`smart-proxy-develop-source-release`'s `ruby=3.0.4` CI leg fails `SSLClientVerificationIntegrationTest` because it launches a real WEBrick HTTPS server without setting `tls_ciphers`, so it falls through to `launcher.rb`'s crypto-policies auto-detection and inherits whatever the host's OpenSSL build happens to support. On that leg, `rbenv`/`ruby-build` vendors a plain `openssl-1.1.1w` that doesn't understand the `'PROFILE=SYSTEM'` cipher-list alias, even though the host's crypto-policies files are genuinely present — so the test fails with a `RuntimeError` before ever reaching the SSL client verification behavior it's actually meant to check. Root cause: https://projects.theforeman.org/issues/39518

## Fix

Pin `tls_ciphers` to `''` (OpenSSL defaults, no cipher restriction) by default for HTTPS integration tests in `test_helper.rb`'s shared `launch` method — one place, so any current or future HTTPS integration test gets this automatically, not just this one file. A test can still override `tls_ciphers` explicitly via its own `settings:` hash if it wants to exercise a specific cipher value.

Auto-detection of `tls_ciphers` itself is already covered deterministically by the mocked unit tests in `test/launcher_test.rb` (`File.exist?`/OpenSSL probes are stubbed there) — this integration test only needs a working TLS handshake to check client-cert verification, not any particular cipher policy, so it shouldn't be coupled to the host's crypto-policies/OpenSSL combination at all.

This is a CI-only workaround to unblock the pipeline. It does not touch production code or `resolve_tls_ciphers`'s behavior — see #39518 / a follow-up PR for the underlying robustness fix in `launcher.rb` itself.

## Testing

- Verified against the **unpatched** `develop` `launcher.rb` (i.e. without any other fix applied): `SSLClientVerificationIntegrationTest` goes from 6 errors → 4/4 passing.
- Full suite (`bundle exec rake test`, excluding `bmc`/`libvirt` which need unrelated native system libs): 869/869 pass.