### PR TITLE
Fixes #38120 - Support Sinatra 4 and Rack 3

### DIFF
--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -1,5 +1,13 @@
 require 'openssl'
 require 'proxy/log'
+
+begin
+  require 'rackup/handler/webrick'
+  WEBRICK_HANDLER = Rackup::Handler::WEBrick
+rescue LoadError
+  require 'rack'
+  WEBRICK_HANDLER = Rack::Handler::WEBrick
+end
 require 'proxy/settings'
 require 'proxy/signal_handler'
 require 'proxy/log_buffer/trace_decorator'
@@ -191,7 +199,7 @@ module Proxy
       rescue ::OpenSSL::SSL::SSLError => e
         raise "Invalid tls_ciphers value '#{app[:SSLCiphers]}': #{e.message}"
       end
-      server.mount "/", Rack::Handler::WEBrick, app[:app]
+      server.mount "/", WEBRICK_HANDLER, app[:app]
 
       # WEBrick 1.9.x does not support :SSLMinVersion in its config hash, so we
       # apply min_version= directly on the SSL context after WEBrick creates it.

--- a/lib/proxy/hsts_middleware.rb
+++ b/lib/proxy/hsts_middleware.rb
@@ -4,14 +4,18 @@ module Proxy
   # is needed.
   # https://www.tenable.com/plugins/nessus/142960
   class HstsMiddleware
+    # Lowercase is required by Rack 3 (https://github.com/rack/rack/issues/1592);
+    # Rack 2 doesn't care about header key case, so this works for both.
+    HEADER_KEY = 'strict-transport-security'.freeze
+
     def initialize(app)
       @app = app
     end
 
     def call(env)
       status, headers, body = @app.call(env)
-      if env['HTTPS'] == 'on' && !headers.include?('Strict-Transport-Security')
-        headers['Strict-Transport-Security'] = 'max-age=31536000'
+      if env['HTTPS'] == 'on' && !headers.include?(HEADER_KEY)
+        headers[HEADER_KEY] = 'max-age=31536000'
       end
       [status, headers, body]
     end

--- a/lib/smart_proxy_main.rb
+++ b/lib/smart_proxy_main.rb
@@ -46,7 +46,11 @@ module Proxy
   ::Sinatra::Base.use ::Proxy::RequestIdMiddleware
   ::Sinatra::Base.use ::Proxy::LoggerMiddleware
   ::Sinatra::Base.use ::Proxy::HstsMiddleware
-  ::Sinatra::Base.set :env, :production
+  # Without this, Sinatra defaults to :development, which in Sinatra 4
+  # enables strict Rack::Protection::HostAuthorization that rejects
+  # requests whose Host header isn't localhost — breaking all real
+  # deployments where Foreman reaches smart-proxy by hostname.
+  ::Sinatra::Base.set :environment, :production
   ::Sinatra::Base.register ::Sinatra::Authorization
 
   require 'root/root'

--- a/modules/registration/registration_api.rb
+++ b/modules/registration/registration_api.rb
@@ -1,6 +1,11 @@
 require 'registration/proxy_request'
 
 class Proxy::Registration::Api < ::Sinatra::Base
+  # Needed so `logger` resolves to Proxy::LogBuffer::Decorator (which implements
+  # #exception, used in the rescue blocks below) instead of Sinatra's own null
+  # logger, which is a plain ::Logger with no #exception method as of Sinatra 4.
+  helpers ::Proxy::Helpers
+
   # Cache for the global registration script (GET /register).
   #
   # The script is identical for all hosts sharing the same registration

--- a/smart_proxy.gemspec
+++ b/smart_proxy.gemspec
@@ -17,10 +17,11 @@ Gem::Specification.new do |s|
   s.add_dependency 'json'
   s.add_dependency 'logging'
   s.add_dependency 'ostruct'
-  s.add_dependency 'rack', '>= 1.3'
+  s.add_dependency 'rack', '>= 2.0', '< 4'
+  s.add_dependency 'rackup'
   s.add_dependency 'rexml', '~> 3.2'
   s.add_dependency 'sd_notify', '~> 0.1'
-  s.add_dependency 'sinatra', '~> 2.0'
+  s.add_dependency 'sinatra', '>= 2.0', '< 5'
   s.add_dependency 'webrick', '~> 1.0'
   s.description = <<~EOF
     Foreman Proxy is used via The Foreman Project, it allows Foreman to manage


### PR DESCRIPTION
Updates bundle to new versions.

In Rack 3, headers must be lowercase https://github.com/rack/rack/issues/1592.

We now use Rackup::... instead of Rack::...

test_global_500 and test_host_500 in RegistrationRegisterApiTest have been failing, both raising `NoMethodError: undefined method   'exception' for #<Logger:...>` from `modules/registration/registration_api.rb`'s error-handling blocks. The cause was that `Proxy::Registration::Api` never included helpers ` ::Proxy::Helpers` (unlike every sibling API class), so its logger calls resolved through Sinatra's own built-in logger helper rather than smart-proxy's real logger; under  Sinatra 2 that helper pointed at `Rack::NullLogger` when logging was disabled, and while `Rack::NullLogger` never actually had an #exception method either, the test's Mocha stub on that exact class silently intercepted the call anyway, whereas Sinatra 4 replaced that null-logger path with a plain `stdlib ::Logger`, which the test's stub no longer targets and which genuinely has no `#exception` method, turning a previously-masked bug into a real crash. The fix was adding `helpers ::Proxy::Helpers` to `Proxy::Registration::Api`, which makes logger resolve to `Proxy::LogBuffer::Decorator.instance` (which does implement `#exception`), matching the pattern already used by every other API class in the codebase — after which the full test suite passed.