### PR TITLE
Fixes #39248 - Migrate tests to Minitest

### DIFF
--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -1,17 +1,17 @@
 group :test do
   gem 'benchmark-ips'
-  gem 'ci_reporter', '>= 1.6.3', "< 2.0.0", :require => false
 
   # Technically this is a hard dependency of the facts module but that's only
   # used in discovery. This at least allows us to run the tests on it
   gem 'facter', :require => false
-  gem 'mocha', '~> 1.10', :require => false
+  gem 'minitest'
+  gem 'minitest-reporters', :require => false
+  gem 'mocha', '~> 3.1.0', :require => false
   gem 'rack-test'
   gem 'rake'
   gem 'rubocop', '~> 1.56.0'
   gem 'rubocop-performance', '~> 1.5.2'
   gem 'rubocop-rake'
   gem 'ruby-prof', '< 1.4'
-  gem 'test-unit'
   gem 'webmock'
 end

--- a/tasks/jenkins.rake
+++ b/tasks/jenkins.rake
@@ -1,5 +1,4 @@
-require "ci/reporter/rake/test_unit"
 namespace :jenkins do
   desc 'Sets up CI environment for testing and run tests'
-  task :unit => ['ci:setup:testunit', 'rake:test']
+  task :unit => :test
 end

--- a/test/bmc/bmc_api_shell_test.rb
+++ b/test/bmc/bmc_api_shell_test.rb
@@ -5,7 +5,7 @@ require 'bmc/shell'
 
 ENV['RACK_ENV'] = 'test'
 
-class BmcApiShellTest < Test::Unit::TestCase
+class BmcApiShellTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/bmc/bmc_api_ssh_test.rb
+++ b/test/bmc/bmc_api_ssh_test.rb
@@ -6,7 +6,7 @@ require 'bmc/bmc_plugin'
 
 ENV['RACK_ENV'] = 'test'
 
-class BmcApiShellTest < Test::Unit::TestCase
+class BmcApiShellTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/bmc/bmc_api_test.rb
+++ b/test/bmc/bmc_api_test.rb
@@ -13,7 +13,7 @@ ENV['RACK_ENV'] = 'test'
 # instead you must testing something like:
 #     put "/#{host}/chassis/power/on", body, "CONTENT_TYPE" => "application/json"
 
-class BmcApiTest < Test::Unit::TestCase
+class BmcApiTest < Minitest::Test
   include Rack::Test::Methods
   include RedfishTestHelper
 
@@ -26,6 +26,7 @@ class BmcApiTest < Test::Unit::TestCase
     pass     ||= ENV["ipmipass"] || "pass"
     @host    ||= ENV["ipmihost"] || "host"
     provider ||= ENV["ipmiprovider"] || "ipmitool"
+    Proxy::BMC::Plugin.load_test_settings(:bmc_default_provider => 'freeipmi')
     @args = { 'bmc_provider' => provider, 'blah' => 'test' }
     authorize user, pass
     mask_redfish_acceess
@@ -114,9 +115,9 @@ class BmcApiTest < Test::Unit::TestCase
     Rubyipmi.stubs(:is_provider_installed?).returns(true)
     Proxy::BMC::Plugin.settings.stubs(:bmc_default_provider).returns('freeipmi')
     Proxy::BMC::IPMI.any_instance.stubs(:poweron).returns(true)
-    Proxy::BMC::IPMI.any_instance.expects(:connect).with(:host => 'host', :username => 'user', :password => 'pass',
-                                                         :bmc_provider => 'ipmitool',
-                                                         :options => {"privilege" => "OPERATOR"})
+    Proxy::BMC::IPMI.any_instance.expects(:connect).with({:host => 'host', :username => 'user', :password => 'pass',
+                                                          :bmc_provider => 'ipmitool',
+                                                          :options => {"privilege" => "OPERATOR"}})
     body = {'bmc_provider' => 'ipmitool', :options => {'privilege' => 'OPERATOR'}}.to_json
     put "/#{host}/chassis/power/on", body, "CONTENT_TYPE" => "application/json"
   end
@@ -125,9 +126,9 @@ class BmcApiTest < Test::Unit::TestCase
     Rubyipmi.stubs(:is_provider_installed?).returns(true)
     Proxy::BMC::Plugin.load_test_settings(:bmc_default_provider => 'freeipmi')
     Proxy::BMC::IPMI.any_instance.stubs(:poweron).returns(true)
-    Proxy::BMC::IPMI.any_instance.expects(:connect).with(:host => 'host', :username => 'user', :password => 'pass',
-                                                         :bmc_provider => 'freeipmi',
-                                                         :options => {"privilege" => "OPERATOR"})
+    Proxy::BMC::IPMI.any_instance.expects(:connect).with({:host => 'host', :username => 'user', :password => 'pass',
+                                                          :bmc_provider => 'freeipmi',
+                                                          :options => {"privilege" => "OPERATOR"}})
     body = {'bmc_provider' => 'freeipmi', :options => {'privilege' => 'OPERATOR'}}.to_json
     put "/#{host}/chassis/power/on", body, "CONTENT_TYPE" => "application/json"
   end
@@ -144,9 +145,9 @@ class BmcApiTest < Test::Unit::TestCase
     Rubyipmi.stubs(:is_provider_installed?).returns(true)
     Proxy::BMC::Plugin.load_test_settings(:bmc_default_provider => 'freeipmi')
     Proxy::BMC::IPMI.any_instance.stubs(:poweron).returns(true)
-    Proxy::BMC::IPMI.any_instance.expects(:connect).with(:host => 'host', :username => 'user', :password => 'pass',
-                                                         :bmc_provider => 'freeipmi',
-                                                         :options => {"driver" => "lan20", "privilege" => "OPERATOR"})
+    Proxy::BMC::IPMI.any_instance.expects(:connect).with({:host => 'host', :username => 'user', :password => 'pass',
+                                                          :bmc_provider => 'freeipmi',
+                                                          :options => {"driver" => "lan20", "privilege" => "OPERATOR"}})
     body = {'bmc_provider' => 'freeipmi', :options => {"driver" => "lan20", 'privilege' => 'OPERATOR'}}.to_json
     put "/#{host}/chassis/power/on", body, "CONTENT_TYPE" => "application/json"
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
@@ -158,9 +159,9 @@ class BmcApiTest < Test::Unit::TestCase
     Rubyipmi.stubs(:is_provider_installed?).returns(true)
     Proxy::BMC::Plugin.load_test_settings(:bmc_default_provider => 'freeipmi')
     Proxy::BMC::IPMI.any_instance.stubs(:poweron).returns(true)
-    Proxy::BMC::IPMI.any_instance.expects(:connect).with(:host => 'host', :username => 'user', :password => 'pass',
-                                                         :bmc_provider => 'freeipmi',
-                                                         :options => nil)
+    Proxy::BMC::IPMI.any_instance.expects(:connect).with({:host => 'host', :username => 'user', :password => 'pass',
+                                                          :bmc_provider => 'freeipmi',
+                                                          :options => nil})
     body = {'bmc_provider' => 'freeipmi', :options => nil}.to_json
     put "/#{host}/chassis/power/on", body, "CONTENT_TYPE" => "application/json"
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
@@ -463,7 +464,7 @@ class BmcApiTest < Test::Unit::TestCase
 
   def test_api_can_set_bmc_action_reset_type_cold
     Rubyipmi.stubs(:is_provider_installed?).returns(true)
-    Proxy::BMC::IPMI.any_instance.expects(:reset).returns(true)
+    Proxy::BMC::IPMI.any_instance.expects(:reset).with('cold').returns(true)
     put "/#{@host}/bmc/reset", :type => "cold"
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
     data = JSON.parse(last_response.body)
@@ -472,7 +473,7 @@ class BmcApiTest < Test::Unit::TestCase
 
   def test_api_can_set_bmc_action_reset_type_warm
     Rubyipmi.stubs(:is_provider_installed?).returns(true)
-    Proxy::BMC::IPMI.any_instance.expects(:reset).returns(true)
+    Proxy::BMC::IPMI.any_instance.expects(:reset).with('warm').returns(true)
     put "/#{@host}/bmc/reset", :type => "warm"
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"
     data = JSON.parse(last_response.body)
@@ -612,9 +613,9 @@ class BmcApiTest < Test::Unit::TestCase
   def test_api_can_pass_options_in_body
     Rubyipmi.stubs(:is_provider_installed?).returns(true)
     args = { 'bmc_provider' => 'freeipmi', :options => {:driver => 'lan20', :privilege => 'USER'} }.to_json
-    Proxy::BMC::IPMI.any_instance.expects(:connect).with(:username => 'user', :password => 'pass',
-                                                         :host => 'host', :bmc_provider => 'freeipmi',
-                                                         :options => {"driver" => "lan20", "privilege" => "USER"})
+    Proxy::BMC::IPMI.any_instance.expects(:connect).with({:username => 'user', :password => 'pass',
+                                                          :host => 'host', :bmc_provider => 'freeipmi',
+                                                          :options => {"driver" => "lan20", "privilege" => "USER"}})
     Proxy::BMC::IPMI.any_instance.stubs(:bootbios).returns(true)
     put "/#{@host}/chassis/config/bootdevice/bios", args, "CONTENT_TYPE" => "application/json"
     assert last_response.ok?, "Last response was not ok: #{last_response.body}"

--- a/test/bmc/bmc_redfish_test.rb
+++ b/test/bmc/bmc_redfish_test.rb
@@ -4,7 +4,7 @@ require 'bmc/redfish'
 require 'bmc/redfish_test_helper'
 require 'json'
 
-class BmcRedfishTest < Test::Unit::TestCase
+class BmcRedfishTest < Minitest::Test
   include RedfishTestHelper
 
   def setup
@@ -41,9 +41,11 @@ class BmcRedfishTest < Test::Unit::TestCase
     system_mock = mock('system')
 
     system_mock.expects(:patch_if_match).with(
-      'Boot' => {
-        'BootSourceOverrideTarget' => 'Pxe',
-        'BootSourceOverrideEnabled' => 'Once',
+      {
+        'Boot' => {
+          'BootSourceOverrideTarget' => 'Pxe',
+          'BootSourceOverrideEnabled' => 'Once',
+        },
       }
     ).returns(true)
 
@@ -51,7 +53,7 @@ class BmcRedfishTest < Test::Unit::TestCase
     @bmc.expects(:powercycle).never
 
     result = @bmc.bootdevice = { :device => 'pxe', :reboot => false, :persistent => false }
-    assert_not_nil result
+    refute_nil result
   end
 
   def test_bootdevice_disk_persistent_uses_patch_if_match
@@ -59,9 +61,11 @@ class BmcRedfishTest < Test::Unit::TestCase
     system_mock = mock('system')
 
     system_mock.expects(:patch_if_match).with(
-      'Boot' => {
-        'BootSourceOverrideTarget' => 'Hdd',
-        'BootSourceOverrideEnabled' => 'Enabled',
+      {
+        'Boot' => {
+          'BootSourceOverrideTarget' => 'Hdd',
+          'BootSourceOverrideEnabled' => 'Enabled',
+        },
       }
     ).returns(true)
 
@@ -69,7 +73,7 @@ class BmcRedfishTest < Test::Unit::TestCase
     @bmc.expects(:powercycle).never
 
     result = @bmc.bootdevice = { :device => 'disk', :reboot => false, :persistent => true }
-    assert_not_nil result
+    refute_nil result
   end
 
   def test_bootdevice_with_reboot
@@ -77,9 +81,11 @@ class BmcRedfishTest < Test::Unit::TestCase
     system_mock = mock('system')
 
     system_mock.expects(:patch_if_match).with(
-      'Boot' => {
-        'BootSourceOverrideTarget' => 'Pxe',
-        'BootSourceOverrideEnabled' => 'Enabled',
+      {
+        'Boot' => {
+          'BootSourceOverrideTarget' => 'Pxe',
+          'BootSourceOverrideEnabled' => 'Enabled',
+        },
       }
     ).returns(true)
 
@@ -87,7 +93,7 @@ class BmcRedfishTest < Test::Unit::TestCase
     @bmc.expects(:powercycle).once
 
     result = @bmc.bootdevice = { :device => 'pxe', :reboot => true, :persistent => true }
-    assert_not_nil result
+    refute_nil result
   end
 
   def test_bootpxe_calls_bootdevice
@@ -95,9 +101,11 @@ class BmcRedfishTest < Test::Unit::TestCase
     system_mock = mock('system')
 
     system_mock.expects(:patch_if_match).with(
-      'Boot' => {
-        'BootSourceOverrideTarget' => 'Pxe',
-        'BootSourceOverrideEnabled' => 'Once',
+      {
+        'Boot' => {
+          'BootSourceOverrideTarget' => 'Pxe',
+          'BootSourceOverrideEnabled' => 'Once',
+        },
       }
     ).returns(true)
 
@@ -105,7 +113,7 @@ class BmcRedfishTest < Test::Unit::TestCase
     @bmc.expects(:powercycle).never
 
     result = @bmc.bootpxe(false, false)
-    assert_not_nil result
+    refute_nil result
   end
 
   def test_bootdisk_calls_bootdevice
@@ -113,9 +121,11 @@ class BmcRedfishTest < Test::Unit::TestCase
     system_mock = mock('system')
 
     system_mock.expects(:patch_if_match).with(
-      'Boot' => {
-        'BootSourceOverrideTarget' => 'Hdd',
-        'BootSourceOverrideEnabled' => 'Once',
+      {
+        'Boot' => {
+          'BootSourceOverrideTarget' => 'Hdd',
+          'BootSourceOverrideEnabled' => 'Once',
+        },
       }
     ).returns(true)
 
@@ -123,7 +133,7 @@ class BmcRedfishTest < Test::Unit::TestCase
     @bmc.expects(:powercycle).never
 
     result = @bmc.bootdisk(false, false)
-    assert_not_nil result
+    refute_nil result
   end
 
   def test_bootbios_calls_bootdevice
@@ -131,9 +141,11 @@ class BmcRedfishTest < Test::Unit::TestCase
     system_mock = mock('system')
 
     system_mock.expects(:patch_if_match).with(
-      'Boot' => {
-        'BootSourceOverrideTarget' => 'BiosSetup',
-        'BootSourceOverrideEnabled' => 'Once',
+      {
+        'Boot' => {
+          'BootSourceOverrideTarget' => 'BiosSetup',
+          'BootSourceOverrideEnabled' => 'Once',
+        },
       }
     ).returns(true)
 
@@ -141,7 +153,7 @@ class BmcRedfishTest < Test::Unit::TestCase
     @bmc.expects(:powercycle).never
 
     result = @bmc.bootbios(false, false)
-    assert_not_nil result
+    refute_nil result
   end
 
   def test_bootcdrom_calls_bootdevice
@@ -149,9 +161,11 @@ class BmcRedfishTest < Test::Unit::TestCase
     system_mock = mock('system')
 
     system_mock.expects(:patch_if_match).with(
-      'Boot' => {
-        'BootSourceOverrideTarget' => 'Cd',
-        'BootSourceOverrideEnabled' => 'Once',
+      {
+        'Boot' => {
+          'BootSourceOverrideTarget' => 'Cd',
+          'BootSourceOverrideEnabled' => 'Once',
+        },
       }
     ).returns(true)
 
@@ -159,7 +173,7 @@ class BmcRedfishTest < Test::Unit::TestCase
     @bmc.expects(:powercycle).never
 
     result = @bmc.bootcdrom(false, false)
-    assert_not_nil result
+    refute_nil result
   end
 
   def test_identifystatus_uses_indicator_led_when_location_indicator_absent

--- a/test/bmc/bmc_test.rb
+++ b/test/bmc/bmc_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'bmc/ipmi'
 
-class BmcTest < Test::Unit::TestCase
+class BmcTest < Minitest::Test
   def setup
     Rubyipmi.stubs(:is_provider_installed?).with('ipmitool').returns(true)
     @args = { :username => "user", :password => "pass", :bmc_provider => "ipmitool", :host => "host" }
@@ -16,7 +16,7 @@ class BmcTest < Test::Unit::TestCase
   end
 
   def test_creates_rubyipmi_object
-    assert_not_nil bmc
+    refute_nil bmc
   end
 
   def test_should_run_connection_test
@@ -57,7 +57,7 @@ class BmcTest < Test::Unit::TestCase
   end
 
   def test_should_power_reboot
-    assert_raise(NotImplementedError) do
+    assert_raises(NotImplementedError) do
       bmc.powerreboot
     end
   end

--- a/test/dependency_injection_test.rb
+++ b/test/dependency_injection_test.rb
@@ -49,7 +49,7 @@ class TestDependsTwo
   inject_attr :singleton_dependency, :singleton_var
 end
 
-class DependencyInjectionTest < Test::Unit::TestCase
+class DependencyInjectionTest < Minitest::Test
   def test_can_locate_dependency
     assert TestContainer.instance.get_dependency(:test_dependency_one)
     assert TestContainer.instance.get_dependency(:singleton_dependency)

--- a/test/dhcp/conf_parser_test.rb
+++ b/test/dhcp/conf_parser_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'dhcp_common/dhcp_common'
 require 'dhcp_common/isc/configuration_parser'
 
-class Proxy::DHCP::CommonISC::ConfigurationParserTest < Test::Unit::TestCase
+class Proxy::DHCP::CommonISC::ConfigurationParserTest < Minitest::Test
   def teardown
     Rsec::Fail.reset
   end

--- a/test/dhcp/dhcp_api_test.rb
+++ b/test/dhcp/dhcp_api_test.rb
@@ -11,7 +11,7 @@ require 'dhcp/sparc_attrs'
 
 ENV['RACK_ENV'] = 'test'
 
-class DhcpApiTest < Test::Unit::TestCase
+class DhcpApiTest < Minitest::Test
   include Rack::Test::Methods
   include SparcAttrs
 

--- a/test/dhcp/dhcp_config_test.rb
+++ b/test/dhcp/dhcp_config_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'dhcp/dhcp_plugin'
 
-class DhcpConfigTest < Test::Unit::TestCase
+class DhcpConfigTest < Minitest::Test
   def test_omitted_settings_have_default_values
     Proxy::DhcpPlugin.load_test_settings()
     assert_equal '127.0.0.1', Proxy::DhcpPlugin.settings.server

--- a/test/dhcp/dhcp_isc_provider_interface_test.rb
+++ b/test/dhcp/dhcp_isc_provider_interface_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'dhcp_common/isc/omapi_provider'
 
-class IscDhcpProviderInterfaceTest < Test::Unit::TestCase
+class IscDhcpProviderInterfaceTest < Minitest::Test
   def test_provider_interface
     assert_dhcp_provider_interface(Proxy::DHCP::CommonISC::IscOmapiProvider.new({}, nil))
   end

--- a/test/dhcp/dhcp_isc_subnet_service_initialization_test.rb
+++ b/test/dhcp/dhcp_isc_subnet_service_initialization_test.rb
@@ -7,7 +7,7 @@ require 'dhcp_common/record/reservation'
 require 'dhcp_common/isc/configuration_parser'
 require 'dhcp_common/isc/subnet_service_initialization'
 
-class DhcpIscSubnetServiceInitializationTest < Test::Unit::TestCase
+class DhcpIscSubnetServiceInitializationTest < Minitest::Test
   DHCPD_CONFIG = <<~END
     # This is a comment.
 
@@ -111,7 +111,7 @@ class DhcpIscSubnetServiceInitializationTest < Test::Unit::TestCase
     @initialization.load_configuration_file(DHCPD_CONFIG)
     subnets = @subnet_service.all_subnets
     assert_equal ["192.168.122.250"], subnets[0].options[:routers]
-    assert_equal nil, subnets[0].options[:routers][1]
+    assert_nil subnets[0].options[:routers][1]
     assert_equal ["192.168.123.1"], subnets[1].options[:routers]
     assert_equal ["192.168.124.1", "192.168.124.2"], subnets[2].options[:routers]
   end
@@ -119,7 +119,7 @@ class DhcpIscSubnetServiceInitializationTest < Test::Unit::TestCase
   def test_managed_subnets_domain_name_servers
     @initialization.load_configuration_file(DHCPD_CONFIG)
     subnets = @subnet_service.all_subnets
-    assert_equal nil, subnets[0].options[:domain_name_servers]
+    assert_nil subnets[0].options[:domain_name_servers]
     assert_equal ["192.168.123.1"], subnets[1].options[:domain_name_servers]
     assert_equal ["192.168.123.1", "192.168.122.250"], subnets[2].options[:domain_name_servers]
   end
@@ -127,9 +127,9 @@ class DhcpIscSubnetServiceInitializationTest < Test::Unit::TestCase
   def test_managed_subnets_range
     @initialization.load_configuration_file(DHCPD_CONFIG)
     subnets = @subnet_service.all_subnets
-    assert_equal nil, subnets[0].options[:range]
+    assert_nil subnets[0].options[:range]
     assert_equal ["192.168.123.2", "192.168.123.62"], subnets[1].options[:range]
-    assert_equal nil, subnets[2].options[:range]
+    assert_nil subnets[2].options[:range]
   end
 
   def test_parse_config_and_leases
@@ -155,7 +155,7 @@ class DhcpIscSubnetServiceInitializationTest < Test::Unit::TestCase
     @subnet_service.add_subnet(subnet)
     @initialization.load_leases_file(File.read("./test/fixtures/dhcp/dhcp.leases"))
 
-    assert_not_nil @subnet_service.find_host_by_hostname("undeleted.example.com")
+    refute_nil @subnet_service.find_host_by_hostname("undeleted.example.com")
   end
 
   def test_host_with_duplicate_mac_address_is_removed

--- a/test/dhcp/free_ips_test.rb
+++ b/test/dhcp/free_ips_test.rb
@@ -5,7 +5,7 @@ require 'dhcp_common/subnet'
 require 'dhcp_common/record/reservation'
 require 'dhcp_common/free_ips'
 
-class Proxy::DHCPFreeIpsTest < Test::Unit::TestCase
+class Proxy::DHCPFreeIpsTest < Minitest::Test
   def setup
     @blacklist_interval = 30 * 60
     @free_ips = Proxy::DHCP::FreeIps.new(@blacklist_interval)
@@ -103,8 +103,8 @@ class Proxy::DHCPFreeIpsTest < Test::Unit::TestCase
 
     @free_ips.find_free_ip("192.168.1.1", "192.168.1.2", [r])
 
-    assert_false @free_ips.allocated_ips.empty?
-    assert_false @free_ips.allocation_timestamps.empty?
+    refute @free_ips.allocated_ips.empty?
+    refute @free_ips.allocation_timestamps.empty?
 
     @free_ips.expects(:time_now).returns(Time.now.to_i + @blacklist_interval + 10)
     @free_ips.clean_up_allocated_ips

--- a/test/dhcp/integration_test.rb
+++ b/test/dhcp/integration_test.rb
@@ -6,7 +6,7 @@ require 'dhcp_common/subnet_service'
 require 'dhcp_common/dhcp_common'
 require 'dhcp_common/record/reservation'
 
-class DhcpApiValidIPTest < Test::Unit::TestCase
+class DhcpApiValidIPTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/dhcp/ipv4_address_arithmetic_test.rb
+++ b/test/dhcp/ipv4_address_arithmetic_test.rb
@@ -1,7 +1,7 @@
 require 'test/benchmark_helper'
 require 'dhcp_common/dhcp_common'
 
-class Ipv4AddressArithmeticTests < Test::Unit::TestCase
+class Ipv4AddressArithmeticTests < Minitest::Test
   def test_ipv4_to_i
     assert_equal 0xffffffff, Proxy::DHCP.ipv4_to_i("255.255.255.255")
     assert_equal 0x7f000001, Proxy::DHCP.ipv4_to_i("127.0.0.1")

--- a/test/dhcp/isc_omapi_provider_test.rb
+++ b/test/dhcp/isc_omapi_provider_test.rb
@@ -4,7 +4,7 @@ require 'dhcp/dhcp_plugin'
 require 'dhcp/sparc_attrs'
 require 'dhcp_common/isc/omapi_provider'
 
-class IscOmapiProviderTest < Test::Unit::TestCase
+class IscOmapiProviderTest < Minitest::Test
   class OMIO
     attr_reader :input_commands
 
@@ -147,9 +147,7 @@ class IscOmapiProviderTest < Test::Unit::TestCase
   end
 
   def test_validate_ip
-    assert_nothing_raised do
-      @dhcp.validate_supported_address("192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0")
-    end
+    @dhcp.validate_supported_address("192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0")
   end
 
   def test_should_not_validate_ipv6

--- a/test/dhcp/record_test.rb
+++ b/test/dhcp/record_test.rb
@@ -6,7 +6,7 @@ require 'dhcp_common/record/reservation'
 require 'dhcp_common/record/deleted_reservation'
 require 'dhcp_common/record/lease'
 
-class Proxy::DHCPRecordTest < Test::Unit::TestCase
+class Proxy::DHCPRecordTest < Minitest::Test
   def setup
     @subnet = Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0")
     @ip = "123.255.123.255"
@@ -26,7 +26,7 @@ class Proxy::DHCPRecordTest < Test::Unit::TestCase
 
   def test_should_not_save_invalid_ip_addresses
     ip = "1..1.1"
-    assert_raise(Proxy::Validations::InvalidIPAddress) { Proxy::DHCP::Record.new(ip, @mac, @subnet) }
+    assert_raises(Proxy::Validations::InvalidIPAddress) { Proxy::DHCP::Record.new(ip, @mac, @subnet) }
   end
 
   def test_mac_should_be_saved_lower_case
@@ -36,48 +36,48 @@ class Proxy::DHCPRecordTest < Test::Unit::TestCase
   end
 
   def test_should_not_save_invalid_mac
-    assert_raise(Proxy::Validations::InvalidMACAddress) { Proxy::DHCP::Record.new(@ip, "XYZxxVVcc123", @subnet) }
+    assert_raises(Proxy::Validations::InvalidMACAddress) { Proxy::DHCP::Record.new(@ip, "XYZxxVVcc123", @subnet) }
   end
 
   def test_should_not_save_invalid_subnets
-    assert_raise(Proxy::Validations::InvalidSubnet) { Proxy::DHCP::Record.new(@ip, @mac, nil) }
+    assert_raises(Proxy::Validations::InvalidSubnet) { Proxy::DHCP::Record.new(@ip, @mac, nil) }
   end
 
   def test_equality
     assert_equal Proxy::DHCP::Record.new(@ip, @mac, Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0"), :option1 => 'one'),
                  Proxy::DHCP::Record.new(@ip, @mac, Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0"), :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Record.new(@ip, @mac, @subnet, :option1 => 'one'),
-                     Proxy::DHCP::Record.new('1.1.1.1', @mac, @subnet, :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Record.new(@ip, @mac, @subnet, :option1 => 'one'),
-                     Proxy::DHCP::Record.new(@ip, '00:01:02:03:04:05', @subnet, :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Record.new(@ip, @mac, @subnet, :option1 => 'one'),
-                     Proxy::DHCP::Record.new(@ip, @mac, @subnet, :option2 => 'two')
-    assert_not_equal Proxy::DHCP::Record.new(@ip, @mac, @subnet, :option1 => 'one'),
-                     Proxy::DHCP::Record.new(@ip, @mac, ::Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.128"), :option1 => 'one')
+    refute_equal Proxy::DHCP::Record.new(@ip, @mac, @subnet, :option1 => 'one'),
+                 Proxy::DHCP::Record.new('1.1.1.1', @mac, @subnet, :option1 => 'one')
+    refute_equal Proxy::DHCP::Record.new(@ip, @mac, @subnet, :option1 => 'one'),
+                 Proxy::DHCP::Record.new(@ip, '00:01:02:03:04:05', @subnet, :option1 => 'one')
+    refute_equal Proxy::DHCP::Record.new(@ip, @mac, @subnet, :option1 => 'one'),
+                 Proxy::DHCP::Record.new(@ip, @mac, @subnet, :option2 => 'two')
+    refute_equal Proxy::DHCP::Record.new(@ip, @mac, @subnet, :option1 => 'one'),
+                 Proxy::DHCP::Record.new(@ip, @mac, ::Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.128"), :option1 => 'one')
   end
 
   def test_reservation_equality
     assert_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
                  Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'), nil
-    assert_not_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'), Object.new
-    assert_not_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
-                     Proxy::DHCP::Reservation.new('test-another', @ip, @mac, @subnet, :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
-                     Proxy::DHCP::Reservation.new('test', '1.1.1.1', @mac, @subnet, :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
-                     Proxy::DHCP::Reservation.new('test', @ip, '00:01:02:03:04:05', @subnet, :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
-                     Proxy::DHCP::Reservation.new('test', @ip, @mac, ::Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.128"), :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
-                     Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option2 => 'one')
+    refute_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'), nil
+    refute_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'), Object.new
+    refute_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
+                 Proxy::DHCP::Reservation.new('test-another', @ip, @mac, @subnet, :option1 => 'one')
+    refute_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
+                 Proxy::DHCP::Reservation.new('test', '1.1.1.1', @mac, @subnet, :option1 => 'one')
+    refute_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
+                 Proxy::DHCP::Reservation.new('test', @ip, '00:01:02:03:04:05', @subnet, :option1 => 'one')
+    refute_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
+                 Proxy::DHCP::Reservation.new('test', @ip, @mac, ::Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.128"), :option1 => 'one')
+    refute_equal Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option1 => 'one'),
+                 Proxy::DHCP::Reservation.new('test', @ip, @mac, @subnet, :option2 => 'one')
   end
 
   def test_deleted_reservation_equality
     assert_equal Proxy::DHCP::DeletedReservation.new('test'), Proxy::DHCP::DeletedReservation.new('test')
-    assert_not_equal Proxy::DHCP::DeletedReservation.new('test'), nil
-    assert_not_equal Proxy::DHCP::DeletedReservation.new('test'), Object.new
-    assert_not_equal Proxy::DHCP::DeletedReservation.new('test'), Proxy::DHCP::DeletedReservation.new('test-1')
+    refute_equal Proxy::DHCP::DeletedReservation.new('test'), nil
+    refute_equal Proxy::DHCP::DeletedReservation.new('test'), Object.new
+    refute_equal Proxy::DHCP::DeletedReservation.new('test'), Proxy::DHCP::DeletedReservation.new('test-1')
   end
 
   def test_lease_equality
@@ -86,22 +86,22 @@ class Proxy::DHCPRecordTest < Test::Unit::TestCase
 
     assert_equal Proxy::DHCP::Lease.new('lease', @ip, @mac, Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0"), start_time, end_time, 'active', :option1 => 'one'),
                  Proxy::DHCP::Lease.new('lease', @ip, @mac, Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0"), start_time, end_time, 'active', :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Lease.new('lease', @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'), Object.new
-    assert_not_equal Proxy::DHCP::Lease.new('lease', @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
-                     Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
-                     Proxy::DHCP::Lease.new(nil, '1.1.1.1', @mac, @subnet, start_time, end_time, 'active', :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
-                     Proxy::DHCP::Lease.new(nil, @ip, '00:01:02:03:04:05', @subnet, start_time, end_time, 'active', :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
-                     Proxy::DHCP::Lease.new(nil, @ip, @mac, ::Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.128"), start_time, end_time, 'active', :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
-                     Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time + 5, end_time, 'active', :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
-                     Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time + 5, 'active', :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
-                     Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'free', :option1 => 'one')
-    assert_not_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
-                     Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option2 => 'two')
+    refute_equal Proxy::DHCP::Lease.new('lease', @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'), Object.new
+    refute_equal Proxy::DHCP::Lease.new('lease', @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
+                 Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one')
+    refute_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
+                 Proxy::DHCP::Lease.new(nil, '1.1.1.1', @mac, @subnet, start_time, end_time, 'active', :option1 => 'one')
+    refute_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
+                 Proxy::DHCP::Lease.new(nil, @ip, '00:01:02:03:04:05', @subnet, start_time, end_time, 'active', :option1 => 'one')
+    refute_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
+                 Proxy::DHCP::Lease.new(nil, @ip, @mac, ::Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.128"), start_time, end_time, 'active', :option1 => 'one')
+    refute_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
+                 Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time + 5, end_time, 'active', :option1 => 'one')
+    refute_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
+                 Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time + 5, 'active', :option1 => 'one')
+    refute_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
+                 Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'free', :option1 => 'one')
+    refute_equal Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option1 => 'one'),
+                 Proxy::DHCP::Lease.new(nil, @ip, @mac, @subnet, start_time, end_time, 'active', :option2 => 'two')
   end
 end

--- a/test/dhcp/server_test.rb
+++ b/test/dhcp/server_test.rb
@@ -4,7 +4,7 @@ require 'dhcp_common/subnet_service'
 require 'dhcp_common/dhcp_common'
 require 'dhcp_common/server'
 
-class DHCPServerTest < Test::Unit::TestCase
+class DHCPServerTest < Minitest::Test
   def setup
     @service = Proxy::DHCP::SubnetService.initialized_instance
     @free_ips = Object.new
@@ -22,9 +22,7 @@ class DHCPServerTest < Test::Unit::TestCase
   end
 
   def test_validate_ip
-    assert_nothing_raised do
-      @server.validate_supported_address("192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0")
-    end
+    @server.validate_supported_address("192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0")
   end
 
   def test_should_raise_exception_for_invalid_ip
@@ -59,26 +57,20 @@ class DHCPServerTest < Test::Unit::TestCase
 
   def test_should_ignore_ip_address_collision_with_a_lease
     @service.add_lease(@subnet.network, ::Proxy::DHCP::Lease.new('test-2', "192.168.0.12", "00:11:22:33:44:55", @subnet, nil, nil, nil))
-    assert_nothing_raised do
-      @server.add_record('hostname' => 'test-1', 'name' => 'test', 'network' => @subnet.network, 'ip' => "192.168.0.12", 'mac' => "aa:bb:cc:dd:ee:ef")
-    end
+    @server.add_record('hostname' => 'test-1', 'name' => 'test', 'network' => @subnet.network, 'ip' => "192.168.0.12", 'mac' => "aa:bb:cc:dd:ee:ef")
   end
 
   def test_should_ignore_mac_address_collision_with_a_lease
     @service.add_lease(@subnet.network, ::Proxy::DHCP::Lease.new('test-2', "192.168.0.13", "00:11:22:33:44:55", @subnet, nil, nil, nil))
-    assert_nothing_raised Proxy::DHCP::Collision do
-      @server.add_record('hostname' => 'test-1', 'name' => 'test', 'network' => @subnet.network, 'ip' => "192.168.0.12", 'mac' => "00:11:22:33:44:55")
-    end
+    @server.add_record('hostname' => 'test-1', 'name' => 'test', 'network' => @subnet.network, 'ip' => "192.168.0.12", 'mac' => "00:11:22:33:44:55")
   end
 
   def test_not_should_raise_exception_when_address_with_related_mac_in_use
     record = Proxy::DHCP::Reservation.new('example.com-01', "192.168.0.15", "aa:bb:cc:dd:ee:ee", @subnet, :hostname => 'example.com')
     @service.add_host(@subnet.network, record)
-    assert_nothing_raised do
-      @server.add_record('hostname' => 'example.com', 'name' => 'example.com-02',
-                         'network' => @subnet.network, 'ip' => "192.168.0.15", 'mac' => "aa:bb:cc:dd:ee:de",
-                         'related_macs' => ['aa:bb:cc:dd:ee:ee'])
-    end
+    @server.add_record('hostname' => 'example.com', 'name' => 'example.com-02',
+                       'network' => @subnet.network, 'ip' => "192.168.0.15", 'mac' => "aa:bb:cc:dd:ee:de",
+                       'related_macs' => ['aa:bb:cc:dd:ee:ee'])
   end
 
   def test_should_find_subnet_based_on_network

--- a/test/dhcp/subnet_service_test.rb
+++ b/test/dhcp/subnet_service_test.rb
@@ -3,7 +3,7 @@ require 'dhcp_common/dhcp_common'
 require 'dhcp_common/server'
 require 'dhcp_common/subnet_service'
 
-class SubnetServiceTest < Test::Unit::TestCase
+class SubnetServiceTest < Minitest::Test
   def setup
     @subnets = {}
     @leases_ip_store = Proxy::MemoryStore.new
@@ -26,7 +26,7 @@ class SubnetServiceTest < Test::Unit::TestCase
   def test_should_not_add_duplicate_subnets
     @service.add_subnet(Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0"))
 
-    assert_raise Proxy::DHCP::Error do
+    assert_raises Proxy::DHCP::Error do
       @service.add_subnet(Proxy::DHCP::Subnet.new("192.168.0.0", "255.255.255.0"))
     end
   end
@@ -75,7 +75,7 @@ class SubnetServiceTest < Test::Unit::TestCase
                Proxy::DHCP::Subnet.new("192.168.0.128", "255.255.255.192"),
                Proxy::DHCP::Subnet.new("192.168.0.192", "255.255.255.192")]
     @service.add_subnets(*subnets)
-    assert_not_nil @service.find_subnet("192.168.0.100")
+    refute_nil @service.find_subnet("192.168.0.100")
     assert_equal subnets[4], @service.find_subnet("192.168.0.100")
   end
 
@@ -88,7 +88,7 @@ class SubnetServiceTest < Test::Unit::TestCase
                Proxy::DHCP::Subnet.new("196.168.0.128", "255.255.255.192"),
                Proxy::DHCP::Subnet.new("196.168.0.192", "255.255.255.192")]
     @service.add_subnets(*subnets)
-    assert_not_nil @service.find_subnet("192.168.0.100")
+    refute_nil @service.find_subnet("192.168.0.100")
     assert_equal subnets[4], @service.find_subnet("192.168.0.100")
   end
 

--- a/test/dhcp/subnet_test.rb
+++ b/test/dhcp/subnet_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'dhcp_common/dhcp_common'
 require 'dhcp_common/server'
 
-class Proxy::DHCPSubnetTest < Test::Unit::TestCase
+class Proxy::DHCPSubnetTest < Minitest::Test
   def setup
     @network = "192.168.0.0"
     @netmask = "255.255.255.0"
@@ -14,38 +14,38 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
   end
 
   def test_should_not_save_invalid_network_addresses
-    assert_raise Proxy::Validations::InvalidIPAddress do
+    assert_raises Proxy::Validations::InvalidIPAddress do
       Proxy::DHCP::Subnet.new("1..1.1", @netmask)
     end
   end
 
   def test_should_not_save_invalid_router_addresses
-    assert_raise Proxy::Validations::InvalidIPAddress do
+    assert_raises Proxy::Validations::InvalidIPAddress do
       Proxy::DHCP::Subnet.new(@network, @netmask, :routers => ["192.168..1"])
     end
   end
 
   def test_should_not_save_invalid_range
-    assert_raise Proxy::Validations::InvalidIPAddress do
+    assert_raises Proxy::Validations::InvalidIPAddress do
       Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.0..", "192.168.0.50"])
     end
-    assert_raise Proxy::Validations::InvalidIPAddress do
+    assert_raises Proxy::Validations::InvalidIPAddress do
       Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.0.3", "192.168.0.."])
     end
-    assert_raise Proxy::DHCP::Error do
+    assert_raises Proxy::DHCP::Error do
       Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.0.3", "192.168.1.100"])
     end
-    assert_raise Proxy::DHCP::Error do
+    assert_raises Proxy::DHCP::Error do
       Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.1.3", "192.168.0.100"])
     end
-    assert_raise Proxy::DHCP::Error do
+    assert_raises Proxy::DHCP::Error do
       Proxy::DHCP::Subnet.new(@network, @netmask, :range => ["192.168.0.100", "192.168.0.3"])
     end
   end
 
   def test_should_not_save_invalid_netmask
     netmask = "XYZxxVVcc123"
-    assert_raise Proxy::Validations::InvalidIPAddress do
+    assert_raises Proxy::Validations::InvalidIPAddress do
       Proxy::DHCP::Subnet.new(@network, netmask)
     end
   end
@@ -76,11 +76,11 @@ class Proxy::DHCPSubnetTest < Test::Unit::TestCase
 
   def test_equality
     assert_equal ::Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name => 'a.b.c'), ::Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name => 'a.b.c')
-    assert_not_equal ::Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name => 'a.b.c'),
-                     ::Proxy::DHCP::Subnet.new('1.1.1.0', @netmask, :domain_name => 'a.b.c')
-    assert_not_equal ::Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name => 'a.b.c'),
-                     ::Proxy::DHCP::Subnet.new(@network, '255.255.255.128', :domain_name => 'a.b.c')
-    assert_not_equal ::Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name => 'a.b.c'),
-                     ::Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name => 'd.e.f')
+    refute_equal ::Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name => 'a.b.c'),
+                 ::Proxy::DHCP::Subnet.new('1.1.1.0', @netmask, :domain_name => 'a.b.c')
+    refute_equal ::Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name => 'a.b.c'),
+                 ::Proxy::DHCP::Subnet.new(@network, '255.255.255.128', :domain_name => 'a.b.c')
+    refute_equal ::Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name => 'a.b.c'),
+                 ::Proxy::DHCP::Subnet.new(@network, @netmask, :domain_name => 'd.e.f')
   end
 end

--- a/test/dhcp_isc/dhcp_isc_config_test.rb
+++ b/test/dhcp_isc/dhcp_isc_config_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'dhcp_isc/dhcp_isc'
 
-class DhcpIscConfigTest < ::Test::Unit::TestCase
+class DhcpIscConfigTest < Minitest::Test
   def test_default_configuration
     Proxy::DHCP::ISC::Plugin.load_test_settings()
     assert_equal '7911', Proxy::DHCP::ISC::Plugin.settings.omapi_port

--- a/test/dhcp_isc/production_di_wirings_test.rb
+++ b/test/dhcp_isc/production_di_wirings_test.rb
@@ -5,7 +5,7 @@ require 'dhcp_common/isc/omapi_provider'
 require 'dhcp_isc/isc_state_changes_observer'
 require 'dhcp_isc/configuration_loader'
 
-class IscDhcpProductionDiWiringsTest < Test::Unit::TestCase
+class IscDhcpProductionDiWiringsTest < Minitest::Test
   def setup
     @settings = {:server => "a_server", :omapi_port => 7911, :key_name => "key_name", :key_secret => "key_secret",
                  :subnets => ["192.168.0.0/255.255.255.0"], :leases_file_observer => :inotify_leases_file_observer,

--- a/test/dhcp_isc/state_changes_observer_test.rb
+++ b/test/dhcp_isc/state_changes_observer_test.rb
@@ -6,7 +6,7 @@ require 'dhcp_common/record/deleted_reservation'
 require 'dhcp_common/subnet_service'
 require 'dhcp_isc/isc_state_changes_observer'
 
-class IscStateChangesObserverEventsTest < Test::Unit::TestCase
+class IscStateChangesObserverEventsTest < Minitest::Test
   class EventsForTesting < ::Proxy::DHCP::ISC::IscStateChangesObserver::Events
     attr_writer :last_event
   end
@@ -76,7 +76,7 @@ class IscStateChangesObserverEventsTest < Test::Unit::TestCase
   end
 end
 
-class StateChangesObserverTest < Test::Unit::TestCase
+class StateChangesObserverTest < Minitest::Test
   class EventsForTesting < ::Proxy::DHCP::ISC::IscStateChangesObserver::Events
     attr_writer :last_event
   end
@@ -105,7 +105,7 @@ class StateChangesObserverTest < Test::Unit::TestCase
     @observer.expects(:new_worker).returns(Object.new)
     @observer.start
     assert @observer.event_loop_active
-    assert_not_nil @observer.worker.nil?
+    refute_nil @observer.worker.nil?
   end
 
   def test_event_loop_with_stopped_event

--- a/test/dhcp_libvirt/dhcp_libvirt_config_test.rb
+++ b/test/dhcp_libvirt/dhcp_libvirt_config_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'dhcp_libvirt/dhcp_libvirt'
 
-class DhcpLibvirtConfigTest < Test::Unit::TestCase
+class DhcpLibvirtConfigTest < Minitest::Test
   def test_omitted_settings_have_default_values
     ::Proxy::DHCP::Libvirt::Plugin.load_test_settings()
     assert_equal 'default', ::Proxy::DHCP::Libvirt::Plugin.settings.network

--- a/test/dhcp_libvirt/dhcp_libvirt_provider_interface_test.rb
+++ b/test/dhcp_libvirt/dhcp_libvirt_provider_interface_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'dhcp_libvirt/dhcp_libvirt_main'
 
-class LibvirtDhcpProviderInterfaceTest < Test::Unit::TestCase
+class LibvirtDhcpProviderInterfaceTest < Minitest::Test
   def test_provider_interface
     ::Libvirt.stubs(:open).returns(true)
     assert_dhcp_provider_interface(::Proxy::DHCP::Libvirt::Provider.new(nil, nil, nil, nil))

--- a/test/dhcp_libvirt/dhcp_libvirt_provider_test.rb
+++ b/test/dhcp_libvirt/dhcp_libvirt_provider_test.rb
@@ -4,7 +4,7 @@ require 'dhcp_common/subnet_service'
 require 'dhcp_libvirt/dhcp_libvirt'
 require 'dhcp_libvirt/dhcp_libvirt_main'
 
-class DhcpLibvirtProviderTest < Test::Unit::TestCase
+class DhcpLibvirtProviderTest < Minitest::Test
   def setup
     @libvirt_network = mock()
     @subnet = Proxy::DHCP::Subnet.new("192.168.122.0", "255.255.255.0")
@@ -32,9 +32,7 @@ class DhcpLibvirtProviderTest < Test::Unit::TestCase
   end
 
   def test_validate_ip
-    assert_nothing_raised do
-      @subject.validate_supported_address("192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0")
-    end
+    @subject.validate_supported_address("192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0")
   end
 
   def test_should_not_validate_ipv6

--- a/test/dhcp_libvirt/libvirt_dhcp_network_test.rb
+++ b/test/dhcp_libvirt/libvirt_dhcp_network_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'ostruct'
 require 'dhcp_libvirt/libvirt_dhcp_network'
 
-class LibvirtDHCPNetworkTest < Test::Unit::TestCase
+class LibvirtDHCPNetworkTest < Minitest::Test
   def setup
     @connection = mock()
     @network = mock()

--- a/test/dhcp_libvirt/production_di_wirings_test.rb
+++ b/test/dhcp_libvirt/production_di_wirings_test.rb
@@ -5,7 +5,7 @@ require 'dhcp_libvirt/libvirt_dhcp_network'
 require 'dhcp_libvirt/dhcp_libvirt_main'
 require 'dhcp_libvirt/configuration_loader'
 
-class DhcpLibvirtProductionDIWiringsTest < Test::Unit::TestCase
+class DhcpLibvirtProductionDIWiringsTest < Minitest::Test
   def setup
     @settings = {:network => "a_network", :url => "qemu:///system"}
     @container = ::Proxy::DependencyInjection::Container.new
@@ -19,7 +19,7 @@ class DhcpLibvirtProductionDIWiringsTest < Test::Unit::TestCase
   end
 
   def test_free_ips_initialization
-    assert_not_nil @container.get_dependency(:free_ips)
+    refute_nil @container.get_dependency(:free_ips)
   end
 
   def test_initialized_subnet_service_initialization
@@ -36,6 +36,6 @@ class DhcpLibvirtProductionDIWiringsTest < Test::Unit::TestCase
     provider = @container.get_dependency(:dhcp_provider)
     assert_equal @settings[:network], provider.network
     assert_equal expected_subnet_service, provider.service
-    assert_not_nil provider.free_ips
+    refute_nil provider.free_ips
   end
 end

--- a/test/dhcp_libvirt/subnet_service_initializer_test.rb
+++ b/test/dhcp_libvirt/subnet_service_initializer_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'dhcp_common/subnet_service'
 require 'dhcp_libvirt/subnet_service_initializer'
 
-class SubnetServiceInitializerTest < Test::Unit::TestCase
+class SubnetServiceInitializerTest < Minitest::Test
   def setup
     @network_xml = <<~XMLFIXTURE
       <network>

--- a/test/dhcp_ms_native/dhcp_ms_native_provider_interface_test.rb
+++ b/test/dhcp_ms_native/dhcp_ms_native_provider_interface_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'dhcp_native_ms/dhcp_native_ms_main'
 
-class MsNativeDhcpProviderInterfaceTest < Test::Unit::TestCase
+class MsNativeDhcpProviderInterfaceTest < Minitest::Test
   def test_provider_interface
     assert_dhcp_provider_interface(Proxy::DHCP::NativeMS::Provider.new(nil, nil, nil))
   end

--- a/test/dhcp_ms_native/native_ms_provider_configuration_test.rb
+++ b/test/dhcp_ms_native/native_ms_provider_configuration_test.rb
@@ -3,7 +3,7 @@ require 'dhcpsapi'
 require 'dhcp_native_ms/plugin_configuration'
 require 'dhcp_native_ms/dhcp_native_ms_main'
 
-class NativeMsProviderConfigurationTest < Test::Unit::TestCase
+class NativeMsProviderConfigurationTest < Minitest::Test
   def setup
     @configuration = ::Proxy::DHCP::NativeMS::PluginConfiguration.new
     @container = ::Proxy::DependencyInjection::Container.new

--- a/test/dhcp_ms_native/server_ms_test.rb
+++ b/test/dhcp_ms_native/server_ms_test.rb
@@ -8,7 +8,7 @@ require 'dhcp_native_ms/dhcp_native_ms'
 require 'dhcp_native_ms/dhcp_native_ms_main'
 require 'dhcp/sparc_attrs'
 
-class DHCPServerMicrosoftTest < Test::Unit::TestCase
+class DHCPServerMicrosoftTest < Minitest::Test
   def setup
     @dhcpsapi = Object.new
     @network = '192.168.42.0'
@@ -106,21 +106,21 @@ class DHCPServerMicrosoftTest < Test::Unit::TestCase
 
   def test_should_not_return_free_ip_address_wrong_end
     @dhcpsapi.expects(:list_subnet_elements).with(@network, anything).returns([{:element => {:start_address => '192.168.42.100', :end_address => '192.168.42.200'}}])
-    assert_equal nil, @server.unused_ip(@network, '00:01:02:03:04:05', '192.168.42.100', '192.168.42.250')
+    assert_nil @server.unused_ip(@network, '00:01:02:03:04:05', '192.168.42.100', '192.168.42.250')
   end
 
   def test_should_not_return_free_ip_address_wrong_start
     @dhcpsapi.expects(:list_subnet_elements).with(@network, anything).returns([{:element => {:start_address => '192.168.42.100', :end_address => '192.168.42.200'}}])
-    assert_equal nil, @server.unused_ip(@network, '00:01:02:03:04:05', '192.168.42.10', '192.168.42.200')
+    assert_nil @server.unused_ip(@network, '00:01:02:03:04:05', '192.168.42.10', '192.168.42.200')
   end
 
   def test_should_not_return_free_ip_address_wrong_subnet
-    assert_equal nil, @server.unused_ip(@network, '00:01:02:03:04:05', nil, nil)
+    assert_nil @server.unused_ip(@network, '00:01:02:03:04:05', nil, nil)
   end
 
   def test_should_not_return_free_ip_address_wrong_dhcp_range
     @dhcpsapi.expects(:list_subnet_elements).with(@network, anything).returns([{:element => {:start_address => '192.168.42.100'}}])
-    assert_equal nil, @server.unused_ip(@network, '00:01:02:03:04:05', nil, nil)
+    assert_nil @server.unused_ip(@network, '00:01:02:03:04:05', nil, nil)
   end
 
   def test_should_return_no_free_ip_address
@@ -128,7 +128,7 @@ class DHCPServerMicrosoftTest < Test::Unit::TestCase
     @server.expects(:all_hosts).with(@network).returns([])
     @server.expects(:all_leases).with(@network).returns([])
     @free_ips.expects(:find_free_ip).returns(nil)
-    assert_equal nil, @server.unused_ip(@network, nil, nil, nil)
+    assert_nil @server.unused_ip(@network, nil, nil, nil)
   end
 
   def test_unused_ip_address_for_known_mac_address
@@ -241,9 +241,9 @@ class DHCPServerMicrosoftTest < Test::Unit::TestCase
 
     @dhcpsapi.expects(:get_subnet).with(@network).returns(:subnet_address => @network, :subnet_mask => @netmask)
     @server.expects(:create_reservation).with(client_ip, @netmask, client_mac, client_name)
-    @server.expects(:build_option_values).with(:hostname => client_name, :option_one => 'option_one_value', :option_two => 'option_two_value')
+    @server.expects(:build_option_values).with({:hostname => client_name, :option_one => 'option_one_value', :option_two => 'option_two_value'})
            .returns(:option_one => 'option_one_value', :option_two => 'option_two_value')
-    @server.expects(:set_option_values).with(client_ip, @network, :option_one => 'option_one_value', :option_two => 'option_two_value')
+    @server.expects(:set_option_values).with(client_ip, @network, {:option_one => 'option_one_value', :option_two => 'option_two_value'})
 
     @server.add_record('ip' => client_ip, 'mac' => client_mac, 'hostname' => client_name, 'network' => @network, :option_one => 'option_one_value', :option_two => 'option_two_value')
   end
@@ -282,7 +282,7 @@ class DHCPServerMicrosoftTest < Test::Unit::TestCase
   end
 
   def test_set_option_values_should_skip_unrecognised_options
-    assert_nothing_raised { @server.set_option_values('192.168.42.1', @network, :blah => '192.168.42.10') }
+    @server.set_option_values('192.168.42.1', @network, :blah => '192.168.42.10')
   end
 
   def test_should_delete_reservation
@@ -304,9 +304,7 @@ class DHCPServerMicrosoftTest < Test::Unit::TestCase
   end
 
   def test_validate_ip
-    assert_nothing_raised do
-      @server.validate_supported_address("192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0")
-    end
+    @server.validate_supported_address("192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0", "192.168.122.0")
   end
 
   def test_should_not_validate_ipv6

--- a/test/dns/dns_api_test.rb
+++ b/test/dns/dns_api_test.rb
@@ -74,7 +74,7 @@ end
 
 require 'dns/dns_api'
 
-class DnsApiTest < Test::Unit::TestCase
+class DnsApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def app
@@ -270,67 +270,63 @@ class DnsApiTest < Test::Unit::TestCase
 
   def test_validate_srv_value_fails_if_more_than_four_parts
     app = Proxy::Dns::Api.new!
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_value!('0 5 5060 sipserver.example.com. 1 2 3')
     end
   end
 
   def test_validate_srv_value_fails_if_priority_weight_port_not_integer
     app = Proxy::Dns::Api.new!
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_value!('a 5 5060 sipserver.example.com.')
     end
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_value!('0 % 5060 sipserver.example.com.')
     end
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_value!('0 5 X sipserver.example.com.')
     end
   end
 
   def test_validate_srv_value_fails_if_priority_weight_port_exceed_range
     app = Proxy::Dns::Api.new!
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_value!('70000 5 5060 sipserver.example.com.')
     end
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_value!('0 70000 5060 sipserver.example.com.')
     end
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_value!('0 5 70000 sipserver.example.com.')
     end
   end
 
   def test_validate_srv_value_fails_if_fewer_than_four_parts
     app = Proxy::Dns::Api.new!
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_value!('0 5 sipserver.example.com.')
     end
   end
 
   def test_validate_srv_name_allows_correct_input
     app = Proxy::Dns::Api.new!
-    assert_nothing_raised do
-      app.validate_srv_name!('_sip._tcp.example.com')
-    end
-    assert_nothing_raised do
-      app.validate_srv_name!('sipserver.example.com.')
-    end
+    app.validate_srv_name!('_sip._tcp.example.com')
+    app.validate_srv_name!('sipserver.example.com.')
   end
 
   def test_validate_srv_name_fails_if_srv_name_blank
     app = Proxy::Dns::Api.new!
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_name!(' ')
     end
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_name!('')
     end
   end
 
   def test_validate_srv_name_fails_if_srv_name_contains_inappropriate_chars
     app = Proxy::Dns::Api.new!
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       app.validate_srv_name!('google com')
     end
   end

--- a/test/dns/dns_config_test.rb
+++ b/test/dns/dns_config_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'dns/dns'
 
-class DnsConfigTest < Test::Unit::TestCase
+class DnsConfigTest < Minitest::Test
   def test_omitted_settings_have_default_values
     Proxy::Dns::Plugin.load_test_settings()
     assert_equal 'dns_nsupdate', Proxy::Dns::Plugin.settings.use_provider

--- a/test/dns_common/record_test.rb
+++ b/test/dns_common/record_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'dns_common/dns_common'
 
-class DnsRecordTest < Test::Unit::TestCase
+class DnsRecordTest < Minitest::Test
   def setup
     @record = Proxy::Dns::Record.new
   end
@@ -15,7 +15,7 @@ class DnsRecordTest < Test::Unit::TestCase
   end
 
   def test_ptr_to_ip_without_record_exception
-    assert_raise Proxy::Dns::Error do
+    assert_raises Proxy::Dns::Error do
       Proxy::Dns::Record.new.ptr_to_ip('host.example.com')
     end
   end
@@ -92,7 +92,7 @@ class DnsRecordTest < Test::Unit::TestCase
   def test_create_duplicate_a_record_fails
     Proxy::Dns::Record.any_instance.expects(:a_record_conflicts).returns(1)
 
-    assert_raise Proxy::Dns::Collision do
+    assert_raises Proxy::Dns::Collision do
       Proxy::Dns::Record.new.create_a_record('some.host', '2001:db8::1')
     end
   end
@@ -113,7 +113,7 @@ class DnsRecordTest < Test::Unit::TestCase
   def test_create_duplicate_aaaa_record_fails
     Proxy::Dns::Record.any_instance.expects(:aaaa_record_conflicts).returns(1)
 
-    assert_raise Proxy::Dns::Collision do
+    assert_raises Proxy::Dns::Collision do
       Proxy::Dns::Record.new.create_aaaa_record('some.host', '2001:db8::1')
     end
   end
@@ -134,7 +134,7 @@ class DnsRecordTest < Test::Unit::TestCase
   def test_create_duplicate_cname_record_fails
     Proxy::Dns::Record.any_instance.expects(:cname_record_conflicts).returns(1)
 
-    assert_raise Proxy::Dns::Collision do
+    assert_raises Proxy::Dns::Collision do
       Proxy::Dns::Record.new.create_cname_record('some.host', 'target.example.com')
     end
   end
@@ -155,7 +155,7 @@ class DnsRecordTest < Test::Unit::TestCase
   def test_create_duplicate_ptr_record_fails
     Proxy::Dns::Record.any_instance.expects(:ptr_record_conflicts).returns(1)
 
-    assert_raise Proxy::Dns::Collision do
+    assert_raises Proxy::Dns::Collision do
       Proxy::Dns::Record.new.create_ptr_record('some.host', '22.33.168.192.in-addr.arpa')
     end
   end

--- a/test/dns_dnscmd/dnscmd_config_test.rb
+++ b/test/dns_dnscmd/dnscmd_config_test.rb
@@ -4,14 +4,14 @@ require 'dns_dnscmd/plugin_configuration'
 require 'dns_dnscmd/dns_dnscmd_plugin'
 require 'dns_dnscmd/dns_dnscmd_main'
 
-class DnsCmdConfigTest < Test::Unit::TestCase
+class DnsCmdConfigTest < Minitest::Test
   def test_default_configuration
     ::Proxy::Dns::Dnscmd::Plugin.load_test_settings()
     assert_equal 'localhost', ::Proxy::Dns::Dnscmd::Plugin.settings.dns_server
   end
 end
 
-class DnsCmdWiringTest < Test::Unit::TestCase
+class DnsCmdWiringTest < Minitest::Test
   def setup
     @container = ::Proxy::DependencyInjection::Container.new
     @config = ::Proxy::Dns::Dnscmd::PluginConfiguration.new

--- a/test/dns_dnscmd/dnscmd_test.rb
+++ b/test/dns_dnscmd/dnscmd_test.rb
@@ -9,7 +9,7 @@ class DnscmdForTesting < Proxy::Dns::Dnscmd::Record
   attr_accessor :enum_zones
 end
 
-class DnsCmdTest < Test::Unit::TestCase
+class DnsCmdTest < Minitest::Test
   def setup
     @server = DnscmdForTesting.new(["_msdcs.bar.domain.local",
                                     "168.192.in-addr.arpa",
@@ -78,13 +78,13 @@ class DnsCmdTest < Test::Unit::TestCase
   end
 
   def test_dns_non_authoritative_zone_raises_exception
-    assert_raise Proxy::Dns::NotFound do
+    assert_raises Proxy::Dns::NotFound do
       @server.match_zone('host.foo.bar.domain.com', ['domain.local'])
     end
-    assert_raise Proxy::Dns::NotFound do
+    assert_raises Proxy::Dns::NotFound do
       @server.match_zone('33.33.16.192.in-addr.arpa', ['168.192.in-addr.arpa'])
     end
-    assert_raise Proxy::Dns::NotFound do
+    assert_raises Proxy::Dns::NotFound do
       @server.match_zone('1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.f.e.e.d.8.b.d.1.1.0.0.2.ip6.arpa', ['f.e.e.d.8.b.d.0.1.0.0.2.ip6.arpa'])
     end
   end

--- a/test/dns_libvirt/dns_libvirt_configuration_test.rb
+++ b/test/dns_libvirt/dns_libvirt_configuration_test.rb
@@ -2,14 +2,14 @@ require 'test_helper'
 require 'dns_libvirt/plugin_configuration'
 require 'dns_libvirt/dns_libvirt_main'
 
-class DnsLibvirtConfigTest < Test::Unit::TestCase
+class DnsLibvirtConfigTest < Minitest::Test
   def test_default_settings
     ::Proxy::Dns::Libvirt::Plugin.load_test_settings()
     assert_equal 'default', Proxy::Dns::Libvirt::Plugin.settings.network
   end
 end
 
-class DnsLibvirtWiringTest < Test::Unit::TestCase
+class DnsLibvirtWiringTest < Minitest::Test
   def setup
     @container = ::Proxy::DependencyInjection::Container.new
     @config = ::Proxy::Dns::Libvirt::PluginConfiguration.new

--- a/test/dns_libvirt/dns_libvirt_provider_test.rb
+++ b/test/dns_libvirt/dns_libvirt_provider_test.rb
@@ -3,7 +3,7 @@ require 'dns_libvirt/plugin_configuration'
 require 'dns_libvirt/dns_libvirt_plugin'
 require 'dns_libvirt/dns_libvirt_main'
 
-class DnsLibvirtProviderTest < Test::Unit::TestCase
+class DnsLibvirtProviderTest < Minitest::Test
   def setup
     fixture = <<~XMLFIXTURE
       <network>
@@ -58,7 +58,7 @@ class DnsLibvirtProviderTest < Test::Unit::TestCase
   end
 
   def test_del_a_record_failure
-    assert_raise Proxy::Dns::NotFound do
+    assert_raises Proxy::Dns::NotFound do
       @subject.remove_a_record('does_not_exist')
     end
   end

--- a/test/dns_libvirt/libvirt_dns_network_test.rb
+++ b/test/dns_libvirt/libvirt_dns_network_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'ostruct'
 require 'dns_libvirt/libvirt_dns_network'
 
-class LibvirtDNSNetworkTest < Test::Unit::TestCase
+class LibvirtDNSNetworkTest < Minitest::Test
   def setup
     @connection = mock()
     @network = mock()

--- a/test/dns_nsupdate/dns_nsupdate_config_test.rb
+++ b/test/dns_nsupdate/dns_nsupdate_config_test.rb
@@ -5,7 +5,7 @@ require 'dns_nsupdate/dns_nsupdate_main'
 require 'dns_nsupdate/dns_nsupdate_gss'
 require 'dns_nsupdate/dns_nsupdate_gss_main'
 
-class DnsNsupdateConfigTest < Test::Unit::TestCase
+class DnsNsupdateConfigTest < Minitest::Test
   def test_nsupdate_default_settings
     Proxy::Dns::Nsupdate::Plugin.load_test_settings()
 
@@ -24,7 +24,7 @@ end
 
 require 'dns_nsupdate/nsupdate_configuration'
 
-class DnsNsupdateWiringTest < Test::Unit::TestCase
+class DnsNsupdateWiringTest < Minitest::Test
   def setup
     @container = ::Proxy::DependencyInjection::Container.new
     @config = ::Proxy::Dns::Nsupdate::PluginConfiguration.new
@@ -40,7 +40,7 @@ class DnsNsupdateWiringTest < Test::Unit::TestCase
   end
 end
 
-class DnsNsupdateGSSWiringTest < Test::Unit::TestCase
+class DnsNsupdateGSSWiringTest < Minitest::Test
   def setup
     @container = ::Proxy::DependencyInjection::Container.new
     @config = ::Proxy::Dns::NsupdateGSS::PluginConfiguration.new

--- a/test/dns_nsupdate/dns_nsupdate_test.rb
+++ b/test/dns_nsupdate/dns_nsupdate_test.rb
@@ -4,7 +4,7 @@ require 'dns_nsupdate/nsupdate_configuration'
 require 'dns_nsupdate/dns_nsupdate_plugin'
 require 'dns_nsupdate/dns_nsupdate_main'
 
-class DnsNsupdateTest < Test::Unit::TestCase
+class DnsNsupdateTest < Minitest::Test
   def test_do_create_ptr
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate_connect).returns(true)
     Proxy::Dns::Nsupdate::Record.any_instance.expects(:nsupdate).with('update add 33.33.168.192.in-addr.arpa. 100 PTR some.host').returns(true)

--- a/test/global_settings_test.rb
+++ b/test/global_settings_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class GlobalSettingsTest < Test::Unit::TestCase
+class GlobalSettingsTest < Minitest::Test
   def test_default_values
     settings = ::Proxy::Settings::Global.new({})
     assert_equal Pathname.new(__dir__).join("..", "config", "settings.d").expand_path.to_s, settings.settings_directory

--- a/test/http_download_test.rb
+++ b/test/http_download_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'tmpdir'
 
-class HttpDownloadsTest < Test::Unit::TestCase
+class HttpDownloadsTest < Minitest::Test
   def setup
     @timeout = Proxy::HttpDownload::DEFAULT_CONNECT_TIMEOUT
     Proxy::HttpDownload.any_instance.stubs(:which).returns('/usr/bin/curl')
@@ -52,7 +52,7 @@ class HttpDownloadsTest < Test::Unit::TestCase
   end
 end
 
-class HttpDownloadsIntegrationTest < Test::Unit::TestCase
+class HttpDownloadsIntegrationTest < Minitest::Test
   def setup
     @server = WEBrick::HTTPServer.new(Port: 0)
     @server.mount_proc '/200' do |req, res|

--- a/test/httpboot/httpboot_api_test.rb
+++ b/test/httpboot/httpboot_api_test.rb
@@ -5,7 +5,7 @@ require 'httpboot/httpboot_api'
 
 ENV['RACK_ENV'] = 'test'
 
-class HttpbootApiTest < Test::Unit::TestCase
+class HttpbootApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/httpboot/integration_test.rb
+++ b/test/httpboot/integration_test.rb
@@ -4,6 +4,20 @@ require 'root/root_v2_api'
 require 'httpboot/httpboot_plugin'
 
 class HttpbootApiFeaturesTest < SmartProxyRootApiTestCase
+  def setup
+    super
+    @http_port = Proxy::SETTINGS.http_port
+    @https_port = Proxy::SETTINGS.https_port
+    Proxy::SETTINGS.http_port = nil
+    Proxy::SETTINGS.https_port = 8443
+  end
+
+  def teardown
+    Proxy::SETTINGS.http_port = @http_port
+    Proxy::SETTINGS.https_port = @https_port
+    super
+  end
+
   def test_features
     Proxy::DefaultModuleLoader.any_instance.expects(:load_configuration_file).with('httpboot.yml').returns(enabled: true, root_dir: '/var/lib/tftpboot')
 

--- a/test/launcher_test.rb
+++ b/test/launcher_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'launcher'
 
-class LauncherTest < Test::Unit::TestCase
+class LauncherTest < Minitest::Test
   def setup
     @launcher = Proxy::Launcher.new
   end
@@ -23,7 +23,7 @@ class LauncherTest < Test::Unit::TestCase
   end
 end
 
-class LauncherTlsCiphersTest < Test::Unit::TestCase
+class LauncherTlsCiphersTest < Minitest::Test
   def setup
     @launcher = Proxy::Launcher.new
   end
@@ -90,7 +90,7 @@ class LauncherTlsCiphersTest < Test::Unit::TestCase
     launcher = launcher_with(tls_min_version: '1.3')
     File.stubs(:exist?).with(CRYPTO_POLICIES_CONFIG).returns(false)
     launcher.logger.stubs(:debug)
-    assert_nothing_raised { launcher.validate_tls_ciphers!(launcher.resolve_tls_ciphers) }
+    launcher.validate_tls_ciphers!(launcher.resolve_tls_ciphers)
   end
 
   def test_validate_tls_ciphers_warns_when_ciphersuites_method_absent_and_tls_ciphers_set
@@ -112,7 +112,7 @@ class LauncherTlsCiphersTest < Test::Unit::TestCase
   end
 end
 
-class LauncherTlsMinVersionTest < Test::Unit::TestCase
+class LauncherTlsMinVersionTest < Minitest::Test
   def test_resolve_tls_min_version_raises_on_invalid_version
     settings = Proxy::Settings::Global.new(tls_min_version: '1.4')
     launcher = Proxy::Launcher.new(settings)
@@ -135,7 +135,7 @@ class LauncherTlsMinVersionTest < Test::Unit::TestCase
   end
 end
 
-class LauncherWebrickSslTest < Test::Unit::TestCase
+class LauncherWebrickSslTest < Minitest::Test
   def setup
     cert, key = WEBrick::Utils.create_self_signed_cert(2048, [['CN', 'test']], 'test')
     @ssl_app = {
@@ -174,7 +174,7 @@ class LauncherWebrickSslTest < Test::Unit::TestCase
   end
 end
 
-class LauncherSslCipherTest < Test::Unit::TestCase
+class LauncherSslCipherTest < Minitest::Test
   SSL_FIXTURES = File.expand_path(File.join(__dir__, 'fixtures', 'ssl')).freeze
 
   def launcher_with_cipher(cipher)

--- a/test/log_buffer/buffer_test.rb
+++ b/test/log_buffer/buffer_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class BufferTest < Test::Unit::TestCase
+class BufferTest < Minitest::Test
   SIZE = 3
   SIZE_TAIL = 2
 

--- a/test/log_buffer/decorator_test.rb
+++ b/test/log_buffer/decorator_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class DecoratorTest < Test::Unit::TestCase
+class DecoratorTest < Minitest::Test
   class DecoratorForTesting < ::Proxy::LogBuffer::Decorator
     attr_reader :logger
   end
@@ -92,7 +92,7 @@ class DecoratorTest < Test::Unit::TestCase
     ::Logging.mdc['request'] = request_id
     @decorator.error('error message')
 
-    assert_false @buffer.to_a.empty?
+    refute @buffer.to_a.empty?
     assert_equal request_id, @buffer.to_a.first.request_id
   ensure
     ::Logging.mdc['request'] = nil

--- a/test/log_buffer/ring_buffer_test.rb
+++ b/test/log_buffer/ring_buffer_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class RingBufferTest < Test::Unit::TestCase
+class RingBufferTest < Minitest::Test
   SIZE = 3
 
   def setup

--- a/test/logs/logs_api_test.rb
+++ b/test/logs/logs_api_test.rb
@@ -4,7 +4,7 @@ require 'logs/logs_api'
 
 ENV['RACK_ENV'] = 'test'
 
-class LogsApiTest < Test::Unit::TestCase
+class LogsApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/memory_store_test.rb
+++ b/test/memory_store_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 require 'set'
 
-class MemoryStoreTest < Test::Unit::TestCase
+class MemoryStoreTest < Minitest::Test
   def setup
     @store = Proxy::MemoryStore.new
   end
 
   def test_should_return_nil_when_key_does_not_exist
-    assert_equal nil, @store["key"]
+    assert_nil @store["key"]
   end
 
   def test_should_store

--- a/test/migrations/autosign_migration_test.rb
+++ b/test/migrations/autosign_migration_test.rb
@@ -4,7 +4,7 @@ require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
 require File.join(__dir__, '../../extra/migrations/20170523000000_migrate_autosign_setting.rb')
 
-class ProxyAutosignMigrationTest < Test::Unit::TestCase
+class ProxyAutosignMigrationTest < Minitest::Test
   def setup
     @migration = MigrateAutosignSetting.new("/tmp")
   end

--- a/test/migrations/dhcp_migration_test.rb
+++ b/test/migrations/dhcp_migration_test.rb
@@ -4,7 +4,7 @@ require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
 require File.join(__dir__, '../../extra/migrations/20150826000000_migrate_dhcp_settings')
 
-class ProxyDhcpMigrationTest < Test::Unit::TestCase
+class ProxyDhcpMigrationTest < Minitest::Test
   def setup
     @migration = MigrateDhcpSettings.new("/tmp")
   end

--- a/test/migrations/dns_migration_test.rb
+++ b/test/migrations/dns_migration_test.rb
@@ -3,7 +3,7 @@ require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
 require File.join(__dir__, '../../extra/migrations/20150611000000_migrate_dns_settings')
 
-class ProxyDnsMigrationTest < Test::Unit::TestCase
+class ProxyDnsMigrationTest < Minitest::Test
   def setup
     @old_config = YAML.load_file(File.join(__dir__, './migration_dns_settings.yml'))
     @migration = MigrateDnsSettings.new("/tmp")

--- a/test/migrations/libvirt_migration_test.rb
+++ b/test/migrations/libvirt_migration_test.rb
@@ -3,7 +3,7 @@ require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
 require File.join(__dir__, '../../extra/migrations/20160411000000_migrate_libvirt_settings')
 
-class ProxyLibvirtMigrationTest < Test::Unit::TestCase
+class ProxyLibvirtMigrationTest < Minitest::Test
   def setup
     @old_config = YAML.load_file(File.join(__dir__, './migration_settings.yml'))
     @migration = MigrateVirshToLibvirtConfig.new("/tmp")

--- a/test/migrations/migration_test.rb
+++ b/test/migrations/migration_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require File.join(__dir__, '../../extra/migrate_settings')
 
-class MigrationTest < Test::Unit::TestCase
+class MigrationTest < Minitest::Test
   def setup
     @module = Module.new
 
@@ -44,7 +44,7 @@ class MigrationTest < Test::Unit::TestCase
       "./work_dir", "./migrations_dir", "./config/dummy-settings.yml", "./modules_config_dir",
       ::Proxy::Migrations.new("./dummy", []))
 
-    assert_raise RuntimeError do
+    assert_raises RuntimeError do
       migrator.verify_paths
     end
   end
@@ -54,7 +54,7 @@ class MigrationTest < Test::Unit::TestCase
       "./work_dir", "./migrations_dir", "./config/dummy-settings.yml", "./modules_config_dir",
       ::Proxy::Migrations.new("./dummy", []))
     File.expects(:directory?).with("./migrations_dir").returns(true)
-    assert_raise RuntimeError do
+    assert_raises RuntimeError do
       migrator.verify_paths
     end
   end

--- a/test/migrations/monolithic_config_file_migration_test.rb
+++ b/test/migrations/monolithic_config_file_migration_test.rb
@@ -3,7 +3,7 @@ require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
 require File.join(__dir__, '../../extra/migrations/20150327000000_migrate_monolithic_config')
 
-class MonolithicConfigMigrationTest < Test::Unit::TestCase
+class MonolithicConfigMigrationTest < Minitest::Test
   def setup
     @old_config = YAML.load_file(File.join(__dir__, './migration_settings.yml'))
     @output, @unknown = MigrateMonolithicConfig.new("/tmp").migrate_monolithic_config(@old_config)

--- a/test/migrations/puppet_migration_test.rb
+++ b/test/migrations/puppet_migration_test.rb
@@ -4,7 +4,7 @@ require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
 require File.join(__dir__, '../../extra/migrations/20160413000000_migrate_puppet_settings.rb')
 
-class ProxyPuppetMigrationTest < Test::Unit::TestCase
+class ProxyPuppetMigrationTest < Minitest::Test
   def setup
     @migration = MigratePuppetSettings.new("/tmp")
   end

--- a/test/migrations/realm_migration_test.rb
+++ b/test/migrations/realm_migration_test.rb
@@ -4,7 +4,7 @@ require File.join(__dir__, '../../extra/migrate_settings')
 ::Proxy::Migration.inject_migrations_instance(::Proxy::Migrations.new("dummy"))
 require File.join(__dir__, '../../extra/migrations/20161209000000_migrate_realm_settings.rb')
 
-class ProxyRealmMigrationTest < Test::Unit::TestCase
+class ProxyRealmMigrationTest < Minitest::Test
   def setup
     @migration = MigrateRealmSettings.new("/tmp")
   end

--- a/test/plugins/module_loader_test.rb
+++ b/test/plugins/module_loader_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ModuleLoaderTest < Test::Unit::TestCase
+class ModuleLoaderTest < Minitest::Test
   class TestPlugin < ::Proxy::Plugin; end
 
   def setup

--- a/test/plugins/plugin_group_test.rb
+++ b/test/plugins/plugin_group_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PluginGroupTest < Test::Unit::TestCase
+class PluginGroupTest < Minitest::Test
   def test_group_initial_state
     group = ::Proxy::PluginGroup.new(nil)
 
@@ -244,8 +244,8 @@ class PluginGroupTest < Test::Unit::TestCase
     end
     group = ::Proxy::PluginGroup.new(TestStopServicesPlugin, [TestStopServicesProvider], di_container)
 
-    assert_not_equal :stopped, di_container.get_dependency(:service_a).state
-    assert_not_equal :stopped, di_container.get_dependency(:service_b).state
+    refute_equal :stopped, di_container.get_dependency(:service_a).state
+    refute_equal :stopped, di_container.get_dependency(:service_b).state
 
     group.stop_services
 

--- a/test/plugins/plugin_initializer_test.rb
+++ b/test/plugins/plugin_initializer_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PluginInitializerTest < Test::Unit::TestCase
+class PluginInitializerTest < Minitest::Test
   class TestPlugin1 < Proxy::Plugin
     plugin :plugin_1, "1.0"
     default_settings :enabled => true

--- a/test/plugins/plugin_test.rb
+++ b/test/plugins/plugin_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class PluginTest < Test::Unit::TestCase
+class PluginTest < Minitest::Test
   class TestPlugin2 < Proxy::Plugin; plugin :test2, '1.0'; end
   def test_http_rackup_returns_empty_string_with_missing_rackup_path
     assert_equal "", TestPlugin2.http_rackup

--- a/test/plugins/validator_test.rb
+++ b/test/plugins/validator_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class BaseValidatorTest < Test::Unit::TestCase
+class BaseValidatorTest < Minitest::Test
   class TestValidator < ::Proxy::PluginValidators::Base
     attr_reader :validate_called
 
@@ -36,7 +36,7 @@ class BaseValidatorTest < Test::Unit::TestCase
   end
 end
 
-class FileReadableValidatorTest < Test::Unit::TestCase
+class FileReadableValidatorTest < Minitest::Test
   class FileReadableValidatorTestPlugin < ::Proxy::Plugin
     default_settings :a_setting => 'some_file'
   end
@@ -64,7 +64,7 @@ class FileReadableValidatorTest < Test::Unit::TestCase
   end
 end
 
-class PresenceValidatorTest < Test::Unit::TestCase
+class PresenceValidatorTest < Minitest::Test
   class PresenceValidatorTestPlugin < ::Proxy::Plugin
     default_settings :a_setting => 'some_file'
   end
@@ -92,7 +92,7 @@ class PresenceValidatorTest < Test::Unit::TestCase
   end
 end
 
-class UrlValidatorTest < Test::Unit::TestCase
+class UrlValidatorTest < Minitest::Test
   class UrlValidatorTestPlugin < ::Proxy::Plugin
     default_settings :a_setting => 'http://example.com'
   end
@@ -134,7 +134,7 @@ class UrlValidatorTest < Test::Unit::TestCase
   end
 end
 
-class OptionalUrlValidatorTest < Test::Unit::TestCase
+class OptionalUrlValidatorTest < Minitest::Test
   class OptionalUrlValidatorTestPlugin < ::Proxy::Plugin
     default_settings url: 'http://example.com'
   end
@@ -168,7 +168,7 @@ class OptionalUrlValidatorTest < Test::Unit::TestCase
   end
 end
 
-class BooleanValidatorTest < Test::Unit::TestCase
+class BooleanValidatorTest < Minitest::Test
   class BooleanValidatorTestPlugin < ::Proxy::Plugin
     default_settings :a_settting => true
   end
@@ -202,7 +202,7 @@ class BooleanValidatorTest < Test::Unit::TestCase
   end
 end
 
-class EnumValidatorTest < Test::Unit::TestCase
+class EnumValidatorTest < Minitest::Test
   class TestPlugin < ::Proxy::Plugin
   end
 
@@ -219,20 +219,23 @@ class EnumValidatorTest < Test::Unit::TestCase
   end
 
   def test_an_invalid_value_fails_validation
-    assert_raise_with_message ::Proxy::Error::ConfigurationError, "Parameter 'drink' must be one of beer, whisky" do
+    error = assert_raises ::Proxy::Error::ConfigurationError do
       validator.validate!(drink: 'wine')
     end
+    assert_equal "Parameter 'drink' must be one of beer, whisky", error.message
   end
 
   def test_empty_string_fails_validation
-    assert_raise_with_message ::Proxy::Error::ConfigurationError, "Parameter 'drink' must be one of beer, whisky" do
+    error = assert_raises ::Proxy::Error::ConfigurationError do
       validator.validate!(drink: '')
     end
+    assert_equal "Parameter 'drink' must be one of beer, whisky", error.message
   end
 
   def test_nil_fails_validation
-    assert_raise_with_message ::Proxy::Error::ConfigurationError, "Parameter 'drink' must be one of beer, whisky" do
+    error = assert_raises ::Proxy::Error::ConfigurationError do
       validator.validate!(drink: nil)
     end
+    assert_equal "Parameter 'drink' must be one of beer, whisky", error.message
   end
 end

--- a/test/puppet/api_request_test.rb
+++ b/test/puppet/api_request_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 require 'puppet_proxy_common/api_request'
 require 'puppet_proxy_puppet_api/v3_api_request'
-require 'webmock/test_unit'
+require 'webmock/minitest'
 
-class PuppetApiRequestTest < Test::Unit::TestCase
+class PuppetApiRequestTest < Minitest::Test
   def test_get_environments_apiv3
     stub_request(:get, 'http://localhost:8140/puppet/v3/environments').to_return(:body => '{"environments":{}}')
     result = Proxy::PuppetApi::EnvironmentsApiv3.new('http://localhost:8140', nil, nil, nil).find_environments

--- a/test/puppet/puppet_api_configuration_test.rb
+++ b/test/puppet/puppet_api_configuration_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'puppet_proxy_puppet_api/puppet_proxy_puppet_api'
 
-class PuppetApiConfigurationTest < Test::Unit::TestCase
+class PuppetApiConfigurationTest < Minitest::Test
   def setup
     @configuration = ::Proxy::PuppetApi::PluginConfiguration.new
   end
@@ -15,7 +15,7 @@ class PuppetApiConfigurationTest < Test::Unit::TestCase
   end
 end
 
-class PuppetApiDefaultSettingsTest < Test::Unit::TestCase
+class PuppetApiDefaultSettingsTest < Minitest::Test
   def test_default_settings
     Proxy::PuppetApi::Plugin.load_test_settings()
     assert_equal '/var/lib/puppet/ssl/certs/ca.pem', Proxy::PuppetApi::Plugin.settings.puppet_ssl_ca
@@ -28,7 +28,7 @@ require 'puppet_proxy_puppet_api/v3_api_request'
 require 'puppet_proxy_puppet_api/v3_environments_retriever'
 require 'puppet_proxy_puppet_api/v3_environment_classes_api_classes_retriever'
 
-class PuppetApiDIWiringsTest < Test::Unit::TestCase
+class PuppetApiDIWiringsTest < Minitest::Test
   def setup
     @configuration = ::Proxy::PuppetApi::PluginConfiguration.new
     @container = ::Proxy::DependencyInjection::Container.new

--- a/test/puppet/puppet_api_environments_retriever_test.rb
+++ b/test/puppet/puppet_api_environments_retriever_test.rb
@@ -4,7 +4,7 @@ require 'puppet_proxy_common/environments_retriever_base'
 require 'puppet_proxy_common/errors'
 require 'puppet_proxy_puppet_api/v3_environments_retriever'
 
-class PuppetApiV3EnvironmentsRetrieverTest < Test::Unit::TestCase
+class PuppetApiV3EnvironmentsRetrieverTest < Minitest::Test
   class EnvironmentApiForTesting
     attr_accessor :find_environments_response
     def find_environments

--- a/test/puppet/puppet_api_test.rb
+++ b/test/puppet/puppet_api_test.rb
@@ -73,7 +73,7 @@ require 'puppet_proxy/puppet_api'
 
 ENV['RACK_ENV'] = 'test'
 
-class PuppetApiTest < Test::Unit::TestCase
+class PuppetApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def setup

--- a/test/puppet/puppet_api_v3_environment_classes_retriever_test.rb
+++ b/test/puppet/puppet_api_v3_environment_classes_retriever_test.rb
@@ -206,7 +206,7 @@ class EnvironmentClassesApiRetrieverForTesting < Proxy::PuppetApi::V3Environment
   attr_accessor :etag_cache, :classes_cache, :futures_cache
 end
 
-class PuppetApiv3EnvironmentClassesApiRetrieverTest < Test::Unit::TestCase
+class PuppetApiv3EnvironmentClassesApiRetrieverTest < Minitest::Test
   include PuppetApiv3EnvironmentClassesApiRetrieverTests
   include PuppetApiv3EnvironmentClassesApiParsingTests
 end

--- a/test/puppet/puppet_class_test.rb
+++ b/test/puppet/puppet_class_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'puppet_proxy_common/puppet_class'
 
-class PuppetClassTest < Test::Unit::TestCase
+class PuppetClassTest < Minitest::Test
   def test_should_parse_modulename_correctly
     klass = Proxy::Puppet::PuppetClass.new "foreman_proxy::install"
     assert_equal "foreman_proxy", klass.module

--- a/test/puppetca/puppetca_api_test.rb
+++ b/test/puppetca/puppetca_api_test.rb
@@ -33,7 +33,7 @@ end
 
 require 'puppetca/puppetca_api'
 
-class PuppetcaApiTest < Test::Unit::TestCase
+class PuppetcaApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_autosigner_test.rb
+++ b/test/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_autosigner_test.rb
@@ -6,7 +6,7 @@ require 'puppetca/puppetca'
 require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting'
 require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_autosigner'
 
-class PuppetCaHostnameWhitelistingAutosignerTest < Test::Unit::TestCase
+class PuppetCaHostnameWhitelistingAutosignerTest < Minitest::Test
   def setup
     @file = Tempfile.new('autosign_test')
     begin
@@ -36,7 +36,7 @@ class PuppetCaHostnameWhitelistingAutosignerTest < Test::Unit::TestCase
       @file.close
       @file.unlink
     end
-    assert_true content.include?('foobar.example.com')
+    assert content.include?('foobar.example.com')
   end
 
   def test_should_not_duplicate_autosign_entry
@@ -62,7 +62,7 @@ class PuppetCaHostnameWhitelistingAutosignerTest < Test::Unit::TestCase
       @file.close
       @file.unlink
     end
-    assert_false content.split("\n").include?('foo.example.com')
-    assert_true content.end_with?("\n")
+    refute content.split("\n").include?('foo.example.com')
+    assert content.end_with?("\n")
   end
 end

--- a/test/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_config_test.rb
+++ b/test/puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_config_test.rb
@@ -3,7 +3,7 @@ require 'puppetca/puppetca'
 require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting'
 require 'puppetca_hostname_whitelisting/puppetca_hostname_whitelisting_plugin'
 
-class PuppetCaHostnameWhitelistingConfigTest < Test::Unit::TestCase
+class PuppetCaHostnameWhitelistingConfigTest < Minitest::Test
   def test_omitted_settings_have_default_values
     Proxy::PuppetCa::HostnameWhitelisting::Plugin.load_test_settings()
     assert_equal '/etc/puppet/autosign.conf', Proxy::PuppetCa::HostnameWhitelisting::Plugin.settings.autosignfile

--- a/test/puppetca_http_api/ca_v1_api_request_test.rb
+++ b/test/puppetca_http_api/ca_v1_api_request_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'puppetca_http_api/puppetca_http_api'
 require 'puppetca_http_api/ca_v1_api_request'
 
-class CaApiv1RequestTest < Test::Unit::TestCase
+class CaApiv1RequestTest < Minitest::Test
   def setup
     @client = Proxy::PuppetCa::PuppetcaHttpApi::CaApiv1Request.new('https://puppet:8140/', nil, nil, nil)
   end

--- a/test/puppetca_http_api/puppetca_http_api_config_test.rb
+++ b/test/puppetca_http_api/puppetca_http_api_config_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'puppetca_http_api/puppetca_http_api'
 
-class PuppetCaHttpApiConfigTest < Test::Unit::TestCase
+class PuppetCaHttpApiConfigTest < Minitest::Test
   def test_omitted_settings_have_default_values
     Proxy::PuppetCa::PuppetcaHttpApi::Plugin.load_test_settings()
     assert_equal '/etc/puppetlabs/puppet/ssl/certs/ca.pem', Proxy::PuppetCa::PuppetcaHttpApi::Plugin.settings.puppet_ssl_ca

--- a/test/puppetca_http_api/puppetca_http_impl_test.rb
+++ b/test/puppetca_http_api/puppetca_http_impl_test.rb
@@ -3,7 +3,7 @@ require 'puppetca/puppetca'
 require 'puppetca/dependency_injection'
 require 'puppetca_http_api/puppetca_impl'
 
-class PuppetCaHttpImplTest < Test::Unit::TestCase
+class PuppetCaHttpImplTest < Minitest::Test
   class FakeCaApiV1Request
     def sign(certname)
     end

--- a/test/puppetca_token_whitelisting/puppetca_token_whitelisting_autosigner_test.rb
+++ b/test/puppetca_token_whitelisting/puppetca_token_whitelisting_autosigner_test.rb
@@ -11,7 +11,7 @@ require 'puppetca_token_whitelisting/puppetca_token_whitelisting_autosigner'
 require 'puppetca_token_whitelisting/puppetca_token_whitelisting_csr'
 require 'puppetca_token_whitelisting/puppetca_token_whitelisting_token_storage'
 
-class PuppetCaTokenWhitelistingAutosignerTest < Test::Unit::TestCase
+class PuppetCaTokenWhitelistingAutosignerTest < Minitest::Test
   def setup
     @file = Tempfile.new('autosign_test')
     begin
@@ -58,34 +58,34 @@ class PuppetCaTokenWhitelistingAutosignerTest < Test::Unit::TestCase
 
   def test_should_validate_on_sign_all
     @autosigner.stubs(:sign_all).returns(true)
-    assert_true @autosigner.validate_csr ''
+    assert @autosigner.validate_csr ''
   end
 
   def test_should_call_verification
     csr_example = File.read './test/fixtures/puppetca/csr_example.pem'
     @autosigner.expects(:validate_token).with('1234').returns(true)
-    assert_true @autosigner.validate_csr csr_example
+    assert @autosigner.validate_csr csr_example
   end
 
   def test_should_validate_a_correct_token
     response = @autosigner.autosign 'signme.example.com', 0
     token = JSON.parse(response)['generated_token']
 
-    assert_true @autosigner.validate_token token
+    assert @autosigner.validate_token token
   end
 
   def test_should_not_validate_expired_token
     payload = { certname: 'foo.example.com', exp: Time.now.to_i - 10 }
     token = JWT.encode payload, @autosigner.smartproxy_cert, 'RS512'
 
-    assert_false @autosigner.validate_token token
+    refute @autosigner.validate_token token
   end
 
   def test_should_not_validate_token_with_invalid_certname
     payload = { certname: 'unknown.example.com', exp: Time.now.to_i + 999_999 }
     token = JWT.encode payload, @autosigner.smartproxy_cert, 'RS512'
 
-    assert_false @autosigner.validate_token token
+    refute @autosigner.validate_token token
   end
 
   def test_should_not_validate_token_with_unkown_signature
@@ -93,6 +93,6 @@ class PuppetCaTokenWhitelistingAutosignerTest < Test::Unit::TestCase
     payload = { certname: 'foo.example.com', exp: Time.now.to_i + 999_999 }
     token = JWT.encode payload, unknown_cert, 'RS512'
 
-    assert_false @autosigner.validate_token token
+    refute @autosigner.validate_token token
   end
 end

--- a/test/puppetca_token_whitelisting/puppetca_token_whitelisting_config_test.rb
+++ b/test/puppetca_token_whitelisting/puppetca_token_whitelisting_config_test.rb
@@ -3,12 +3,12 @@ require 'puppetca/puppetca'
 require 'puppetca_token_whitelisting/puppetca_token_whitelisting'
 require 'puppetca_token_whitelisting/puppetca_token_whitelisting_plugin'
 
-class PuppetCATokenWhitelistingConfigTest < Test::Unit::TestCase
+class PuppetCATokenWhitelistingConfigTest < Minitest::Test
   def test_omitted_settings_have_default_values
     Proxy::PuppetCa::TokenWhitelisting::Plugin.load_test_settings()
     assert_equal false, Proxy::PuppetCa::TokenWhitelisting::Plugin.settings.sign_all
     assert_equal '/var/lib/foreman-proxy/tokens.yml', Proxy::PuppetCa::TokenWhitelisting::Plugin.settings.tokens_file
     assert_equal 360, Proxy::PuppetCa::TokenWhitelisting::Plugin.settings.token_ttl
-    assert_equal nil, Proxy::PuppetCa::TokenWhitelisting::Plugin.settings.certificate
+    assert_nil Proxy::PuppetCa::TokenWhitelisting::Plugin.settings.certificate
   end
 end

--- a/test/puppetca_token_whitelisting/puppetca_token_whitelisting_csr_test.rb
+++ b/test/puppetca_token_whitelisting/puppetca_token_whitelisting_csr_test.rb
@@ -4,7 +4,7 @@ require 'puppetca/puppetca'
 require 'puppetca_token_whitelisting/puppetca_token_whitelisting'
 require 'puppetca_token_whitelisting/puppetca_token_whitelisting_csr'
 
-class PuppetCaTokenWhitelistingCSRTest < Test::Unit::TestCase
+class PuppetCaTokenWhitelistingCSRTest < Minitest::Test
   def setup
     @csr_example = File.read './test/fixtures/puppetca/csr_example.pem'
   end
@@ -16,7 +16,7 @@ class PuppetCaTokenWhitelistingCSRTest < Test::Unit::TestCase
 
   def test_should_fail_on_invalid_csr
     @csr_example.slice!(42...69)
-    assert_raise OpenSSL::X509::RequestError do
+    assert_raises OpenSSL::X509::RequestError do
       Proxy::PuppetCa::TokenWhitelisting::CSR.new @csr_example
     end
   end

--- a/test/puppetca_token_whitelisting/puppetca_token_whitelisting_token_storage_test.rb
+++ b/test/puppetca_token_whitelisting/puppetca_token_whitelisting_token_storage_test.rb
@@ -4,7 +4,7 @@ require 'timeout'
 require 'puppetca/puppetca'
 require 'puppetca_token_whitelisting/puppetca_token_whitelisting_token_storage'
 
-class PuppetCaTokenWhitelistingTokenStorageTest < Test::Unit::TestCase
+class PuppetCaTokenWhitelistingTokenStorageTest < Minitest::Test
   def setup
     @file = Tempfile.new('autosign_test')
     begin
@@ -46,7 +46,7 @@ class PuppetCaTokenWhitelistingTokenStorageTest < Test::Unit::TestCase
 
   def test_should_queue_writes_when_locked
     @storage.lock do
-      assert_raise Timeout::Error do
+      assert_raises Timeout::Error do
         Timeout.timeout(3) do
           @storage.write ['test']
         end

--- a/test/realm/ipa_config_parser_test.rb
+++ b/test/realm/ipa_config_parser_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'realm_freeipa/ipa_config_parser'
 
-class IpaConfigParserTest < Test::Unit::TestCase
+class IpaConfigParserTest < Minitest::Test
   def setup
     @parser = Proxy::FreeIPARealm::IpaConfigParser.new(File.expand_path("realm.conf", File.expand_path(__dir__)))
   end

--- a/test/realm/realm_api_test.rb
+++ b/test/realm/realm_api_test.rb
@@ -6,7 +6,7 @@ require 'realm/realm_api'
 
 ENV['RACK_ENV'] = 'test'
 
-class RealmApiTest < Test::Unit::TestCase
+class RealmApiTest < Minitest::Test
   include Rack::Test::Methods
 
   class RealmProviderForTesting

--- a/test/realm_freeipa/freeipa_provider_test.rb
+++ b/test/realm_freeipa/freeipa_provider_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'xmlrpc/client'
 require 'realm_freeipa/provider'
 
-class FreeIPATest < Test::Unit::TestCase
+class FreeIPATest < Minitest::Test
   class IpaConfigParserForTesting
     attr_reader :realm
 
@@ -47,7 +47,7 @@ class FreeIPATest < Test::Unit::TestCase
 
   def test_delete
     ok_result = {:a => 'a'}
-    @provider.expects(:ipa_call).with('host_del', ['a_host'], 'updatedns' => true).returns(ok_result)
+    @provider.expects(:ipa_call).with('host_del', ['a_host'], {'updatedns' => true}).returns(ok_result)
     assert_equal JSON.pretty_generate(ok_result), @provider.delete(@realm, 'a_host')
   end
 
@@ -57,13 +57,13 @@ class FreeIPATest < Test::Unit::TestCase
 
   def test_delete_respects_remove_dns_parameter
     provider = Proxy::FreeIPARealm::Provider.new(@ipa_config, 'keytab', 'prinicipal', false, false)
-    provider.expects(:ipa_call).with('host_del', ['a_host'], 'updatedns' => false).returns(true)
+    provider.expects(:ipa_call).with('host_del', ['a_host'], {'updatedns' => false}).returns(true)
     provider.delete(@realm, 'a_host')
   end
 
   def test_delete_if_host_does_not_exist_and_remove_dns_is_true
-    @provider.expects(:ipa_call).with('host_del', ['a_host'], 'updatedns' => true).raises(StandardError)
-    @provider.expects(:ipa_call).with('host_del', ['a_host'], 'updatedns' => false).returns(true)
+    @provider.expects(:ipa_call).with('host_del', ['a_host'], {'updatedns' => true}).raises(StandardError)
+    @provider.expects(:ipa_call).with('host_del', ['a_host'], {'updatedns' => false}).returns(true)
     @provider.delete(@realm, 'a_host')
   end
 
@@ -72,7 +72,7 @@ class FreeIPATest < Test::Unit::TestCase
     setattr = 'userclass'
     @provider.expects(:find).with(hostname).returns('result' => {'has_keytab' => true})
     @provider.expects(:ipa_call).with('host_disable', [hostname])
-    @provider.expects(:ipa_call).with('host_mod', [hostname], :random => 1, :setattr => ['userclass=userclass']).returns({})
+    @provider.expects(:ipa_call).with('host_mod', [hostname], {:random => 1, :setattr => ['userclass=userclass']}).returns({})
     @provider.create(@realm, hostname, :rebuild => 'true', setattr => setattr)
   end
 
@@ -80,7 +80,7 @@ class FreeIPATest < Test::Unit::TestCase
     hostname = 'hostname'
     setattr = 'userclass'
     @provider.expects(:find).with(hostname).returns('result' => {})
-    @provider.expects(:ipa_call).with('host_mod', [hostname], :setattr => ['userclass=userclass']).returns({})
+    @provider.expects(:ipa_call).with('host_mod', [hostname], {:setattr => ['userclass=userclass']}).returns({})
     @provider.create(@realm, hostname, setattr => setattr)
   end
 
@@ -88,7 +88,7 @@ class FreeIPATest < Test::Unit::TestCase
     hostname = 'hostname'
     setattr = 'userclass'
     @provider.expects(:find).with(hostname).returns(nil)
-    @provider.expects(:ipa_call).with('host_add', [hostname], :random => 1, :force => 1, :setattr => ['userclass=userclass']).returns({})
+    @provider.expects(:ipa_call).with('host_add', [hostname], {:random => 1, :force => 1, :setattr => ['userclass=userclass']}).returns({})
     @provider.create(@realm, hostname, setattr => setattr)
   end
 

--- a/test/registration/registration_api_test.rb
+++ b/test/registration/registration_api_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'registration/registration_api'
 
-class RegistrationRegisterApiTest < Test::Unit::TestCase
+class RegistrationRegisterApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def app
@@ -27,6 +27,7 @@ class RegistrationRegisterApiTest < Test::Unit::TestCase
   def setup
     @foreman_url = 'http://foreman.example.com'
     Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)
+    Proxy::Registration::Plugin.load_test_settings(:registration_url => nil)
     # Clear class-level state between tests to prevent cross-test contamination
     Proxy::Registration::Api.registration_script_cache.clear
     Proxy::Registration::Api::KEY_MUTEXES.clear

--- a/test/request_test.rb
+++ b/test/request_test.rb
@@ -5,9 +5,9 @@ require 'mocha'
 require 'templates/templates_plugin'
 require "proxy/util"
 require 'proxy/request'
-require 'webmock/test_unit'
+require 'webmock/minitest'
 
-class RequestTest < Test::Unit::TestCase
+class RequestTest < Minitest::Test
   def setup
     @foreman_url = 'https://foreman.example.com'
     Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)

--- a/test/root/root_api_test.rb
+++ b/test/root/root_api_test.rb
@@ -17,7 +17,7 @@ class TestPlugin3 < ::Proxy::Plugin
   plugin :test3, "0.0.1"
 end
 
-class RootApiTest < Test::Unit::TestCase
+class RootApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/root/root_v2_api_test.rb
+++ b/test/root/root_v2_api_test.rb
@@ -17,7 +17,7 @@ class TestPlugin3 < ::Proxy::Plugin
   plugin :test3, "0.0.1"
 end
 
-class RootV2ApiTest < Test::Unit::TestCase
+class RootV2ApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/sinatra/authorization_helpers_test.rb
+++ b/test/sinatra/authorization_helpers_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'sinatra/base'
 
-class AuthorizationHelpersTest < Test::Unit::TestCase
+class AuthorizationHelpersTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/sinatra/default_not_found_page_test.rb
+++ b/test/sinatra/default_not_found_page_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'sinatra/base'
 require 'sinatra/default_not_found_page'
 
-class DefaultNotFoundPageTest < Test::Unit::TestCase
+class DefaultNotFoundPageTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/sinatra/ssl_client_verification_integration_test.rb
+++ b/test/sinatra/ssl_client_verification_integration_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'net/http'
 
-class SSLClientVerificationIntegrationTest < Test::Unit::TestCase
+class SSLClientVerificationIntegrationTest < Minitest::Test
   include Proxy::IntegrationTestCase
 
   class TestAPIWithSSLClientAuth < ::Sinatra::Base
@@ -43,7 +43,7 @@ class SSLClientVerificationIntegrationTest < Test::Unit::TestCase
     http.cert    = OpenSSL::X509::Certificate.new(File.read(File.join(fixtures, 'certs', 'badclient.example.com.pem')))
     http.key     = OpenSSL::PKey::RSA.new(File.read(File.join(fixtures, 'private_keys', 'badclient.example.com.pem')))
     http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-    assert_raise OpenSSL::SSL::SSLError do
+    assert_raises OpenSSL::SSL::SSLError do
       http.get('/')
     end
   end

--- a/test/sinatra/ssl_client_verification_test.rb
+++ b/test/sinatra/ssl_client_verification_test.rb
@@ -4,7 +4,7 @@ require 'sinatra/base'
 
 ENV['RACK_ENV'] = 'test'
 
-class SSLClientVerificationTest < Test::Unit::TestCase
+class SSLClientVerificationTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/sinatra/trusted_hosts_test.rb
+++ b/test/sinatra/trusted_hosts_test.rb
@@ -4,7 +4,7 @@ require 'sinatra/base'
 
 ENV['RACK_ENV'] = 'test'
 
-class TrustedHostsTest < Test::Unit::TestCase
+class TrustedHostsTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/templates/template_proxy_request_test.rb
+++ b/test/templates/template_proxy_request_test.rb
@@ -4,9 +4,9 @@ require 'net/http'
 require 'mocha'
 require 'templates/templates_plugin'
 require 'templates/template_proxy_request'
-require 'webmock/test_unit'
+require 'webmock/minitest'
 
-class TemplateProxyRequestTest < Test::Unit::TestCase
+class TemplateProxyRequestTest < Minitest::Test
   def setup
     @foreman_url = 'https://foreman.example.com'
     Proxy::SETTINGS.stubs(:foreman_url).returns(@foreman_url)

--- a/test/templates/templates_unattended_api_test.rb
+++ b/test/templates/templates_unattended_api_test.rb
@@ -2,9 +2,9 @@ require 'test_helper'
 require 'json'
 require 'templates/templates_unattended_api'
 require 'templates/templates'
-require 'webmock/test_unit'
+require 'webmock/minitest'
 
-class TemplatesUnattendedApiTest < Test::Unit::TestCase
+class TemplatesUnattendedApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/templates/templates_userdata_api_test.rb
+++ b/test/templates/templates_userdata_api_test.rb
@@ -2,9 +2,9 @@ require 'test_helper'
 require 'json'
 require 'templates/templates_userdata_api'
 require 'templates/templates'
-require 'webmock/test_unit'
+require 'webmock/minitest'
 
-class TemplatesApiTest < Test::Unit::TestCase
+class TemplatesApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'English'
-require "test/unit"
+require 'minitest/autorun'
 require 'fileutils'
 
 $LOAD_PATH << File.join(__dir__, '..', 'lib')
@@ -15,10 +15,15 @@ ENV['RACK_ENV'] = 'test'
 ENV['TMPDIR'] = 'test/tmp'
 FileUtils.rm_f Dir.glob 'test/tmp/*.tmp'
 
-require "mocha/test_unit"
+if ENV['JENKINS_URL']
+  require 'minitest/reporters'
+  Minitest::Reporters.use! [Minitest::Reporters::JUnitReporter.new]
+end
+
+require 'mocha/minitest'
 require "rack/test"
 require 'timeout'
-require 'webmock/test_unit'
+require 'webmock/minitest'
 
 require 'smart_proxy_for_testing'
 require 'provider_interface_validation/dhcp_provider'
@@ -76,7 +81,7 @@ module Proxy::IntegrationTestCase
   end
 end
 
-class SmartProxyRootApiTestCase < Test::Unit::TestCase
+class SmartProxyRootApiTestCase < Minitest::Test
   include Rack::Test::Methods
 
   def setup

--- a/test/tftp/tftp_api_test.rb
+++ b/test/tftp/tftp_api_test.rb
@@ -5,7 +5,7 @@ require 'tftp/tftp_api'
 
 ENV['RACK_ENV'] = 'test'
 
-class TftpApiTest < Test::Unit::TestCase
+class TftpApiTest < Minitest::Test
   include Rack::Test::Methods
 
   def app

--- a/test/tftp/tftp_server_test.rb
+++ b/test/tftp/tftp_server_test.rb
@@ -52,7 +52,7 @@ module TftpGenericServerSuite
   end
 end
 
-class HelperServerTest < Test::Unit::TestCase
+class HelperServerTest < Minitest::Test
   def setup
     @subject = Proxy::TFTP::Server.new
   end
@@ -92,7 +92,7 @@ class HelperServerTest < Test::Unit::TestCase
   end
 end
 
-class TftpSyslinuxServerTest < Test::Unit::TestCase
+class TftpSyslinuxServerTest < Minitest::Test
   include TftpGenericServerSuite
 
   def setup_paths
@@ -107,7 +107,7 @@ class TftpSyslinuxServerTest < Test::Unit::TestCase
   end
 end
 
-class TftpPxegrub2ServerTest < Test::Unit::TestCase
+class TftpPxegrub2ServerTest < Minitest::Test
   include TftpGenericServerSuite
 
   def setup
@@ -200,7 +200,7 @@ class TftpPxegrub2ServerTest < Test::Unit::TestCase
   end
 end
 
-class TftpPoapServerTest < Test::Unit::TestCase
+class TftpPoapServerTest < Minitest::Test
   include TftpGenericServerSuite
 
   def setup_paths
@@ -213,7 +213,7 @@ class TftpPoapServerTest < Test::Unit::TestCase
   end
 end
 
-class TftpZtpServerTest < Test::Unit::TestCase
+class TftpZtpServerTest < Minitest::Test
   include TftpGenericServerSuite
 
   def setup_paths
@@ -226,7 +226,7 @@ class TftpZtpServerTest < Test::Unit::TestCase
   end
 end
 
-class TftpIpxeServerTest < Test::Unit::TestCase
+class TftpIpxeServerTest < Minitest::Test
   include TftpGenericServerSuite
 
   def setup_paths

--- a/test/tftp/tftp_test.rb
+++ b/test/tftp/tftp_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 require 'tftp/tftp_plugin'
 require "tftp/server"
 
-class TftpTest < Test::Unit::TestCase
+class TftpTest < Minitest::Test
   def setup
     @tftp = Proxy::TFTP::Server.new
     Proxy::TFTP::Plugin.load_test_settings(:tftproot => "/some/root")
@@ -74,9 +74,7 @@ class TftpTest < Test::Unit::TestCase
   end
 
   def test_choose_protocol_and_fetch_nfs
-    assert_nothing_raised RuntimeError do
-      Proxy::TFTP.choose_protocol_and_fetch 'nfs://proxy.test', '/destination'
-    end
+    Proxy::TFTP.choose_protocol_and_fetch 'nfs://proxy.test', '/destination'
   end
 
   def test_choose_protocol_and_fetch_unknown

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class ProxyUtilTest < Test::Unit::TestCase
+class ProxyUtilTest < Minitest::Test
   class UtilClass; extend Proxy::Util; end
 
   def test_util_should_support_path

--- a/test/validations_test.rb
+++ b/test/validations_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 require 'proxy/validations'
 
-class ProxyValidationsTest < Test::Unit::TestCase
+class ProxyValidationsTest < Minitest::Test
   include Proxy::Validations
 
   def test_should_be_valid_mac
@@ -30,10 +30,10 @@ class ProxyValidationsTest < Test::Unit::TestCase
   end
 
   def test_should_not_return_invalid_ip
-    assert_raise InvalidIPAddress do
+    assert_raises InvalidIPAddress do
       validate_ip "192.168.1"
     end
-    assert_raise InvalidIPAddress do
+    assert_raises InvalidIPAddress do
       validate_ip "192.168.1.i"
     end
   end
@@ -53,10 +53,10 @@ class ProxyValidationsTest < Test::Unit::TestCase
   end
 
   def test_should_not_return_invalid_mac
-    assert_raise InvalidMACAddress do
+    assert_raises InvalidMACAddress do
       validate_mac "aa:bb:cc:00:11:22:33"
     end
-    assert_raise InvalidMACAddress do
+    assert_raises InvalidMACAddress do
       validate_mac "aa:bb:cc:00:11:zz"
     end
   end


### PR DESCRIPTION
## What changed

- migrate the Smart Proxy test suite from `test-unit` to Minitest
- replace `ci_reporter` with `minitest-reporters` for Jenkins JUnit output
- load the CI reporter only when Jenkins is running
- update Test::Unit-specific assertions and the Mocha/WebMock integrations

## Why

`ci_reporter_test_unit` is unmaintained and its integration broke when Rake 13.4.2 changed how verbose test options are passed. PR #938 fixed the immediate test invocation failure, but left the obsolete reporting stack in place. This change completes the migration described in the issue and removes that dependency.

## Validation

- checked Ruby syntax for all files under `test`, `lib`, `modules`, and `tasks`
- checked the diff for whitespace errors

Full test execution is left to the upstream Ruby matrix because the local Docker runtime was unavailable.

AI assistance disclosure: This pull request was prepared with assistance from Codex 5.6 Sol High. The changes were reviewed by the author.
