### PR TITLE
Refs #39354 - Update RuboCop dependencies

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rake
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -193,7 +193,7 @@ Naming/MethodParameterName:
 # ForbiddenPrefixes: is_, has_, have_
 # AllowedMethods: is_a?
 # MethodDefinitionMacros: define_method, define_singleton_method
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Exclude:
     - 'spec/**/*'
     - 'modules/puppet_proxy_common/puppet_class.rb'

--- a/bundler.d/test.rb
+++ b/bundler.d/test.rb
@@ -8,8 +8,8 @@ group :test do
   gem 'mocha', '~> 1.10', :require => false
   gem 'rack-test'
   gem 'rake'
-  gem 'rubocop', '~> 1.56.0'
-  gem 'rubocop-performance', '~> 1.5.2'
+  gem 'rubocop', '~> 1.88.0'
+  gem 'rubocop-performance', '~> 1.26.0'
   gem 'rubocop-rake'
   gem 'ruby-prof', '< 1.4'
   gem 'test-unit'

--- a/extra/migrations/20160413000000_migrate_puppet_settings.rb
+++ b/extra/migrations/20160413000000_migrate_puppet_settings.rb
@@ -65,7 +65,7 @@ class MigratePuppetSettings < ::Proxy::Migration
 
     if migrated.has_key?(:puppet_proxy_mcollective)
       puppet_user = migrated[:puppet_proxy_mcollective].delete(:puppet_user)
-      unless (migrated[:puppet_proxy_mcollective].has_key?(:user) || puppet_user.nil?)
+      unless migrated[:puppet_proxy_mcollective].has_key?(:user) || puppet_user.nil?
         migrated[:puppet_proxy_mcollective][:user] = puppet_user
       end
     end

--- a/lib/launcher.rb
+++ b/lib/launcher.rb
@@ -115,7 +115,7 @@ module Proxy
     def resolve_tls_ciphers
       configured = settings.tls_ciphers
       raise "Invalid tls_ciphers value '#{configured}': must be a String" if !configured.nil? && !configured.is_a?(String)
-      return nil if configured&.empty?
+      return nil if configured == ''
       return configured unless configured.nil?
 
       if File.exist?(CRYPTO_POLICIES_CONFIG)

--- a/modules/dhcp_common/server.rb
+++ b/modules/dhcp_common/server.rb
@@ -205,7 +205,7 @@ module Proxy::DHCP
 
     # Default: manage any subnet. If specified: manage only specified subnets.
     def managed_subnet?(subnet)
-      @managed_subnets.empty? ? true : @managed_subnets.include?(subnet)
+      @managed_subnets.empty? || @managed_subnets.include?(subnet)
     end
   end
 end

--- a/modules/templates/templates_unattended_api.rb
+++ b/modules/templates/templates_unattended_api.rb
@@ -7,7 +7,7 @@ class Proxy::TemplatesUnattendedApi < Sinatra::Base
   # It will also modify the rendering of the foreman_url specified in the templates.
   get "/templateServer" do
     content_type :json
-    {"templateServer" => (Proxy::Templates::Plugin.settings.template_url || "")}.to_json
+    {"templateServer" => Proxy::Templates::Plugin.settings.template_url || ""}.to_json
   rescue => e
     log_halt 400, e
   end

--- a/modules/tftp/tftp_api.rb
+++ b/modules/tftp/tftp_api.rb
@@ -21,7 +21,7 @@ module Proxy::TFTP
       def create(variant, mac, os: nil, release: nil, arch: nil, bootfile_suffix: nil)
         tftp = instantiate variant, mac
         log_halt(400, "TFTP: Failed to setup host specific bootloader directory: ") { tftp.setup_bootloader(mac: mac, os: os, release: release, arch: arch, bootfile_suffix: bootfile_suffix) }
-        log_halt(400, "TFTP: Failed to create pxe config file: ") { tftp.set(mac, (params[:pxeconfig] || params[:syslinux_config])) }
+        log_halt(400, "TFTP: Failed to create pxe config file: ") { tftp.set(mac, params[:pxeconfig] || params[:syslinux_config]) }
       end
 
       def delete(variant, mac)
@@ -70,7 +70,7 @@ module Proxy::TFTP
 
     # Get the value for next_server
     get "/serverName" do
-      {"serverName" => (Proxy::TFTP::Plugin.settings.tftp_servername || "")}.to_json
+      {"serverName" => Proxy::TFTP::Plugin.settings.tftp_servername || ""}.to_json
     end
   end
 end


### PR DESCRIPTION
## What changed

- update RuboCop from 1.56.x to 1.88.x
- update rubocop-performance from 1.5.x to 1.26.x
- migrate the RuboCop extensions to the current plugin configuration
- apply the behavior-preserving style updates required by the new cops

This removes RuboCop's `< 3.0` restriction on `unicode-display_width`, allowing the generated Smart Proxy CI lockfile to align on the 3.x release used by the other Foreman projects.

## Thor remains blocked

The `thor` part of #39354 cannot be resolved by `bundle update`: Facter 4.11.0 still declares `thor >= 1.0.1, < 1.3` to retain Ruby 2.5 support. The upstream change to remove that restriction is still open in [puppetlabs/facter#2751](https://github.com/puppetlabs/facter/pull/2751). Raising Thor in Smart Proxy before a compatible Facter release would make the bundle unsatisfiable, so this PR deliberately uses `Refs` rather than claiming to fix the whole issue.

## Validation

- verified the new RuboCop releases support Smart Proxy's Ruby 3.0 minimum
- verified RuboCop 1.88 permits `unicode-display_width >= 2.4, < 4.0`
- checked the diff for whitespace errors
- checked Ruby syntax for every adjusted source file

The generated lockfile and RuboCop run will be validated by the upstream CI matrix.

AI assistance disclosure: This pull request was prepared with assistance from Codex 5.6 Sol High. The changes were reviewed by the author.
